### PR TITLE
Fix organ projectile weapon requirement

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/LuoXuanGuQiangguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/LuoXuanGuQiangguOrganBehavior.java
@@ -14,6 +14,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ArrowItem;
+import net.minecraft.world.item.ProjectileWeaponItem;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import net.tigereye.chestcavity.ChestCavity;
@@ -166,7 +167,7 @@ public enum LuoXuanGuQiangguOrganBehavior implements OrganSlowTickListener, Orga
         Vec3 origin = player.getEyePosition().add(player.getLookAngle().scale(0.4));
         Vec3 direction = player.getLookAngle().normalize();
 
-        AbstractArrow projectile = ((ArrowItem) Items.ARROW).createArrow(level, new ItemStack(Items.ARROW), player, ItemStack.EMPTY);
+        AbstractArrow projectile = ((ArrowItem) Items.ARROW).createArrow(level, new ItemStack(Items.ARROW), player, findCompatibleWeapon(player));
         projectile.setSoundEvent(SoundEvents.ARROW_HIT);
         projectile.setBaseDamage(damage);
         projectile.pickup = AbstractArrow.Pickup.DISALLOWED;
@@ -183,6 +184,24 @@ public enum LuoXuanGuQiangguOrganBehavior implements OrganSlowTickListener, Orga
         level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.SKELETON_AMBIENT, SoundSource.PLAYERS, 0.7f, 1.0f);
         level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.CROSSBOW_SHOOT, SoundSource.PLAYERS, 1.0f, 1.2f);
         return true;
+    }
+
+    private static ItemStack findCompatibleWeapon(Player player) {
+        ItemStack mainHand = player.getMainHandItem();
+        if (isProjectileWeapon(mainHand)) {
+            return mainHand.copy();
+        }
+
+        ItemStack offHand = player.getOffhandItem();
+        if (isProjectileWeapon(offHand)) {
+            return offHand.copy();
+        }
+
+        return Items.BOW.getDefaultInstance();
+    }
+
+    private static boolean isProjectileWeapon(ItemStack stack) {
+        return !stack.isEmpty() && stack.getItem() instanceof ProjectileWeaponItem;
     }
 
     private static void applyCustomPickupItem(AbstractArrow projectile, ItemStack pickup) {


### PR DESCRIPTION
## Summary
- ensure the Luo Xuan Gu Qiang Gu ability provides a valid projectile weapon stack when spawning its arrow
- fall back to a synthetic bow when the player is not holding a projectile weapon to avoid IllegalArgumentException

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d184a9eb60832686c3a838e0bddd50