### PR TITLE
Ensure organ removal listeners trigger when organs are shift-clicked out

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/YuGuguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/YuGuguOrganBehavior.java
@@ -18,6 +18,7 @@ import net.tigereye.chestcavity.listeners.OrganRemovalListener;
 import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
 import net.tigereye.chestcavity.util.NBTCharge;
 import net.tigereye.chestcavity.util.NetworkUtil;
+import net.tigereye.chestcavity.util.ChestCavityUtil;
 
 import net.tigereye.chestcavity.compat.guzhenren.GuzhenrenResourceBridge;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.SaturationPolicy;
@@ -74,8 +75,9 @@ public enum YuGuguOrganBehavior implements OrganSlowTickListener, OrganOnHitList
      * Registers a removal listener and, on first insert, applies the baseline efficiency bonus.
      */
     public void onEquip(ChestCavityInstance cc, ItemStack organ, List<OrganRemovalContext> staleRemovalContexts) {
-        boolean alreadyRegistered = staleRemovalContexts.removeIf(old -> old.organ == organ && old.listener == this);
-        cc.onRemovedListeners.add(new OrganRemovalContext(organ, this));
+        int slotIndex = ChestCavityUtil.findOrganSlot(cc, organ);
+        boolean alreadyRegistered = staleRemovalContexts.removeIf(old -> ChestCavityUtil.matchesRemovalContext(old, slotIndex, organ, this));
+        cc.onRemovedListeners.add(new OrganRemovalContext(slotIndex, organ, this));
         if (alreadyRegistered) {
             return;
         }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/linkage/effect/DefaultLinkageEffectContext.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/linkage/effect/DefaultLinkageEffectContext.java
@@ -21,6 +21,7 @@ import net.tigereye.chestcavity.listeners.OrganRemovalContext;
 import net.tigereye.chestcavity.listeners.OrganRemovalListener;
 import net.tigereye.chestcavity.listeners.OrganSlowTickContext;
 import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.util.ChestCavityUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -159,7 +160,9 @@ final class DefaultLinkageEffectContext implements LinkageEffectContext {
         if (listener == null) {
             return;
         }
-        chestCavity.onRemovedListeners.add(new OrganRemovalContext(organ, listener));
+        int slotIndex = ChestCavityUtil.findOrganSlot(chestCavity, organ);
+        chestCavity.onRemovedListeners.add(new OrganRemovalContext(slotIndex, organ, listener));
+        staleRemovalContexts.removeIf(old -> ChestCavityUtil.matchesRemovalContext(old, slotIndex, organ, listener));
         logListenerRegistration("removal", organ, listener);
     }
 

--- a/src/main/java/net/tigereye/chestcavity/listeners/OrganRemovalContext.java
+++ b/src/main/java/net/tigereye/chestcavity/listeners/OrganRemovalContext.java
@@ -6,11 +6,18 @@ import net.minecraft.world.item.ItemStack;
  * Stores the association between an organ stack and its removal listener implementation.
  */
 public class OrganRemovalContext {
+    /** Slot index the organ stack occupied when the listener was registered, or -1 if unknown. */
+    public final int slotIndex;
     public final ItemStack organ;
     public final OrganRemovalListener listener;
 
-    public OrganRemovalContext(ItemStack organ, OrganRemovalListener listener) {
+    public OrganRemovalContext(int slotIndex, ItemStack organ, OrganRemovalListener listener) {
+        this.slotIndex = slotIndex;
         this.organ = organ;
         this.listener = listener;
+    }
+
+    public OrganRemovalContext(ItemStack organ, OrganRemovalListener listener) {
+        this(-1, organ, listener);
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/util/ChestCavityUtil.java
+++ b/src/main/java/net/tigereye/chestcavity/util/ChestCavityUtil.java
@@ -372,6 +372,34 @@ public class ChestCavityUtil {
         }
     }
 
+    public static int findOrganSlot(ChestCavityInstance cc, ItemStack organ) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return -1;
+        }
+        for (int i = 0; i < cc.inventory.getContainerSize(); i++) {
+            if (cc.inventory.getItem(i) == organ) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static boolean matchesRemovalContext(OrganRemovalContext context, int slotIndex, ItemStack stack, OrganRemovalListener listener) {
+        if (context == null || context.listener != listener) {
+            return false;
+        }
+        if (context.slotIndex >= 0 && slotIndex >= 0) {
+            return context.slotIndex == slotIndex;
+        }
+        if (context.organ == stack) {
+            return true;
+        }
+        if (context.organ != null && stack != null && !context.organ.isEmpty() && !stack.isEmpty()) {
+            return ItemStack.isSameItemSameComponents(context.organ, stack);
+        }
+        return false;
+    }
+
     public static void dropUnboundOrgans(ChestCavityInstance cc) {
         try {
             cc.inventory.removeListener(cc);
@@ -444,12 +472,13 @@ public class ChestCavityUtil {
                             cc.onSlowTickListeners.add(new OrganSlowTickContext(itemStack,(OrganSlowTickListener)slotitem));
                         }
                         if(slotitem instanceof OrganRemovalListener removalListener){
+                            int slotIndex = i;
                             boolean alreadyRegistered = cc.onRemovedListeners.stream()
-                                    .anyMatch(context -> context.organ == itemStack && context.listener == removalListener);
+                                    .anyMatch(context -> matchesRemovalContext(context, slotIndex, itemStack, removalListener));
                             if (!alreadyRegistered) {
-                                cc.onRemovedListeners.add(new OrganRemovalContext(itemStack, removalListener));
+                                cc.onRemovedListeners.add(new OrganRemovalContext(slotIndex, itemStack, removalListener));
                             }
-                            staleRemovalContexts.removeIf(old -> old.organ == itemStack && old.listener == removalListener);
+                            staleRemovalContexts.removeIf(old -> matchesRemovalContext(old, slotIndex, itemStack, removalListener));
                         }
                         if (!data.pseudoOrgan) {
                             int compatibility = getCompatibilityLevel(cc,itemStack);


### PR DESCRIPTION
## Summary
- track the chest cavity slot for each removal listener context so removals are detected reliably
- update the chest cavity evaluation pass and Guzhenren behaviours to use the slot-aware matching helpers when registering listeners

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68d2013fe6448326b0631083773a7ac7