### PR TITLE
Add rebuildIncreaseEffects hooks to Guzhenren organ behaviors

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/GuQiangguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/GuQiangguOrganBehavior.java
@@ -12,6 +12,8 @@ import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectLedger;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.LinkageChannel;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.ClampPolicy;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.SaturationPolicy;
@@ -28,7 +30,7 @@ import java.util.Optional;
  * - 按阈值转换为 Charge 并写入器官 NBT
  * - 参考骨竹蛊的调试播报输出增量
  */
-public enum GuQiangguOrganBehavior implements OrganSlowTickListener, OrganOnHitListener {
+public enum GuQiangguOrganBehavior implements OrganSlowTickListener, OrganOnHitListener, IncreaseEffectContributor {
     INSTANCE;
 
     private static final String MOD_ID = "guzhenren";
@@ -142,5 +144,15 @@ public enum GuQiangguOrganBehavior implements OrganSlowTickListener, OrganOnHitL
 
     private static void sendHitDebug(String message) {
         ChestCavity.LOGGER.info("[GuQiang] {}", message);
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        // GuQianggu does not contribute to INCREASE effects.
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/GuzhuguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/GuzhuguOrganBehavior.java
@@ -15,6 +15,8 @@ import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
 import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectLedger;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.LinkageChannel;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.ClampPolicy;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.SaturationPolicy;
@@ -29,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Passive: each slow tick adds +5 per organ stack.
  * Active: using bone meal near the player injects +20 per stack.
  */
-public enum GuzhuguOrganBehavior implements OrganSlowTickListener {
+public enum GuzhuguOrganBehavior implements OrganSlowTickListener, IncreaseEffectContributor {
     INSTANCE;
 
     private static final String MOD_ID = "guzhenren";
@@ -268,5 +270,15 @@ public enum GuzhuguOrganBehavior implements OrganSlowTickListener {
                     0.0, 0.02, 0.0,
                     0.0);
         }
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        // Guzhugu does not contribute to INCREASE effects.
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/HuGuguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/HuGuguOrganBehavior.java
@@ -17,6 +17,8 @@ import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
 import net.tigereye.chestcavity.compat.guzhenren.GuzhenrenResourceBridge;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectLedger;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.LinkageChannel;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.ClampPolicy;
 import net.tigereye.chestcavity.listeners.OrganIncomingDamageListener;
@@ -30,7 +32,7 @@ import java.util.OptionalDouble;
 /**
  * 虎骨蛊：低蓄能时提供额外回复但施加虚弱，受击时为使用者提供防御增益并反弹伤害。
  */
-public enum HuGuguOrganBehavior implements OrganSlowTickListener, OrganIncomingDamageListener {
+public enum HuGuguOrganBehavior implements OrganSlowTickListener, OrganIncomingDamageListener, IncreaseEffectContributor {
     INSTANCE;
 
     private static final String MOD_ID = "guzhenren";
@@ -291,6 +293,16 @@ public enum HuGuguOrganBehavior implements OrganSlowTickListener, OrganIncomingD
         setStoredUnits(stack, updated);
         NetworkUtil.sendOrganSlotUpdate(cc, stack);
         return true;
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        // HuGugu does not contribute to INCREASE effects.
     }
 
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/LuoXuanGuQiangguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/LuoXuanGuQiangguOrganBehavior.java
@@ -24,6 +24,8 @@ import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
 import net.tigereye.chestcavity.compat.guzhenren.GuzhenrenResourceBridge;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectLedger;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.LinkageChannel;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.ClampPolicy;
 import net.tigereye.chestcavity.listeners.OrganActivationListeners;
@@ -38,7 +40,7 @@ import java.util.OptionalDouble;
 /**
  * Behaviour for 螺旋骨枪蛊. Handles slow tick recharging and active projectile firing.
  */
-public enum LuoXuanGuQiangguOrganBehavior implements OrganSlowTickListener, OrganOnHitListener {
+public enum LuoXuanGuQiangguOrganBehavior implements OrganSlowTickListener, OrganOnHitListener, IncreaseEffectContributor {
     INSTANCE;
 
     private static final String MOD_ID = "guzhenren";
@@ -256,5 +258,15 @@ public enum LuoXuanGuQiangguOrganBehavior implements OrganSlowTickListener, Orga
     @Override
     public float onHit(DamageSource source, LivingEntity attacker, LivingEntity target, ChestCavityInstance cc, ItemStack organ, float damage) {
         return damage;
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        // LuoXuanGuQianggu does not contribute to INCREASE effects.
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/san_zhuan/wu_hang/HuoxinguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/san_zhuan/wu_hang/HuoxinguOrganBehavior.java
@@ -5,12 +5,15 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
 import net.tigereye.chestcavity.compat.guzhenren.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectLedger;
 import net.tigereye.chestcavity.listeners.OrganOnFireListener;
 
 /**
  * Handles slow-burning recovery for the Guzhenren Huoxingu organ.
  */
-public enum HuoxinguOrganBehavior implements OrganOnFireListener {
+public enum HuoxinguOrganBehavior implements OrganOnFireListener, IncreaseEffectContributor {
     INSTANCE;
 
     private static final double BASE_COST = 100.0;
@@ -39,5 +42,15 @@ public enum HuoxinguOrganBehavior implements OrganOnFireListener {
                 player.heal(healAmount);
             }
         });
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        // Huoxingu does not contribute to INCREASE effects.
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/san_zhuan/wu_hang/JinfeiguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/san_zhuan/wu_hang/JinfeiguOrganBehavior.java
@@ -7,13 +7,16 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.food.FoodData;
 import net.minecraft.world.item.ItemStack;
 import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectLedger;
 import net.tigereye.chestcavity.listeners.OrganOnGroundListener;
 import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
 
 /**
  * Jinfeigu converts surplus hunger into absorption hearts on a slow tick cadence.
  */
-public enum JinfeiguOrganBehavior implements OrganOnGroundListener, OrganSlowTickListener {
+public enum JinfeiguOrganBehavior implements OrganOnGroundListener, OrganSlowTickListener, IncreaseEffectContributor {
     INSTANCE;
 
     private static final int FULL_FOOD_LEVEL = 20;
@@ -75,5 +78,15 @@ public enum JinfeiguOrganBehavior implements OrganOnGroundListener, OrganSlowTic
 
     private static float heartsFromAmplifier(int amplifier) {
         return (amplifier + 1) * 2.0f;
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        // Jinfeigu does not contribute to INCREASE effects.
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/san_zhuan/wu_hang/MuganguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/san_zhuan/wu_hang/MuganguOrganBehavior.java
@@ -9,6 +9,8 @@ import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
 import net.tigereye.chestcavity.compat.guzhenren.GuzhenrenResourceBridge;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectLedger;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.LinkageChannel;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.ClampPolicy;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.DecayPolicy;
@@ -21,7 +23,7 @@ import java.util.Set;
 /**
  * Mugangu regenerates zhenyuan each slow tick, with optional jingli cost when the five-element set is incomplete.
  */
-public enum MuganguOrganBehavior implements OrganOnGroundListener, OrganSlowTickListener {
+public enum MuganguOrganBehavior implements OrganOnGroundListener, OrganSlowTickListener, IncreaseEffectContributor {
     INSTANCE;
 
     private static final String MOD_ID = "guzhenren";
@@ -139,5 +141,15 @@ public enum MuganguOrganBehavior implements OrganOnGroundListener, OrganSlowTick
         double fraction = Math.min(1.0, missing / max);
         double scaled = baseAmount * (1.0 - Math.exp(-REGEN_ALPHA * fraction));
         return Double.isFinite(scaled) ? Math.max(0.0, scaled) : 0.0;
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        // Mugangu does not contribute to INCREASE effects.
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/san_zhuan/wu_hang/ShuishenguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/san_zhuan/wu_hang/ShuishenguOrganBehavior.java
@@ -17,6 +17,8 @@ import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
 import net.tigereye.chestcavity.compat.guzhenren.GuzhenrenResourceBridge;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectLedger;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.LinkageChannel;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.ClampPolicy;
 import net.tigereye.chestcavity.listeners.OrganIncomingDamageListener;
@@ -39,7 +41,7 @@ import net.tigereye.chestcavity.util.NBTCharge;
  * - Visuals: charging bubbles rising near feet; conduit-power for a subtle water outline; END_ROD/SOUL bursts on full.
  * - Sounds: bubble-column during charge, beacon select on full, splash every mitigation, shield-break on depletion.
  */
-public enum ShuishenguOrganBehavior implements OrganOnGroundListener, OrganSlowTickListener, OrganIncomingDamageListener {
+public enum ShuishenguOrganBehavior implements OrganOnGroundListener, OrganSlowTickListener, OrganIncomingDamageListener, IncreaseEffectContributor {
     INSTANCE;
 
     private static final String MOD_ID = "guzhenren";
@@ -260,5 +262,15 @@ public enum ShuishenguOrganBehavior implements OrganOnGroundListener, OrganSlowT
         LinkageChannel channel = context.lookupChannel(CHARGE_CHANNEL_ID)
                 .orElseGet(() -> context.getOrCreateChannel(CHARGE_CHANNEL_ID).addPolicy(UNIT_CLAMP));
         channel.set(Math.max(0.0, Math.min(1.0, ratio)));
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        // Shuishengu does not contribute to INCREASE effects.
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/san_zhuan/wu_hang/TupiguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/san_zhuan/wu_hang/TupiguOrganBehavior.java
@@ -8,13 +8,16 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
 import net.tigereye.chestcavity.compat.guzhenren.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectLedger;
 import net.tigereye.chestcavity.listeners.OrganOnGroundListener;
 import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
 
 /**
  * Tupigu converts zhenyuan into jingli boosts on a slow cadence with a small jump bonus.
  */
-public enum TupiguOrganBehavior implements OrganOnGroundListener, OrganSlowTickListener {
+public enum TupiguOrganBehavior implements OrganOnGroundListener, OrganSlowTickListener, IncreaseEffectContributor {
     INSTANCE;
 
     private static final double BASE_COST = 400.0;
@@ -48,5 +51,15 @@ public enum TupiguOrganBehavior implements OrganOnGroundListener, OrganSlowTickL
                 player.playSound(SoundEvents.EXPERIENCE_ORB_PICKUP, 0.1f, 1.1f);
             }
         });
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        // Tupigu does not contribute to INCREASE effects.
     }
 }


### PR DESCRIPTION
## Summary
- make each Guzhenren gu_dao organ behavior implement `IncreaseEffectContributor` and provide a no-op `rebuildIncreaseEffects`
- extend the san_zhuan wu_hang organ behaviors with empty `rebuildIncreaseEffects` implementations so every internal organ supports the hook

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d21a8666ac8326a3e18b3066bc821a