### PR TITLE
Fix client ability event registration on mod bus

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/ChestCavity.java
+++ b/src/main/java/net/tigereye/chestcavity/ChestCavity.java
@@ -28,6 +28,7 @@ import net.tigereye.chestcavity.listeners.KeybindingClientListeners;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoClientAbilities;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoClientRenderLayers;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
 
@@ -62,7 +63,8 @@ public class ChestCavity { //TODO: fix 1.19 version to include color thing, fix 
 		bus.addListener(this::doServerStuff);
 		bus.addListener(NetworkHandler::registerCommon);
 
-		bus.addListener(GuDaoClientRenderLayers::onAddLayers);
+                bus.addListener(GuDaoClientAbilities::onClientSetup);
+                bus.addListener(GuDaoClientRenderLayers::onAddLayers);
 
 
 		NeoForge.EVENT_BUS.addListener(ServerEvents::onPlayerLogin);

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoClientAbilities.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoClientAbilities.java
@@ -1,22 +1,16 @@
 package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao;
 
-import net.neoforged.api.distmarker.Dist;
-import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
-import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.LuoXuanGuQiangguOrganBehavior;
 import net.tigereye.chestcavity.registration.CCKeybindings;
 
 /**
  * Ensures Guzhenren attack abilities are hooked into the shared attack hotkey on the client.
  */
-@EventBusSubscriber(modid = ChestCavity.MODID, value = Dist.CLIENT)
 public final class GuDaoClientAbilities {
     private GuDaoClientAbilities() {
     }
 
-    @SubscribeEvent
     public static void onClientSetup(FMLClientSetupEvent event) {
         if (!CCKeybindings.ATTACK_ABILITY_LIST.contains(LuoXuanGuQiangguOrganBehavior.ABILITY_ID)) {
             CCKeybindings.ATTACK_ABILITY_LIST.add(LuoXuanGuQiangguOrganBehavior.ABILITY_ID);


### PR DESCRIPTION
## Summary
- register GuDao client ability setup handler on the mod event bus from the main mod class
- remove runtime event annotations from the FMLClientSetupEvent handler so it is only invoked via the mod bus

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d2a0cb1a90832691f5278ca0fd5dde