### PR TITLE
Fix Guzhenren compile issues

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/GuzhenrenItems.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/GuzhenrenItems.java
@@ -21,8 +21,6 @@ public final class GuzhenrenItems {
     public static final Item XIE_DI_GU = resolve("xie_di_gu");
     public static final Item XIE_YAN_GU = resolve("xie_yan_gu");
 
-    public static final Item XIE_DI_GU = resolve("xie_di_gu");
-
 
     public static final Item WEI_LIAN_HUA_JIAN_XIA_GU = resolve("weilianhuajianxiagu");
     public static final Item WEI_LIAN_HUA_JIAN_ZHI_GU_3 = resolve("wei_lian_hua_jian_zhi_gu_3");

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/XueDaoClientAbilities.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/XueDaoClientAbilities.java
@@ -2,6 +2,7 @@ package net.tigereye.chestcavity.compat.guzhenren.item.xue_dao;
 
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 
+import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.behavior.XiediguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.behavior.XueFeiguOrganBehavior;
 import net.tigereye.chestcavity.registration.CCKeybindings;
 


### PR DESCRIPTION
## Summary
- remove the duplicate Xie Di Gu item constant from the Guzhenren item accessors
- import the Xiedigu organ behavior so its ability registers with the shared attack keybinding

## Testing
- `./gradlew compileJava --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68d3d59976548326ac79818d099363da