### PR TITLE
Add Guzhenren ability framework

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/GuzhenrenOrganHandlers.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/GuzhenrenOrganHandlers.java
@@ -10,6 +10,7 @@ import net.minecraft.world.item.Items;
 import net.neoforged.fml.ModList;
 import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.ability.Abilities;
 import net.tigereye.chestcavity.compat.guzhenren.item.du_dao.DuDaoOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_cai.GuCaiOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoOrganRegistry;
@@ -60,6 +61,7 @@ public final class GuzhenrenOrganHandlers {
             );
         }
         ActiveLinkageContext context = GuzhenrenLinkageManager.getContext(cc);
+        Abilities.bootstrap();
         GuCaiOrganRegistry.bootstrap();
         DuDaoOrganRegistry.bootstrap();
         GuDaoOrganRegistry.bootstrap();

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/ability/Abilities.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/ability/Abilities.java
@@ -1,0 +1,39 @@
+package net.tigereye.chestcavity.compat.guzhenren.ability;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.listeners.OrganActivationListeners;
+
+/**
+ * Registers Guzhenren-specific active abilities exposed through the Chest Cavity hotkeys.
+ */
+public final class Abilities {
+
+    private static final String MOD_ID = "guzhenren";
+
+    /** Identifier for the combined Blood/Bone offensive ability. */
+    public static final ResourceLocation BLOOD_BONE_BOMB =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "blood_bone_bomb");
+
+    static {
+        OrganActivationListeners.register(BLOOD_BONE_BOMB, Abilities::activateBloodBoneBomb);
+    }
+
+    private Abilities() {
+    }
+
+    /**
+     * Forces class initialisation when invoked from bootstrap hooks.
+     */
+    public static void bootstrap() {
+        // no-op
+    }
+
+    private static void activateBloodBoneBomb(LivingEntity entity, ChestCavityInstance chestCavity) {
+        if (ChestCavity.LOGGER.isDebugEnabled()) {
+            ChestCavity.LOGGER.debug("[Guzhenren] Blood Bone Bomb ability triggered for {}", entity);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Guzhenren ability bootstrap class that registers the Blood Bone Bomb active ability id with the organ activation system
- ensure the Guzhenren organ handler initializes the new ability registry alongside the existing organ registries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4b528527c8326b264d8a5d65c360a