### PR TITLE
Add Guzhenren Jiu Chong alcohol mechanics

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/ChestCavity.java
+++ b/src/main/java/net/tigereye/chestcavity/ChestCavity.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoClientAbilities;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoClientRenderLayers;
+import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.ShiDaoClientAbilities;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
 
 @Mod(ChestCavity.MODID)
@@ -65,6 +66,7 @@ public class ChestCavity { //TODO: fix 1.19 version to include color thing, fix 
 
     if (FMLEnvironment.dist.isClient()) {
             bus.addListener(GuDaoClientAbilities::onClientSetup);
+            bus.addListener(ShiDaoClientAbilities::onClientSetup);
     }
 
     bus.addListener(GuDaoClientRenderLayers::onAddLayers);

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/GuzhenrenOrganHandlers.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/GuzhenrenOrganHandlers.java
@@ -13,6 +13,7 @@ import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.lei_dao.LeiDaoOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.san_zhuan.wu_hang.WuHangOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.ShiDaoOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.effect.GuzhenrenLinkageEffectRegistry;
@@ -56,6 +57,7 @@ public final class GuzhenrenOrganHandlers {
         GuDaoOrganRegistry.bootstrap();
         LeiDaoOrganRegistry.bootstrap();
         WuHangOrganRegistry.bootstrap();
+        ShiDaoOrganRegistry.bootstrap();
         GuzhenrenLinkageEffectRegistry.applyEffects(cc, stack, staleRemovalContexts);
         if (stack.is(Items.WOODEN_SHOVEL)) {
             displayChannelSnapshot(cc, context);

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shi_dao/ShiDaoClientAbilities.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shi_dao/ShiDaoClientAbilities.java
@@ -1,0 +1,20 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.shi_dao;
+
+import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.behavior.JiuChongOrganBehavior;
+import net.tigereye.chestcavity.registration.CCKeybindings;
+
+/**
+ * Ensures Shi Dao attack abilities are bound to the shared attack keybinding on the client.
+ */
+public final class ShiDaoClientAbilities {
+
+    private ShiDaoClientAbilities() {
+    }
+
+    public static void onClientSetup(FMLClientSetupEvent event) {
+        if (!CCKeybindings.ATTACK_ABILITY_LIST.contains(JiuChongOrganBehavior.ABILITY_ID)) {
+            CCKeybindings.ATTACK_ABILITY_LIST.add(JiuChongOrganBehavior.ABILITY_ID);
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shi_dao/ShiDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shi_dao/ShiDaoOrganRegistry.java
@@ -1,0 +1,30 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.shi_dao;
+
+import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.behavior.JiuChongOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.effect.GuzhenrenLinkageEffectRegistry;
+
+/**
+ * Registry wiring for 食道（Shi Dao） organs such as the 酒虫.
+ */
+public final class ShiDaoOrganRegistry {
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation JIU_CHONG_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "jiu_chong");
+
+    static {
+        GuzhenrenLinkageEffectRegistry.registerSingle(JIU_CHONG_ID, context -> {
+            context.addSlowTickListener(JiuChongOrganBehavior.INSTANCE);
+            context.addOnHitListener(JiuChongOrganBehavior.INSTANCE);
+            context.addIncomingDamageListener(JiuChongOrganBehavior.INSTANCE);
+            JiuChongOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
+        });
+    }
+
+    private ShiDaoOrganRegistry() {
+    }
+
+    public static void bootstrap() {
+        // no-op, just triggers class initialisation
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shi_dao/behavior/JiuChongOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shi_dao/behavior/JiuChongOrganBehavior.java
@@ -1,0 +1,307 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.behavior;
+
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.food.FoodData;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.LinkageChannel;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.compat.guzhenren.util.GuzhenrenCombatUtil;
+import net.tigereye.chestcavity.listeners.OrganActivationListeners;
+import net.tigereye.chestcavity.listeners.OrganIncomingDamageListener;
+import net.tigereye.chestcavity.listeners.OrganOnHitListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.registration.CCDamageSources;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Behaviour for 酒虫. Manages the alcohol resource, drunken buffs, active breath skill and overcharge.
+ */
+public enum JiuChongOrganBehavior implements OrganSlowTickListener, OrganOnHitListener, OrganIncomingDamageListener {
+    INSTANCE;
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation ORGAN_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "jiu_chong");
+    public static final ResourceLocation ABILITY_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "jiu_chong_breath");
+
+    private static final ResourceLocation ALCOHOL_CHANNEL = ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/jiu_chong_alcohol");
+
+    private static final double MAX_ALCOHOL = 100.0;
+    private static final double ALCOHOL_PER_FEED = 1.0;
+    private static final double HUNGER_COST = 0.5;
+    private static final double DRUNK_THRESHOLD = 20.0;
+    private static final double ATTACK_BONUS = 0.2;
+    private static final float BASE_DODGE_CHANCE = 0.1f;
+    private static final float MIN_DODGE_DISTANCE = 0.5f;
+    private static final float MAX_DODGE_DISTANCE = 1.0f;
+    private static final float DODGE_YAW_RANGE = 60.0f;
+    private static final float ATTACK_YAW_RANGE = 15.0f;
+    private static final float ATTACK_PITCH_RANGE = 5.0f;
+
+    private static final double BREATH_COST = 30.0;
+    private static final double REGEN_COST = 10.0;
+    private static final float REGEN_HEAL_AMOUNT = 2.0f;
+    private static final long REGEN_INTERVAL_TICKS = 40L;
+
+    private static final long MANIA_DURATION_TICKS = 20L * 20L;
+    private static final float MANIA_DAMAGE_MULTIPLIER = 2.0f;
+
+    private static final ClampPolicy ALCOHOL_CLAMP = new ClampPolicy(0.0, MAX_ALCOHOL);
+
+    private static final Map<UUID, Long> MANIA_EXPIRY = new ConcurrentHashMap<>();
+    private static final Map<UUID, Long> LAST_REGEN_TICK = new ConcurrentHashMap<>();
+
+    static {
+        OrganActivationListeners.register(ABILITY_ID, JiuChongOrganBehavior::activateAbility);
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (!(entity instanceof Player player) || entity.level().isClientSide()) {
+            return;
+        }
+        if (!hasOrgan(cc)) {
+            return;
+        }
+        LinkageChannel channel = ensureAlcoholChannel(cc);
+        double previousAlcohol = channel.get();
+        int stackCount = Math.max(1, organ.getCount());
+        int gained = convertHungerToAlcohol(player, stackCount);
+        double newAlcohol = previousAlcohol;
+        if (gained > 0) {
+            newAlcohol = channel.adjust(ALCOHOL_PER_FEED * gained);
+            long gameTime = player.level().getGameTime();
+            if (previousAlcohol < MAX_ALCOHOL && newAlcohol >= MAX_ALCOHOL) {
+                triggerMania(player, gameTime);
+            } else if (newAlcohol >= MAX_ALCOHOL && isManiaActive(player, gameTime)) {
+                player.hurt(CCDamageSources.alcoholOverdose(player), gained);
+            }
+        }
+        long gameTime = player.level().getGameTime();
+        handleManiaLoop(player, gameTime);
+        tryDrunkenRegeneration(player, channel, gameTime);
+    }
+
+    @Override
+    public float onHit(DamageSource source, LivingEntity attacker, LivingEntity target, ChestCavityInstance cc, ItemStack organ, float damage) {
+        if (attacker == null || attacker.level().isClientSide()) {
+            return damage;
+        }
+        LinkageChannel channel = ensureAlcoholChannel(cc);
+        double alcohol = channel.get();
+        double multiplier = 1.0;
+        if (alcohol >= DRUNK_THRESHOLD) {
+            multiplier += ATTACK_BONUS;
+            GuzhenrenCombatUtil.applyRandomAttackOffset(attacker, ATTACK_YAW_RANGE, ATTACK_PITCH_RANGE, alcohol / MAX_ALCOHOL);
+        }
+        if (attacker instanceof Player player) {
+            if (isManiaActive(player, player.level().getGameTime())) {
+                multiplier *= MANIA_DAMAGE_MULTIPLIER;
+            }
+        }
+        return (float) (damage * multiplier);
+    }
+
+    @Override
+    public float onIncomingDamage(DamageSource source, LivingEntity victim, ChestCavityInstance cc, ItemStack organ, float damage) {
+        if (victim == null || victim.level().isClientSide()) {
+            return damage;
+        }
+        LinkageChannel channel = ensureAlcoholChannel(cc);
+        double alcohol = channel.get();
+        boolean dodged = false;
+        if (alcohol >= DRUNK_THRESHOLD) {
+            float stacks = Math.max(1, organ.getCount());
+            float chance = Math.min(1.0f, BASE_DODGE_CHANCE * stacks);
+            if (victim.getRandom().nextFloat() < chance) {
+                LivingEntity attacker = source.getEntity() instanceof LivingEntity living ? living : null;
+                dodged = GuzhenrenCombatUtil.performShortDodge(
+                        victim,
+                        attacker,
+                        MIN_DODGE_DISTANCE,
+                        MAX_DODGE_DISTANCE,
+                        DODGE_YAW_RANGE,
+                        SoundEvents.SLIME_JUMP,
+                        ParticleTypes.CLOUD
+                );
+            }
+        }
+        if (dodged) {
+            return 0.0f;
+        }
+        double multiplier = 1.0;
+        if (victim instanceof Player player && isManiaActive(player, player.level().getGameTime())) {
+            multiplier *= MANIA_DAMAGE_MULTIPLIER;
+        }
+        return (float) (damage * multiplier);
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        ensureAlcoholChannel(cc);
+    }
+
+    private static LinkageChannel ensureAlcoholChannel(ChestCavityInstance cc) {
+        ActiveLinkageContext context = GuzhenrenLinkageManager.getContext(cc);
+        return context.getOrCreateChannel(ALCOHOL_CHANNEL).addPolicy(ALCOHOL_CLAMP);
+    }
+
+    private static int convertHungerToAlcohol(Player player, int attempts) {
+        FoodData foodData = player.getFoodData();
+        int successful = 0;
+        for (int i = 0; i < attempts; i++) {
+            if (tryConsumeHalf(foodData)) {
+                successful++;
+            } else {
+                break;
+            }
+        }
+        return successful;
+    }
+
+    private static boolean tryConsumeHalf(FoodData foodData) {
+        float saturation = foodData.getSaturationLevel();
+        if (saturation > 0.0f) {
+            float updated = Math.max(0.0f, saturation - (float) HUNGER_COST);
+            foodData.setSaturation(Math.min(updated, foodData.getFoodLevel()));
+            return true;
+        }
+        int hunger = foodData.getFoodLevel();
+        if (hunger > 0) {
+            foodData.setFoodLevel(Math.max(0, hunger - 1));
+            return true;
+        }
+        return false;
+    }
+
+    private static void tryDrunkenRegeneration(Player player, LinkageChannel channel, long gameTime) {
+        if (player.getHealth() > player.getMaxHealth() * 0.3f) {
+            return;
+        }
+        if (channel.get() < REGEN_COST) {
+            return;
+        }
+        long last = LAST_REGEN_TICK.getOrDefault(player.getUUID(), Long.MIN_VALUE);
+        if (gameTime - last < REGEN_INTERVAL_TICKS) {
+            return;
+        }
+        channel.adjust(-REGEN_COST);
+        player.heal(REGEN_HEAL_AMOUNT);
+        Level level = player.level();
+        RandomSource random = player.getRandom();
+        level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.PLAYER_HURT_DROWN, SoundSource.PLAYERS, 0.7f, 0.8f + random.nextFloat() * 0.4f);
+        if (level instanceof ServerLevel server) {
+            server.sendParticles(ParticleTypes.HAPPY_VILLAGER, player.getX(), player.getY() + player.getBbHeight() * 0.6, player.getZ(), 8, 0.2, 0.2, 0.2, 0.01);
+        }
+        LAST_REGEN_TICK.put(player.getUUID(), gameTime);
+    }
+
+    private static void triggerMania(Player player, long gameTime) {
+        long endTick = gameTime + MANIA_DURATION_TICKS;
+        MANIA_EXPIRY.put(player.getUUID(), endTick);
+        player.addEffect(new MobEffectInstance(MobEffects.CONFUSION, (int) MANIA_DURATION_TICKS, 0, false, true, true));
+        Level level = player.level();
+        SoundSource category = SoundSource.PLAYERS;
+        level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.WITCH_AMBIENT, category, 1.0f, 1.0f);
+    }
+
+    private static void handleManiaLoop(Player player, long gameTime) {
+        if (!isManiaActive(player, gameTime)) {
+            return;
+        }
+        RandomSource random = player.getRandom();
+        if (random.nextFloat() < 0.25f) {
+            Level level = player.level();
+            SoundSource category = SoundSource.PLAYERS;
+            level.playSound(
+                    null,
+                    player.getX(),
+                    player.getY(),
+                    player.getZ(),
+                    random.nextBoolean() ? SoundEvents.VILLAGER_NO : SoundEvents.WITCH_AMBIENT,
+                    category,
+                    0.9f,
+                    0.8f + random.nextFloat() * 0.4f
+            );
+        }
+    }
+
+    private static boolean isManiaActive(Player player, long gameTime) {
+        Long expiry = MANIA_EXPIRY.get(player.getUUID());
+        if (expiry == null) {
+            return false;
+        }
+        if (expiry <= gameTime) {
+            MANIA_EXPIRY.remove(player.getUUID());
+            return false;
+        }
+        return true;
+    }
+
+    private static void activateAbility(LivingEntity entity, ChestCavityInstance cc) {
+        if (!(entity instanceof Player player) || entity.level().isClientSide()) {
+            return;
+        }
+        if (!hasOrgan(cc)) {
+            return;
+        }
+        LinkageChannel channel = ensureAlcoholChannel(cc);
+        if (channel.get() < BREATH_COST) {
+            return;
+        }
+        channel.adjust(-BREATH_COST);
+        Level level = player.level();
+        level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.GENERIC_DRINK, SoundSource.PLAYERS, 0.8f, 1.2f);
+        level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.PLAYER_BURP, SoundSource.PLAYERS, 0.8f, 0.8f);
+        if (level instanceof ServerLevel server) {
+            server.sendParticles(ParticleTypes.POOF, player.getX(), player.getY() + 0.8, player.getZ(), 12, 0.4, 0.3, 0.4, 0.02);
+            server.sendParticles(ParticleTypes.DRAGON_BREATH, player.getX(), player.getY() + 0.6, player.getZ(), 16, 0.5, 0.2, 0.5, 0.01);
+        }
+        AABB area = player.getBoundingBox().inflate(4.0);
+        List<LivingEntity> victims = level.getEntitiesOfClass(LivingEntity.class, area, target -> target != player && target.isAlive());
+        for (LivingEntity target : victims) {
+            if (target.isAlliedTo(player)) {
+                continue;
+            }
+            target.addEffect(new MobEffectInstance(MobEffects.CONFUSION, 40, 0, false, true, true));
+            target.addEffect(new MobEffectInstance(MobEffects.BLINDNESS, 40, 0, false, true, true));
+        }
+        player.addEffect(new MobEffectInstance(MobEffects.DAMAGE_BOOST, 100, 0, false, true, true));
+        player.addEffect(new MobEffectInstance(MobEffects.WEAKNESS, 100, 0, false, true, true));
+    }
+
+    private static boolean hasOrgan(ChestCavityInstance cc) {
+        if (cc == null) {
+            return false;
+        }
+        for (int i = 0; i < cc.inventory.getContainerSize(); i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (stack.isEmpty()) {
+                continue;
+            }
+            ResourceLocation id = BuiltInRegistries.ITEM.getKey(stack.getItem());
+            if (ORGAN_ID.equals(id)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/util/GuzhenrenCombatUtil.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/util/GuzhenrenCombatUtil.java
@@ -1,0 +1,104 @@
+package net.tigereye.chestcavity.compat.guzhenren.util;
+
+import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Shared combat helpers for Guzhenren organ behaviours.
+ */
+public final class GuzhenrenCombatUtil {
+
+    private GuzhenrenCombatUtil() {
+    }
+
+    /**
+     * Performs a short horizontal dodge for the target. The direction is based on the attacker's look
+     * vector when available, otherwise a random heading is used. The motion is applied via {@link LivingEntity#push}
+     * so that vanilla movement syncing is preserved.
+     */
+    public static boolean performShortDodge(
+            LivingEntity target,
+            LivingEntity attacker,
+            float minDistance,
+            float maxDistance,
+            float yawRangeDeg,
+            SoundEvent sound,
+            ParticleOptions particle
+    ) {
+        if (target == null) {
+            return false;
+        }
+        Level level = target.level();
+        RandomSource random = target.getRandom();
+        Vec3 base = attacker != null ? attacker.getLookAngle() : target.getLookAngle();
+        Vec3 horizontal = new Vec3(base.x, 0.0, base.z);
+        if (horizontal.lengthSqr() < 1.0E-6) {
+            double angle = random.nextDouble() * Math.PI * 2.0;
+            horizontal = new Vec3(Math.cos(angle), 0.0, Math.sin(angle));
+        }
+        float yawOffset = (random.nextFloat() - 0.5f) * yawRangeDeg;
+        Vec3 rotated = horizontal.normalize().yRot((float) Math.toRadians(yawOffset));
+        double distance = Mth.lerp(random.nextDouble(), minDistance, maxDistance);
+        Vec3 motion = rotated.scale(distance);
+        target.push(motion.x, 0.05, motion.z);
+        if (level instanceof ServerLevel server) {
+            ParticleOptions particleType = particle != null ? particle : ParticleTypes.CLOUD;
+            server.sendParticles(
+                    particleType,
+                    target.getX(),
+                    target.getY() + target.getBbHeight() * 0.4,
+                    target.getZ(),
+                    6,
+                    0.2,
+                    0.1,
+                    0.2,
+                    0.01
+            );
+        }
+        if (sound != null) {
+            level.playSound(
+                    null,
+                    target.getX(),
+                    target.getY(),
+                    target.getZ(),
+                    sound,
+                    target.getSoundSource(),
+                    0.8f,
+                    0.9f + random.nextFloat() * 0.2f
+            );
+        }
+        return true;
+    }
+
+    /**
+     * Applies a randomised attack offset by rotating the attacker's view. The magnitude is scaled by
+     * {@code intensity} so callers can tie the effect to a "drunkness" factor.
+     */
+    public static void applyRandomAttackOffset(LivingEntity attacker, float yawRangeDeg, float pitchRangeDeg, double intensity) {
+        if (attacker == null || intensity <= 0.0) {
+            return;
+        }
+        RandomSource random = attacker.getRandom();
+        float scale = (float) Mth.clamp(intensity, 0.0, 1.0);
+        float yawOffset = (random.nextFloat() * 2.0f - 1.0f) * yawRangeDeg * scale;
+        float pitchOffset = (random.nextFloat() * 2.0f - 1.0f) * pitchRangeDeg * scale;
+        float newYaw = attacker.getYRot() + yawOffset;
+        float newPitch = Mth.clamp(attacker.getXRot() + pitchOffset, -90.0f, 90.0f);
+        attacker.setYRot(newYaw);
+        attacker.setXRot(newPitch);
+        attacker.setYHeadRot(newYaw);
+        attacker.setYBodyRot(newYaw);
+        attacker.yHeadRotO = newYaw;
+        attacker.yBodyRotO = newYaw;
+        attacker.yRotO = newYaw;
+        attacker.xRotO = newPitch;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/registration/CCDamageSources.java
+++ b/src/main/java/net/tigereye/chestcavity/registration/CCDamageSources.java
@@ -11,6 +11,7 @@ import net.tigereye.chestcavity.ChestCavity;
 public final class CCDamageSources {
     public static final ResourceKey<DamageType> HEARTBLEED = register("heartbleed");
     public static final ResourceKey<DamageType> ORGAN_REJECTION = register("organ_rejection");
+    public static final ResourceKey<DamageType> ALCOHOL_OVERDOSE = register("alcohol_overdose");
 
     private CCDamageSources() {}
 
@@ -24,5 +25,9 @@ public final class CCDamageSources {
 
     public static DamageSource organRejection(LivingEntity entity) {
         return entity.level().damageSources().source(ORGAN_REJECTION);
+    }
+
+    public static DamageSource alcoholOverdose(LivingEntity entity) {
+        return entity.level().damageSources().source(ALCOHOL_OVERDOSE);
     }
 }

--- a/src/main/resources/assets/chestcavity/lang/en_us.json
+++ b/src/main/resources/assets/chestcavity/lang/en_us.json
@@ -3,6 +3,8 @@
     "death.attack.ccHeartbleed.player": "%2$s witnessed %1$s's sacrifice",
     "death.attack.ccOrganRejection": "%1$s died of medical complications",
     "death.attack.ccOrganRejection.player": "%1$s died of medical complications while fighting %2$s",
+    "death.attack.alcohol_overdose": "%1$s succumbed to alcohol poisoning",
+    "death.attack.alcohol_overdose.player": "%1$s succumbed to alcohol poisoning while fighting %2$s",
     "effect.chestcavity.organ_rejection": "Organ Rejection",
     "effect.chestcavity.arrow_dodge_cooldown": "Arrow Dodge Cooldown",
     "effect.chestcavity.dragon_breath_cooldown": "Dragon Breath Cooldown",

--- a/src/main/resources/assets/chestcavity/lang/zh_cn.json
+++ b/src/main/resources/assets/chestcavity/lang/zh_cn.json
@@ -6,5 +6,7 @@
   "text.chestcavity.wooden_shovel.tick_rate_set": "已将集成服务器刻速设置为 %s",
   "text.chestcavity.wooden_shovel.freeze": "集成服务器刻已冻结",
   "text.chestcavity.wooden_shovel.unfreeze": "集成服务器刻已恢复",
-  "text.chestcavity.wooden_shovel.unavailable": "仅在单机模式下可以控制刻速。"
+  "text.chestcavity.wooden_shovel.unavailable": "仅在单机模式下可以控制刻速。",
+  "death.attack.alcohol_overdose": "%1$s 醉死沙场君莫笑",
+  "death.attack.alcohol_overdose.player": "%1$s 与 %2$s 交锋时醉死沙场君莫笑"
 }

--- a/src/main/resources/data/chestcavity/damage_type/alcohol_overdose.json
+++ b/src/main/resources/data/chestcavity/damage_type/alcohol_overdose.json
@@ -1,0 +1,7 @@
+{
+  "message_id": "alcohol_overdose",
+  "scaling": "never",
+  "exhaustion": 0.1,
+  "death_message_type": "default",
+  "effects": "hurt"
+}


### PR DESCRIPTION
## Summary
- add a reusable Guzhenren combat utility for dodge movement and drunken aim offsets
- implement the Jiu Chong organ behaviour with alcohol tracking, buffs, dodges, active breath attack, regeneration, and overcharge effects
- register the new Shi Dao organ listeners, client ability wiring, alcohol overdose damage type, and localisation strings

## Testing
- ./gradlew build --console=plain --max-workers=1

------
https://chatgpt.com/codex/tasks/task_e_68d2b218f4988326aca8393cdfdffaa1