### PR TITLE
Add Jianjiteng organ behavior for Guzhenren compatibility

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/GuzhenrenItems.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/GuzhenrenItems.java
@@ -1,0 +1,23 @@
+package net.tigereye.chestcavity.compat.guzhenren.item;
+
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+
+/**
+ * Lightweight accessors for Guzhenren mod items referenced by the compat layer.
+ */
+public final class GuzhenrenItems {
+
+    private static final String MOD_ID = "guzhenren";
+
+    public static final Item JIANJITENG = resolve("jianjiteng");
+    public static final Item JIANMAI_GU_GUFANG = resolve("jianmaigugufang");
+
+    private GuzhenrenItems() {
+    }
+
+    private static Item resolve(String path) {
+        return BuiltInRegistries.ITEM.get(ResourceLocation.fromNamespaceAndPath(MOD_ID, path));
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_cai/JianjitengOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_cai/JianjitengOrganBehavior.java
@@ -1,0 +1,144 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.gu_cai;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.compat.guzhenren.item.GuzhenrenItems;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.LinkageChannel;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.util.NBTCharge;
+import net.tigereye.chestcavity.util.NetworkUtil;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+/**
+ * Behaviour for 剑脊藤 organ stacks. Gradually charges by draining player resources.
+ */
+public enum JianjitengOrganBehavior implements OrganSlowTickListener {
+    INSTANCE;
+
+    private static final String MOD_ID = "guzhenren";
+    private static final String STATE_KEY = "JianjitengCharge";
+    private static final int MAX_CHARGE = 20;
+
+    private static final float HEALTH_COST = 0.5f;
+    private static final double ZHENYUAN_COST = 2.0;
+    private static final double ENERGY_COST = 5.0;
+
+    private static final ResourceLocation ENERGY_CHANNEL_ID =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/jianjiteng_energy");
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    private static final int BONUS_ROLL = 100;
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance chestCavity, ItemStack organ) {
+        if (!(entity instanceof Player player) || entity.level().isClientSide()) {
+            return;
+        }
+        if (chestCavity == null) {
+            return;
+        }
+
+        LinkageChannel energyChannel = ensureEnergyChannel(chestCavity);
+        int currentCharge = clampCharge(NBTCharge.getCharge(organ, STATE_KEY));
+
+        if (!canAffordHealth(player) || !hasSufficientEnergy(energyChannel)) {
+            return;
+        }
+
+        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+        if (handleOpt.isEmpty()) {
+            return;
+        }
+        GuzhenrenResourceBridge.ResourceHandle handle = handleOpt.get();
+        OptionalDouble zhenyuanResult = handle.consumeScaledZhenyuan(ZHENYUAN_COST);
+        if (zhenyuanResult.isEmpty()) {
+            return;
+        }
+
+        drainHealth(player);
+        energyChannel.adjust(-ENERGY_COST);
+
+        int updatedCharge = currentCharge + 1;
+        if (updatedCharge >= MAX_CHARGE) {
+            NBTCharge.setCharge(organ, STATE_KEY, 0);
+            NetworkUtil.sendOrganSlotUpdate(chestCavity, organ);
+            dispensePrimaryReward(player);
+            maybeGrantBonus(player);
+        } else {
+            NBTCharge.setCharge(organ, STATE_KEY, updatedCharge);
+            NetworkUtil.sendOrganSlotUpdate(chestCavity, organ);
+        }
+    }
+
+    /** Ensures linkage channels exist for the owning chest cavity. */
+    public void ensureAttached(ChestCavityInstance chestCavity) {
+        if (chestCavity == null) {
+            return;
+        }
+        ensureEnergyChannel(chestCavity);
+    }
+
+    private static LinkageChannel ensureEnergyChannel(ChestCavityInstance chestCavity) {
+        ActiveLinkageContext context = GuzhenrenLinkageManager.getContext(chestCavity);
+        return context.getOrCreateChannel(ENERGY_CHANNEL_ID).addPolicy(NON_NEGATIVE);
+    }
+
+    private static int clampCharge(int rawCharge) {
+        if (rawCharge <= 0) {
+            return 0;
+        }
+        return Math.min(MAX_CHARGE, rawCharge);
+    }
+
+    private static boolean canAffordHealth(Player player) {
+        return player.getHealth() > 1.0f;
+    }
+
+    private static void drainHealth(Player player) {
+        float current = player.getHealth();
+        float updated = Math.max(1.0f, current - HEALTH_COST);
+        player.setHealth(updated);
+    }
+
+    private static boolean hasSufficientEnergy(LinkageChannel channel) {
+        return channel.get() >= ENERGY_COST;
+    }
+
+    private static void dispensePrimaryReward(Player player) {
+        ItemStack reward = new ItemStack(GuzhenrenItems.JIANJITENG);
+        if (!player.addItem(reward)) {
+            player.drop(reward, false);
+        }
+    }
+
+    private static void maybeGrantBonus(Player player) {
+        if (!hasFullStack(player)) {
+            return;
+        }
+        if (player.getRandom().nextInt(BONUS_ROLL) != 0) {
+            return;
+        }
+        ItemStack bonus = new ItemStack(GuzhenrenItems.JIANMAI_GU_GUFANG);
+        if (!player.addItem(bonus)) {
+            player.drop(bonus, false);
+        }
+    }
+
+    private static boolean hasFullStack(Player player) {
+        for (ItemStack stack : player.getInventory().items) {
+            if (stack.is(GuzhenrenItems.JIANJITENG) && stack.getCount() >= 64) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganRegistry.java
@@ -1,6 +1,7 @@
 package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao;
 
 import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_cai.JianjitengOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.GuQiangguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.GuzhuguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.HuGuguOrganBehavior;
@@ -20,6 +21,7 @@ public final class GuDaoOrganRegistry {
     private static final ResourceLocation SPIRAL_BONE_SPEAR_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "luo_xuan_gu_qiang_gu");
     private static final ResourceLocation TIGER_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "hugugu");
     private static final ResourceLocation JADE_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "yu_gu_gu"); // 新增玉骨蛊
+    private static final ResourceLocation JIANJITENG_BLOCK_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "jianjiteng");
 
     static {
         GuDaoOrganEvents.register();
@@ -54,6 +56,11 @@ public final class GuDaoOrganRegistry {
                     context.sourceOrgan(),
                     context.staleRemovalContexts()
             );
+        });
+
+        GuzhenrenLinkageEffectRegistry.registerSingle(JIANJITENG_BLOCK_ID, context -> {
+            context.addSlowTickListener(JianjitengOrganBehavior.INSTANCE);
+            JianjitengOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
         });
     }
 


### PR DESCRIPTION
## Summary
- implement the Jianjiteng organ slow tick behaviour that consumes player health, zhenyuan and linkage energy to charge and produces Guzhenren rewards
- add a GuzhenrenItems helper for item lookups and register the new behaviour against the Guzhenren Jianjiteng block

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68d2ace278088326b67b918e52541912