### PR TITLE
Deduplicate organ removal listener registration

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/util/ChestCavityUtil.java
+++ b/src/main/java/net/tigereye/chestcavity/util/ChestCavityUtil.java
@@ -444,7 +444,11 @@ public class ChestCavityUtil {
                             cc.onSlowTickListeners.add(new OrganSlowTickContext(itemStack,(OrganSlowTickListener)slotitem));
                         }
                         if(slotitem instanceof OrganRemovalListener removalListener){
-                            cc.onRemovedListeners.add(new OrganRemovalContext(itemStack, removalListener));
+                            boolean alreadyRegistered = cc.onRemovedListeners.stream()
+                                    .anyMatch(context -> context.organ == itemStack && context.listener == removalListener);
+                            if (!alreadyRegistered) {
+                                cc.onRemovedListeners.add(new OrganRemovalContext(itemStack, removalListener));
+                            }
                             staleRemovalContexts.removeIf(old -> old.organ == itemStack && old.listener == removalListener);
                         }
                         if (!data.pseudoOrgan) {


### PR DESCRIPTION
## Summary
- avoid adding duplicate organ removal contexts when a stack already registered a listener via Guzhenren handlers

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68d18c601e348326aa730575ceeb0200