### PR TITLE
Add Luo Xuan bone spear behavior and attack ability

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoClientAbilities.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoClientAbilities.java
@@ -1,0 +1,25 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao;
+
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.LuoXuanGuQiangguOrganBehavior;
+import net.tigereye.chestcavity.registration.CCKeybindings;
+
+/**
+ * Ensures Guzhenren attack abilities are hooked into the shared attack hotkey on the client.
+ */
+@EventBusSubscriber(modid = ChestCavity.MODID, value = Dist.CLIENT)
+public final class GuDaoClientAbilities {
+    private GuDaoClientAbilities() {
+    }
+
+    @SubscribeEvent
+    public static void onClientSetup(FMLClientSetupEvent event) {
+        if (!CCKeybindings.ATTACK_ABILITY_LIST.contains(LuoXuanGuQiangguOrganBehavior.ABILITY_ID)) {
+            CCKeybindings.ATTACK_ABILITY_LIST.add(LuoXuanGuQiangguOrganBehavior.ABILITY_ID);
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganRegistry.java
@@ -3,6 +3,7 @@ package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao;
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.GuQiangguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.GuzhuguOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.LuoXuanGuQiangguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.YuGuguOrganBehavior; // 你需要自己写对应行为
 import net.tigereye.chestcavity.compat.guzhenren.linkage.effect.GuzhenrenLinkageEffectRegistry;
 
@@ -15,6 +16,7 @@ public final class GuDaoOrganRegistry {
     private static final String MOD_ID = "guzhenren";
     private static final ResourceLocation BONE_BAMBOO_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "gu_zhu_gu");
     private static final ResourceLocation BONE_SPEAR_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "gu_qiang_gu");
+    private static final ResourceLocation SPIRAL_BONE_SPEAR_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "luo_xuan_gu_qiang_gu");
     private static final ResourceLocation JADE_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "yu_gu_gu"); // 新增玉骨蛊
 
     static {
@@ -29,6 +31,12 @@ public final class GuDaoOrganRegistry {
             context.addSlowTickListener(GuQiangguOrganBehavior.INSTANCE);
             context.addOnHitListener(GuQiangguOrganBehavior.INSTANCE);
             GuQiangguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
+        });
+
+        GuzhenrenLinkageEffectRegistry.registerSingle(SPIRAL_BONE_SPEAR_ID, context -> {
+            context.addSlowTickListener(LuoXuanGuQiangguOrganBehavior.INSTANCE);
+            context.addOnHitListener(LuoXuanGuQiangguOrganBehavior.INSTANCE);
+            LuoXuanGuQiangguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
         });
 
         GuzhenrenLinkageEffectRegistry.registerSingle(JADE_BONE_ID, context -> {

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/LuoXuanGuQiangguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/LuoXuanGuQiangguOrganBehavior.java
@@ -1,0 +1,210 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior;
+
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.AbstractArrow;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.ArrowItem;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.LinkageChannel;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.listeners.OrganActivationListeners;
+import net.tigereye.chestcavity.listeners.OrganOnHitListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.util.NBTCharge;
+import net.tigereye.chestcavity.util.NetworkUtil;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+/**
+ * Behaviour for 螺旋骨枪蛊. Handles slow tick recharging and active projectile firing.
+ */
+public enum LuoXuanGuQiangguOrganBehavior implements OrganSlowTickListener, OrganOnHitListener {
+    INSTANCE;
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation ORGAN_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "luo_xuan_gu_qiang_gu");
+    public static final ResourceLocation ABILITY_ID = ORGAN_ID;
+
+    private static final ResourceLocation GU_DAO_INCREASE_EFFECT =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/gu_dao_increase_effect");
+    private static final ResourceLocation LI_DAO_INCREASE_EFFECT =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/li_dao_increase_effect");
+
+    private static final ResourceLocation BONE_SPEAR_ITEM_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "gu_qiang");
+
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    private static final String STATE_KEY = "LuoXuanGuCharge";
+    private static final int MAX_CHARGE = 3;
+    private static final double BASE_ZHENYUAN_COST = 50.0;
+    private static final double BASE_JINGLI_COST = 50.0;
+
+    private static final double BASE_PROJECTILE_DAMAGE = 7.0;
+    private static final double BASE_PROJECTILE_SPEED = 2.6;
+
+    static {
+        OrganActivationListeners.register(ABILITY_ID, LuoXuanGuQiangguOrganBehavior::activateAbility);
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (!(entity instanceof Player player) || entity.level().isClientSide()) {
+            return;
+        }
+
+        int currentCharge = Math.max(0, Math.min(MAX_CHARGE, NBTCharge.getCharge(organ, STATE_KEY)));
+        if (currentCharge >= MAX_CHARGE) {
+            return;
+        }
+
+        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+        if (handleOpt.isEmpty()) {
+            return;
+        }
+        GuzhenrenResourceBridge.ResourceHandle handle = handleOpt.get();
+
+        OptionalDouble jingliResult = handle.adjustJingli(-BASE_JINGLI_COST, true);
+        if (jingliResult.isEmpty()) {
+            return;
+        }
+
+        OptionalDouble zhenyuanResult = handle.consumeScaledZhenyuan(BASE_ZHENYUAN_COST);
+        if (zhenyuanResult.isEmpty()) {
+            handle.adjustJingli(BASE_JINGLI_COST, true);
+            return;
+        }
+
+        int updated = Math.min(MAX_CHARGE, currentCharge + 1);
+        if (updated != currentCharge) {
+            NBTCharge.setCharge(organ, STATE_KEY, updated);
+            NetworkUtil.sendOrganSlotUpdate(cc, organ);
+            ChestCavity.LOGGER.info("[LuoXuanGuQiangGu] recharge -> {}/{}", updated, MAX_CHARGE);
+        }
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        ensureChannel(cc, GU_DAO_INCREASE_EFFECT);
+        ensureChannel(cc, LI_DAO_INCREASE_EFFECT);
+    }
+
+    private static LinkageChannel ensureChannel(ChestCavityInstance cc, ResourceLocation id) {
+        ActiveLinkageContext context = GuzhenrenLinkageManager.getContext(cc);
+        return context.getOrCreateChannel(id).addPolicy(NON_NEGATIVE);
+    }
+
+    private static void activateAbility(LivingEntity entity, ChestCavityInstance cc) {
+        if (!(entity instanceof Player player) || entity.level().isClientSide()) {
+            return;
+        }
+        ItemStack organ = findChargedOrgan(cc);
+        if (organ.isEmpty()) {
+            return;
+        }
+
+        int currentCharge = Math.max(0, Math.min(MAX_CHARGE, NBTCharge.getCharge(organ, STATE_KEY)));
+        if (currentCharge <= 0) {
+            return;
+        }
+
+        double guDaoEfficiency = 1.0 + ensureChannel(cc, GU_DAO_INCREASE_EFFECT).get();
+        double liDaoEfficiency = 1.0 + ensureChannel(cc, LI_DAO_INCREASE_EFFECT).get();
+        double multiplier = Math.max(0.0, guDaoEfficiency * liDaoEfficiency);
+
+        if (!fireProjectile(player, multiplier)) {
+            return;
+        }
+
+        int updated = Math.max(0, currentCharge - 1);
+        if (updated != currentCharge) {
+            NBTCharge.setCharge(organ, STATE_KEY, updated);
+            NetworkUtil.sendOrganSlotUpdate(cc, organ);
+        }
+    }
+
+    private static ItemStack findChargedOrgan(ChestCavityInstance cc) {
+        for (int i = 0; i < cc.inventory.getContainerSize(); i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (stack.isEmpty()) {
+                continue;
+            }
+            ResourceLocation id = BuiltInRegistries.ITEM.getKey(stack.getItem());
+            if (id != null && ORGAN_ID.equals(id)) {
+                if (NBTCharge.getCharge(stack, STATE_KEY) > 0) {
+                    return stack;
+                }
+            }
+        }
+        return ItemStack.EMPTY;
+    }
+
+    private static boolean fireProjectile(Player player, double multiplier) {
+        Level level = player.level();
+        if (!(level instanceof ServerLevel server)) {
+            return false;
+        }
+
+        double speed = BASE_PROJECTILE_SPEED * multiplier;
+        double damage = BASE_PROJECTILE_DAMAGE * multiplier;
+
+        Vec3 origin = player.getEyePosition().add(player.getLookAngle().scale(0.4));
+        Vec3 direction = player.getLookAngle().normalize();
+
+        AbstractArrow projectile = ((ArrowItem) Items.ARROW).createArrow(level, new ItemStack(Items.ARROW), player, ItemStack.EMPTY);
+        projectile.setSoundEvent(SoundEvents.ARROW_HIT);
+        projectile.setBaseDamage(damage);
+        projectile.pickup = AbstractArrow.Pickup.DISALLOWED;
+        projectile.setPos(origin.x, origin.y, origin.z);
+        projectile.shoot(direction.x, direction.y, direction.z, (float) speed, 0.0F);
+        projectile.setCritArrow(true);
+
+        Optional<Item> spearItem = BuiltInRegistries.ITEM.getOptional(BONE_SPEAR_ITEM_ID);
+        spearItem.ifPresent(item -> applyCustomPickupItem(projectile, new ItemStack(item)));
+
+        server.addFreshEntity(projectile);
+
+        server.sendParticles(ParticleTypes.END_ROD, origin.x, origin.y, origin.z, 16, 0.1, 0.1, 0.1, 0.05);
+        level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.SKELETON_AMBIENT, SoundSource.PLAYERS, 0.7f, 1.0f);
+        level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.CROSSBOW_SHOOT, SoundSource.PLAYERS, 1.0f, 1.2f);
+        return true;
+    }
+
+    private static void applyCustomPickupItem(AbstractArrow projectile, ItemStack pickup) {
+        try {
+            java.lang.reflect.Field field = AbstractArrow.class.getDeclaredField("pickupItem");
+            field.setAccessible(true);
+            field.set(projectile, pickup);
+        } catch (NoSuchFieldException ignored) {
+            try {
+                java.lang.reflect.Field altField = AbstractArrow.class.getDeclaredField("pickupItemStack");
+                altField.setAccessible(true);
+                altField.set(projectile, pickup);
+            } catch (ReflectiveOperationException ignoredToo) {
+                // Fall back silently when the field cannot be customised on this version.
+            }
+        } catch (IllegalAccessException ignored) {
+            // ignore
+        }
+    }
+
+    @Override
+    public float onHit(DamageSource source, LivingEntity attacker, LivingEntity target, ChestCavityInstance cc, ItemStack organ, float damage) {
+        return damage;
+    }
+}


### PR DESCRIPTION
## Summary
- add a Luo Xuan bone spear organ behaviour that recharges with zhenyuan and fires a projectile scaled by linkage efficiency
- register the new organ in the Guzhenren registry and ensure the attack hotkey is wired on the client

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68d17e6886c483269700920673d173ce