### PR TITLE
Extend poison mist duration and remove self-healing

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/behavior/XieFeiguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/behavior/XieFeiguOrganBehavior.java
@@ -84,11 +84,11 @@ public enum XieFeiguOrganBehavior implements OrganSlowTickListener, OrganRemoval
 
     private static final int COOLDOWN_TICKS = 200; // 10 seconds
 
-    private static final int FOG_DURATION_SECONDS = 5;
+    private static final int FOG_DURATION_SECONDS = 8;
     private static final double FOG_RADIUS = 6.0;
     private static final float FOG_DAMAGE = 4.0f;
     private static final int BLINDNESS_DURATION_TICKS = 60;
-    private static final int POISON_DURATION_TICKS = 80;
+    private static final int POISON_DURATION_TICKS = 160;
     private static final int FOG_PARTICLE_COUNT = 120;
 
     private static final DustParticleOptions BLOOD_DUST =
@@ -416,9 +416,7 @@ public enum XieFeiguOrganBehavior implements OrganSlowTickListener, OrganRemoval
             applyFogDamage(level, player, target, fogDamage);
         }
 
-        if (!player.isDeadOrDying() && player.distanceToSqr(center) <= FOG_RADIUS * FOG_RADIUS) {
-            applySelfRecovery(player);
-        }
+        // Poison fog no longer grants the caster recovery; only enemies are affected.
     }
 
     private static void applyFogDamage(ServerLevel level, Player player, LivingEntity target, float amount) {
@@ -428,16 +426,6 @@ public enum XieFeiguOrganBehavior implements OrganSlowTickListener, OrganRemoval
         target.invulnerableTime = 0;
         target.hurt(level.damageSources().magic(), amount);
         target.invulnerableTime = 0;
-    }
-
-    private static void applySelfRecovery(Player player) {
-        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
-        if (handleOpt.isPresent()) {
-            GuzhenrenResourceBridge.ResourceHandle handle = handleOpt.get();
-            handle.replenishScaledZhenyuan(ZHENYUAN_COST, true);
-            handle.adjustJingli(ZHENYUAN_COST, true);
-        }
-        player.heal(4.0f);
     }
 
     private static double resolveIncreaseMultiplier(ChestCavityInstance cc) {


### PR DESCRIPTION
## Summary
- extend the blood fog ability duration to keep pulses active for 8 seconds and lengthen the applied poison effect
- remove the self-recovery effect granted to the caster when standing inside the fog

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68d3e4d4deb08326903d17d6254f9112