### PR TITLE
Relax removal context matching to ignore NBT-only changes

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/util/ChestCavityUtil.java
+++ b/src/main/java/net/tigereye/chestcavity/util/ChestCavityUtil.java
@@ -397,9 +397,9 @@ public class ChestCavityUtil {
             return true;
         }
 
-        boolean sameItem = context.organ != null && !context.organ.isEmpty()
-                && ItemStack.isSameItemSameComponents(context.organ, stack);
-        if (!sameItem) {
+        boolean sameItemType = context.organ != null && !context.organ.isEmpty()
+                && ItemStack.isSameItem(context.organ, stack);
+        if (!sameItemType) {
             return false;
         }
         if (context.slotIndex >= 0 && slotIndex >= 0) {


### PR DESCRIPTION
## Summary
- adjust `ChestCavityUtil.matchesRemovalContext` to treat stacks with the same item type in the same slot as the same organ, preventing spurious removal/re-equip cycles when NBT changes.

## Testing
- ./gradlew check --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d226b757388326b3d8e44dce477b33