### PR TITLE
Add testing wooden shovel organ placeholder

### DIFF
--- a/src/main/resources/data/chestcavity/organs/testing/wooden_shovel.json
+++ b/src/main/resources/data/chestcavity/organs/testing/wooden_shovel.json
@@ -1,0 +1,4 @@
+{
+  "itemID": "minecraft:wooden_shovel",
+  "organScores": []
+}


### PR DESCRIPTION
## Summary
- add a TESTING organ data file for the Wooden Shovel item with no organ scores so it can serve as a placeholder entry

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d2019ff14483269da89719e691e03d