### PR TITLE
Add HuGugu defensive organ behavior

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoClientAbilities.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoClientAbilities.java
@@ -1,0 +1,25 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao;
+
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.LuoXuanGuQiangguOrganBehavior;
+import net.tigereye.chestcavity.registration.CCKeybindings;
+
+/**
+ * Ensures Guzhenren attack abilities are hooked into the shared attack hotkey on the client.
+ */
+@EventBusSubscriber(modid = ChestCavity.MODID, value = Dist.CLIENT)
+public final class GuDaoClientAbilities {
+    private GuDaoClientAbilities() {
+    }
+
+    @SubscribeEvent
+    public static void onClientSetup(FMLClientSetupEvent event) {
+        if (!CCKeybindings.ATTACK_ABILITY_LIST.contains(LuoXuanGuQiangguOrganBehavior.ABILITY_ID)) {
+            CCKeybindings.ATTACK_ABILITY_LIST.add(LuoXuanGuQiangguOrganBehavior.ABILITY_ID);
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganRegistry.java
@@ -3,6 +3,8 @@ package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao;
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.GuQiangguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.GuzhuguOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.HuGuguOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.LuoXuanGuQiangguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.YuGuguOrganBehavior; // 你需要自己写对应行为
 import net.tigereye.chestcavity.compat.guzhenren.linkage.effect.GuzhenrenLinkageEffectRegistry;
 
@@ -15,6 +17,8 @@ public final class GuDaoOrganRegistry {
     private static final String MOD_ID = "guzhenren";
     private static final ResourceLocation BONE_BAMBOO_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "gu_zhu_gu");
     private static final ResourceLocation BONE_SPEAR_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "gu_qiang_gu");
+    private static final ResourceLocation SPIRAL_BONE_SPEAR_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "luo_xuan_gu_qiang_gu");
+    private static final ResourceLocation TIGER_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "hu_gu_gu");
     private static final ResourceLocation JADE_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "yu_gu_gu"); // 新增玉骨蛊
 
     static {
@@ -29,6 +33,18 @@ public final class GuDaoOrganRegistry {
             context.addSlowTickListener(GuQiangguOrganBehavior.INSTANCE);
             context.addOnHitListener(GuQiangguOrganBehavior.INSTANCE);
             GuQiangguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
+        });
+
+        GuzhenrenLinkageEffectRegistry.registerSingle(SPIRAL_BONE_SPEAR_ID, context -> {
+            context.addSlowTickListener(LuoXuanGuQiangguOrganBehavior.INSTANCE);
+            context.addOnHitListener(LuoXuanGuQiangguOrganBehavior.INSTANCE);
+            LuoXuanGuQiangguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
+        });
+
+        GuzhenrenLinkageEffectRegistry.registerSingle(TIGER_BONE_ID, context -> {
+            context.addSlowTickListener(HuGuguOrganBehavior.INSTANCE);
+            context.addIncomingDamageListener(HuGuguOrganBehavior.INSTANCE);
+            HuGuguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
         });
 
         GuzhenrenLinkageEffectRegistry.registerSingle(JADE_BONE_ID, context -> {

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/HuGuguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/HuGuguOrganBehavior.java
@@ -1,0 +1,239 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.LinkageChannel;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.listeners.OrganIncomingDamageListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.util.NBTCharge;
+import net.tigereye.chestcavity.util.NetworkUtil;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+/**
+ * 虎骨蛊：低蓄能时提供额外回复但施加虚弱，受击时为使用者提供防御增益并反弹伤害。
+ */
+public enum HuGuguOrganBehavior implements OrganSlowTickListener, OrganIncomingDamageListener {
+    INSTANCE;
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation GU_DAO_INCREASE_EFFECT =
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/gu_dao_increase_effect");
+    private static final ResourceLocation LI_DAO_INCREASE_EFFECT =
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/li_dao_increase_effect");
+    private static final ResourceLocation BIAN_HUA_DAO_INCREASE_EFFECT =
+        ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/bian_hua_dao_increase_effect");
+
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    private static final String STATE_KEY = "HuGuguCharge";
+    private static final int CHARGE_SCALE = 100; // store hundredths in NBT
+    private static final int MAX_CHARGE_UNITS = 20 * CHARGE_SCALE;
+    private static final int HALF_CHARGE_UNITS = MAX_CHARGE_UNITS / 2;
+    private static final int BASE_RECOVERY_LOW_UNITS = (int)Math.round(0.25 * CHARGE_SCALE);
+    private static final int BONUS_RECOVERY_LOW_UNITS = (int)Math.round(0.25 * CHARGE_SCALE);
+    private static final int RECOVERY_HIGH_UNITS = (int)Math.round(0.10 * CHARGE_SCALE);
+
+    private static final double MIN_DAMAGE_THRESHOLD = 10.0;
+    private static final double BASE_REFLECT_RATIO = 0.5;
+    private static final double BASE_MAX_REFLECT = 50.0;
+
+    private static final double BASE_JINGLI_COST = 10.0;
+    private static final double BASE_ZHENYUAN_COST = 500.0;
+
+    private static final int LOW_CHARGE_DEBUFF_DURATION = 60; // 3 seconds refresh per slow tick
+
+    private static final int BASE_BUFF_DURATION = 20 * 60; // 1 minute in ticks
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (!(entity instanceof Player player) || entity.level().isClientSide()) {
+            return;
+        }
+
+        int currentUnits = getStoredUnits(organ);
+        if (currentUnits >= MAX_CHARGE_UNITS) {
+            return;
+        }
+
+        int addedUnits = 0;
+        if (currentUnits < HALF_CHARGE_UNITS) {
+            applyLowChargeDebuffs(player);
+            addedUnits += BASE_RECOVERY_LOW_UNITS;
+
+            Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+            if (handleOpt.isPresent()) {
+                GuzhenrenResourceBridge.ResourceHandle handle = handleOpt.get();
+                OptionalDouble jingliResult = handle.adjustJingli(-BASE_JINGLI_COST, true);
+                if (jingliResult.isPresent()) {
+                    OptionalDouble zhenyuanResult = handle.consumeScaledZhenyuan(BASE_ZHENYUAN_COST);
+                    if (zhenyuanResult.isPresent()) {
+                        addedUnits += BONUS_RECOVERY_LOW_UNITS;
+                    } else {
+                        handle.adjustJingli(BASE_JINGLI_COST, true);
+                    }
+                }
+            }
+        } else {
+            addedUnits += RECOVERY_HIGH_UNITS;
+        }
+
+        if (addedUnits <= 0) {
+            return;
+        }
+
+        int updatedUnits = Math.min(MAX_CHARGE_UNITS, currentUnits + addedUnits);
+        if (updatedUnits != currentUnits) {
+            setStoredUnits(organ, updatedUnits);
+            NetworkUtil.sendOrganSlotUpdate(cc, organ);
+        }
+    }
+
+    private static void applyLowChargeDebuffs(Player player) {
+        player.addEffect(new MobEffectInstance(MobEffects.WEAKNESS, LOW_CHARGE_DEBUFF_DURATION, 0, true, true));
+        player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, LOW_CHARGE_DEBUFF_DURATION, 0, true, true));
+        player.addEffect(new MobEffectInstance(MobEffects.DIG_SLOWDOWN, LOW_CHARGE_DEBUFF_DURATION, 0, true, true));
+        player.addEffect(new MobEffectInstance(MobEffects.HUNGER, LOW_CHARGE_DEBUFF_DURATION, 0, true, true));
+    }
+
+    @Override
+    public float onIncomingDamage(DamageSource source, LivingEntity victim, ChestCavityInstance cc, ItemStack organ, float damage) {
+        if (!(victim instanceof Player player) || victim.level().isClientSide()) {
+            return damage;
+        }
+        if (damage < MIN_DAMAGE_THRESHOLD) {
+            return damage;
+        }
+
+        double increaseTotal = getIncreaseTotal(cc);
+        double multiplier = 1.0 + increaseTotal;
+        int duration = Math.max(20, (int)Math.round(BASE_BUFF_DURATION * multiplier));
+
+        applyAbsorption(player, multiplier, duration);
+        applyResistance(player, increaseTotal, duration);
+        applySpeed(player, multiplier, duration);
+        applyJump(player, multiplier, duration);
+
+        reflectDamage(source, victim, damage, multiplier);
+        return damage;
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        ensureChannel(cc, GU_DAO_INCREASE_EFFECT);
+        ensureChannel(cc, LI_DAO_INCREASE_EFFECT);
+        ensureChannel(cc, BIAN_HUA_DAO_INCREASE_EFFECT);
+    }
+
+    private static void applyAbsorption(Player player, double multiplier, int duration) {
+        int absorptionPoints = Math.max(4, (int)Math.round(20.0 * multiplier));
+        int absorptionLevel = Math.max(1, (int)Math.round(absorptionPoints / 4.0));
+        int amplifier = Math.max(0, absorptionLevel - 1);
+        player.addEffect(new MobEffectInstance(MobEffects.ABSORPTION, duration, amplifier, true, true));
+        float expected = 4.0f * (amplifier + 1);
+        if (player.getAbsorptionAmount() < expected) {
+            player.setAbsorptionAmount(expected);
+        }
+    }
+
+    private static void applyResistance(Player player, double increaseTotal, int duration) {
+        int amplifier = Math.max(0, (int)Math.round(increaseTotal));
+        player.addEffect(new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, duration, amplifier, true, true));
+    }
+
+    private static void applySpeed(Player player, double multiplier, int duration) {
+        int level = Math.max(1, (int)Math.round(multiplier));
+        int amplifier = Math.max(0, level - 1);
+        player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, duration, amplifier, true, true));
+    }
+
+    private static void applyJump(Player player, double multiplier, int duration) {
+        int level = Math.max(1, (int)Math.round(multiplier));
+        int amplifier = Math.max(0, level - 1);
+        player.addEffect(new MobEffectInstance(MobEffects.JUMP, duration, amplifier, true, true));
+    }
+
+    private static void reflectDamage(DamageSource source, LivingEntity victim, float incomingDamage, double multiplier) {
+        LivingEntity attacker = null;
+        Entity attackerEntity = source.getEntity();
+        if (attackerEntity instanceof LivingEntity living) {
+            attacker = living;
+        } else {
+            Entity direct = source.getDirectEntity();
+            if (direct instanceof LivingEntity livingDirect) {
+                attacker = livingDirect;
+            }
+        }
+        if (attacker == null) {
+            return;
+        }
+
+        double reflectAmount = Math.min(BASE_MAX_REFLECT * multiplier, BASE_REFLECT_RATIO * incomingDamage * multiplier);
+        if (reflectAmount <= 0) {
+            return;
+        }
+
+        knockbackAttacker(victim, attacker, multiplier);
+        attacker.hurt(victim.damageSources().thorns(victim), (float)reflectAmount);
+        playRetaliationCue(victim.level(), victim);
+    }
+
+    private static void knockbackAttacker(LivingEntity victim, LivingEntity attacker, double multiplier) {
+        Vec3 direction = attacker.position().subtract(victim.position());
+        Vec3 horizontal = new Vec3(direction.x, 0.0, direction.z);
+        if (horizontal.lengthSqr() < 1.0E-4) {
+            return;
+        }
+        Vec3 normalised = horizontal.normalize();
+        double strength = 0.6 * multiplier;
+        attacker.knockback(strength, -normalised.x, -normalised.z);
+    }
+
+    private static void playRetaliationCue(Level level, LivingEntity victim) {
+        level.playSound(null, victim.getX(), victim.getY(), victim.getZ(), SoundEvents.SKELETON_HURT, SoundSource.PLAYERS, 0.7f, 0.9f);
+        level.playSound(null, victim.getX(), victim.getY(), victim.getZ(), SoundEvents.SHIELD_BLOCK, SoundSource.PLAYERS, 1.0f, 1.0f);
+        if (level instanceof ServerLevel serverLevel) {
+            serverLevel.sendParticles(net.minecraft.core.particles.ParticleTypes.CRIT, victim.getX(), victim.getY() + victim.getBbHeight() * 0.5, victim.getZ(), 12, 0.2, 0.2, 0.2, 0.05);
+        }
+    }
+
+    private static double getIncreaseTotal(ChestCavityInstance cc) {
+        return ensureChannel(cc, GU_DAO_INCREASE_EFFECT).get()
+            + ensureChannel(cc, LI_DAO_INCREASE_EFFECT).get()
+            + ensureChannel(cc, BIAN_HUA_DAO_INCREASE_EFFECT).get();
+    }
+
+    private static LinkageChannel ensureChannel(ChestCavityInstance cc, ResourceLocation id) {
+        ActiveLinkageContext context = GuzhenrenLinkageManager.getContext(cc);
+        return context.getOrCreateChannel(id).addPolicy(NON_NEGATIVE);
+    }
+
+    private static int getStoredUnits(ItemStack stack) {
+        int stored = Math.max(0, NBTCharge.getCharge(stack, STATE_KEY));
+        if (stored > MAX_CHARGE_UNITS) {
+            return MAX_CHARGE_UNITS;
+        }
+        return stored;
+    }
+
+    private static void setStoredUnits(ItemStack stack, int units) {
+        int clamped = Math.max(0, Math.min(MAX_CHARGE_UNITS, units));
+        NBTCharge.setCharge(stack, STATE_KEY, clamped);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/LuoXuanGuQiangguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/LuoXuanGuQiangguOrganBehavior.java
@@ -1,0 +1,210 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior;
+
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.AbstractArrow;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.ArrowItem;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.LinkageChannel;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.listeners.OrganActivationListeners;
+import net.tigereye.chestcavity.listeners.OrganOnHitListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.util.NBTCharge;
+import net.tigereye.chestcavity.util.NetworkUtil;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+/**
+ * Behaviour for 螺旋骨枪蛊. Handles slow tick recharging and active projectile firing.
+ */
+public enum LuoXuanGuQiangguOrganBehavior implements OrganSlowTickListener, OrganOnHitListener {
+    INSTANCE;
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation ORGAN_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "luo_xuan_gu_qiang_gu");
+    public static final ResourceLocation ABILITY_ID = ORGAN_ID;
+
+    private static final ResourceLocation GU_DAO_INCREASE_EFFECT =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/gu_dao_increase_effect");
+    private static final ResourceLocation LI_DAO_INCREASE_EFFECT =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/li_dao_increase_effect");
+
+    private static final ResourceLocation BONE_SPEAR_ITEM_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "gu_qiang");
+
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    private static final String STATE_KEY = "LuoXuanGuCharge";
+    private static final int MAX_CHARGE = 3;
+    private static final double BASE_ZHENYUAN_COST = 50.0;
+    private static final double BASE_JINGLI_COST = 50.0;
+
+    private static final double BASE_PROJECTILE_DAMAGE = 7.0;
+    private static final double BASE_PROJECTILE_SPEED = 2.6;
+
+    static {
+        OrganActivationListeners.register(ABILITY_ID, LuoXuanGuQiangguOrganBehavior::activateAbility);
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (!(entity instanceof Player player) || entity.level().isClientSide()) {
+            return;
+        }
+
+        int currentCharge = Math.max(0, Math.min(MAX_CHARGE, NBTCharge.getCharge(organ, STATE_KEY)));
+        if (currentCharge >= MAX_CHARGE) {
+            return;
+        }
+
+        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+        if (handleOpt.isEmpty()) {
+            return;
+        }
+        GuzhenrenResourceBridge.ResourceHandle handle = handleOpt.get();
+
+        OptionalDouble jingliResult = handle.adjustJingli(-BASE_JINGLI_COST, true);
+        if (jingliResult.isEmpty()) {
+            return;
+        }
+
+        OptionalDouble zhenyuanResult = handle.consumeScaledZhenyuan(BASE_ZHENYUAN_COST);
+        if (zhenyuanResult.isEmpty()) {
+            handle.adjustJingli(BASE_JINGLI_COST, true);
+            return;
+        }
+
+        int updated = Math.min(MAX_CHARGE, currentCharge + 1);
+        if (updated != currentCharge) {
+            NBTCharge.setCharge(organ, STATE_KEY, updated);
+            NetworkUtil.sendOrganSlotUpdate(cc, organ);
+            ChestCavity.LOGGER.info("[LuoXuanGuQiangGu] recharge -> {}/{}", updated, MAX_CHARGE);
+        }
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        ensureChannel(cc, GU_DAO_INCREASE_EFFECT);
+        ensureChannel(cc, LI_DAO_INCREASE_EFFECT);
+    }
+
+    private static LinkageChannel ensureChannel(ChestCavityInstance cc, ResourceLocation id) {
+        ActiveLinkageContext context = GuzhenrenLinkageManager.getContext(cc);
+        return context.getOrCreateChannel(id).addPolicy(NON_NEGATIVE);
+    }
+
+    private static void activateAbility(LivingEntity entity, ChestCavityInstance cc) {
+        if (!(entity instanceof Player player) || entity.level().isClientSide()) {
+            return;
+        }
+        ItemStack organ = findChargedOrgan(cc);
+        if (organ.isEmpty()) {
+            return;
+        }
+
+        int currentCharge = Math.max(0, Math.min(MAX_CHARGE, NBTCharge.getCharge(organ, STATE_KEY)));
+        if (currentCharge <= 0) {
+            return;
+        }
+
+        double guDaoEfficiency = 1.0 + ensureChannel(cc, GU_DAO_INCREASE_EFFECT).get();
+        double liDaoEfficiency = 1.0 + ensureChannel(cc, LI_DAO_INCREASE_EFFECT).get();
+        double multiplier = Math.max(0.0, guDaoEfficiency * liDaoEfficiency);
+
+        if (!fireProjectile(player, multiplier)) {
+            return;
+        }
+
+        int updated = Math.max(0, currentCharge - 1);
+        if (updated != currentCharge) {
+            NBTCharge.setCharge(organ, STATE_KEY, updated);
+            NetworkUtil.sendOrganSlotUpdate(cc, organ);
+        }
+    }
+
+    private static ItemStack findChargedOrgan(ChestCavityInstance cc) {
+        for (int i = 0; i < cc.inventory.getContainerSize(); i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (stack.isEmpty()) {
+                continue;
+            }
+            ResourceLocation id = BuiltInRegistries.ITEM.getKey(stack.getItem());
+            if (id != null && ORGAN_ID.equals(id)) {
+                if (NBTCharge.getCharge(stack, STATE_KEY) > 0) {
+                    return stack;
+                }
+            }
+        }
+        return ItemStack.EMPTY;
+    }
+
+    private static boolean fireProjectile(Player player, double multiplier) {
+        Level level = player.level();
+        if (!(level instanceof ServerLevel server)) {
+            return false;
+        }
+
+        double speed = BASE_PROJECTILE_SPEED * multiplier;
+        double damage = BASE_PROJECTILE_DAMAGE * multiplier;
+
+        Vec3 origin = player.getEyePosition().add(player.getLookAngle().scale(0.4));
+        Vec3 direction = player.getLookAngle().normalize();
+
+        AbstractArrow projectile = ((ArrowItem) Items.ARROW).createArrow(level, new ItemStack(Items.ARROW), player, ItemStack.EMPTY);
+        projectile.setSoundEvent(SoundEvents.ARROW_HIT);
+        projectile.setBaseDamage(damage);
+        projectile.pickup = AbstractArrow.Pickup.DISALLOWED;
+        projectile.setPos(origin.x, origin.y, origin.z);
+        projectile.shoot(direction.x, direction.y, direction.z, (float) speed, 0.0F);
+        projectile.setCritArrow(true);
+
+        Optional<Item> spearItem = BuiltInRegistries.ITEM.getOptional(BONE_SPEAR_ITEM_ID);
+        spearItem.ifPresent(item -> applyCustomPickupItem(projectile, new ItemStack(item)));
+
+        server.addFreshEntity(projectile);
+
+        server.sendParticles(ParticleTypes.END_ROD, origin.x, origin.y, origin.z, 16, 0.1, 0.1, 0.1, 0.05);
+        level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.SKELETON_AMBIENT, SoundSource.PLAYERS, 0.7f, 1.0f);
+        level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.CROSSBOW_SHOOT, SoundSource.PLAYERS, 1.0f, 1.2f);
+        return true;
+    }
+
+    private static void applyCustomPickupItem(AbstractArrow projectile, ItemStack pickup) {
+        try {
+            java.lang.reflect.Field field = AbstractArrow.class.getDeclaredField("pickupItem");
+            field.setAccessible(true);
+            field.set(projectile, pickup);
+        } catch (NoSuchFieldException ignored) {
+            try {
+                java.lang.reflect.Field altField = AbstractArrow.class.getDeclaredField("pickupItemStack");
+                altField.setAccessible(true);
+                altField.set(projectile, pickup);
+            } catch (ReflectiveOperationException ignoredToo) {
+                // Fall back silently when the field cannot be customised on this version.
+            }
+        } catch (IllegalAccessException ignored) {
+            // ignore
+        }
+    }
+
+    @Override
+    public float onHit(DamageSource source, LivingEntity attacker, LivingEntity target, ChestCavityInstance cc, ItemStack organ, float damage) {
+        return damage;
+    }
+}


### PR DESCRIPTION
## Summary
- implement the HuGugu organ behaviour with slow-tick charge restoration, low-charge debuffs, and incoming-damage buffs plus reflect scaling from linkage efficiencies
- register the new tiger bone organ so it hooks into slow-tick and incoming-damage listeners via the Guzhenren organ registry

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68d17e6886c483269700920673d173ce