### PR TITLE
Fix Xie Di Gu equip message triggering for unrelated organs

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/behavior/XiediguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/behavior/XiediguOrganBehavior.java
@@ -104,6 +104,9 @@ public enum XiediguOrganBehavior implements OrganSlowTickListener, OrganRemovalL
         if (cc == null || organ == null || organ.isEmpty()) {
             return;
         }
+        if (!matchesOrgan(organ)) {
+            return;
+        }
 
         int slotIndex = ChestCavityUtil.findOrganSlot(cc, organ);
         boolean alreadyRegistered = staleRemovalContexts.removeIf(old ->


### PR DESCRIPTION
## Summary
- guard the Xie Di Gu onEquip handler so it only runs for genuine Xie Di Gu organ stacks

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d3d1f011208326ba58c4ce770605bd