### PR TITLE
Add organ removal listener support

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/chestcavities/instance/ChestCavityInstance.java
+++ b/src/main/java/net/tigereye/chestcavity/chestcavities/instance/ChestCavityInstance.java
@@ -21,6 +21,7 @@ import net.tigereye.chestcavity.listeners.OrganIncomingDamageContext;
 import net.tigereye.chestcavity.listeners.OrganOnHitContext;
 import net.tigereye.chestcavity.listeners.OrganHealContext;
 import net.tigereye.chestcavity.listeners.OrganOnGroundContext;
+import net.tigereye.chestcavity.listeners.OrganRemovalContext;
 import net.tigereye.chestcavity.listeners.OrganSlowTickContext;
 import net.tigereye.chestcavity.util.ChestCavityUtil;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
@@ -48,6 +49,7 @@ public class ChestCavityInstance implements ContainerListener {
     public List<OrganHealContext> onHealListeners = new ArrayList<>();
     public List<OrganOnGroundContext> onGroundListeners = new ArrayList<>();
     public List<OrganSlowTickContext> onSlowTickListeners = new ArrayList<>();
+    public List<OrganRemovalContext> onRemovedListeners = new ArrayList<>();
     public LinkedList<Consumer<LivingEntity>> projectileQueue = new LinkedList<>();
     private final Set<ResourceLocation> scoreboardUpgrades = new HashSet<>();
 

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/GuQiangguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/GuQiangguOrganBehavior.java
@@ -14,6 +14,7 @@ import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.LinkageChannel;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.SaturationPolicy;
 import net.tigereye.chestcavity.listeners.OrganOnHitListener;
 import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
 import net.tigereye.chestcavity.util.NBTCharge;

--- a/src/main/java/net/tigereye/chestcavity/listeners/OrganRemovalContext.java
+++ b/src/main/java/net/tigereye/chestcavity/listeners/OrganRemovalContext.java
@@ -1,0 +1,16 @@
+package net.tigereye.chestcavity.listeners;
+
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Stores the association between an organ stack and its removal listener implementation.
+ */
+public class OrganRemovalContext {
+    public final ItemStack organ;
+    public final OrganRemovalListener listener;
+
+    public OrganRemovalContext(ItemStack organ, OrganRemovalListener listener) {
+        this.organ = organ;
+        this.listener = listener;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/listeners/OrganRemovalListener.java
+++ b/src/main/java/net/tigereye/chestcavity/listeners/OrganRemovalListener.java
@@ -1,0 +1,20 @@
+package net.tigereye.chestcavity.listeners;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+
+/**
+ * Implemented by organs that need to react when they are removed from the chest cavity.
+ */
+public interface OrganRemovalListener {
+
+    /**
+     * Called when the organ stack providing this listener is removed from the chest cavity inventory.
+     *
+     * @param entity the entity whose chest cavity contained the organ
+     * @param cc     the chest cavity instance for that entity
+     * @param organ  the organ stack providing this listener
+     */
+    void onRemoved(LivingEntity entity, ChestCavityInstance cc, ItemStack organ);
+}

--- a/src/main/java/net/tigereye/chestcavity/util/ChestCavityUtil.java
+++ b/src/main/java/net/tigereye/chestcavity/util/ChestCavityUtil.java
@@ -401,14 +401,17 @@ public class ChestCavityUtil {
             if(cc.getChestCavityType().getDefaultOrganScores() != null) {
                 organScores.putAll(cc.getChestCavityType().getDefaultOrganScores());
             }
+            cc.onRemovedListeners.clear();
         }
         else {
             cc.onHitListeners.clear();
             cc.onDamageListeners.clear();
             cc.onFireListeners.clear();
+            List<OrganRemovalContext> staleRemovalContexts = new ArrayList<>(cc.onRemovedListeners);
             cc.onHealListeners.clear();
             cc.onGroundListeners.clear();
             cc.onSlowTickListeners.clear();
+            cc.onRemovedListeners.clear();
             cc.getChestCavityType().loadBaseOrganScores(organScores);
 
             for (int i = 0; i < cc.inventory.getContainerSize(); i++) {
@@ -440,6 +443,10 @@ public class ChestCavityUtil {
                         if(slotitem instanceof OrganSlowTickListener){
                             cc.onSlowTickListeners.add(new OrganSlowTickContext(itemStack,(OrganSlowTickListener)slotitem));
                         }
+                        if(slotitem instanceof OrganRemovalListener removalListener){
+                            cc.onRemovedListeners.add(new OrganRemovalContext(itemStack, removalListener));
+                            staleRemovalContexts.removeIf(old -> old.organ == itemStack && old.listener == removalListener);
+                        }
                         if (!data.pseudoOrgan) {
                             int compatibility = getCompatibilityLevel(cc,itemStack);
                             if(compatibility < 1){
@@ -448,6 +455,11 @@ public class ChestCavityUtil {
                         }
                     }
 
+                }
+            }
+            if (cc.owner != null) {
+                for (OrganRemovalContext context : staleRemovalContexts) {
+                    context.listener.onRemoved(cc.owner, cc, context.organ);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add a dedicated OrganRemovalListener API and context for organs reacting to removal
- wire ChestCavity evaluation to maintain removal listener state and fire callbacks when organs leave the inventory
- fix a missing SaturationPolicy import in GuQiangguOrganBehavior so the project compiles

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d161e74bf88326beb225d0ab047a89