### PR TITLE
Implement Bloodbone Bomb active ability

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/ability/Abilities.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/ability/Abilities.java
@@ -5,6 +5,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.ability.blood_bone_bomb.BloodBoneBombAbility;
 import net.tigereye.chestcavity.listeners.OrganActivationListeners;
 import net.tigereye.chestcavity.registration.CCKeybindings;
 
@@ -48,5 +49,6 @@ public final class Abilities {
         if (ChestCavity.LOGGER.isDebugEnabled()) {
             ChestCavity.LOGGER.debug("[Guzhenren] Blood Bone Bomb ability triggered for {}", entity);
         }
+        BloodBoneBombAbility.tryActivate(entity, chestCavity);
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/ability/blood_bone_bomb/BloodBoneBombAbility.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/ability/blood_bone_bomb/BloodBoneBombAbility.java
@@ -1,0 +1,524 @@
+package net.tigereye.chestcavity.compat.guzhenren.ability.blood_bone_bomb;
+
+import com.google.common.collect.ImmutableSet;
+import net.minecraft.core.Holder;
+import net.minecraft.core.particles.DustParticleOptions;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.tick.EntityTickEvent;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.LinkageChannel;
+import net.tigereye.chestcavity.compat.guzhenren.linkage.policy.ClampPolicy;
+import org.joml.Vector3f;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.UUID;
+import java.util.WeakHashMap;
+
+/**
+ * Runtime implementation of the Bloodbone Bomb active organ ability.
+ * Handles the 10 second channel, resource payments and the simulated
+ * projectile that is spawned on completion.
+ */
+@EventBusSubscriber(modid = ChestCavity.MODID)
+public final class BloodBoneBombAbility {
+
+    private static final ResourceLocation TIE_XUE_GU = ResourceLocation.fromNamespaceAndPath("guzhenren", "tiexuegu");
+    private static final ResourceLocation XIE_DI_GU = ResourceLocation.fromNamespaceAndPath("guzhenren", "xie_di_gu");
+    private static final ResourceLocation XIE_YAN_GU = ResourceLocation.fromNamespaceAndPath("guzhenren", "xie_yan_gu");
+    private static final ResourceLocation GU_ZHU_GU = ResourceLocation.fromNamespaceAndPath("guzhenren", "gu_zhu_gu");
+    private static final ResourceLocation LUO_XUAN_GU = ResourceLocation.fromNamespaceAndPath("guzhenren", "luo_xuan_gu_qiang_gu");
+
+    private static final ImmutableSet<ResourceLocation> REQUIRED_ORGANS = ImmutableSet.of(
+            TIE_XUE_GU,
+            XIE_DI_GU,
+            XIE_YAN_GU,
+            GU_ZHU_GU,
+            LUO_XUAN_GU
+    );
+
+    private static final ResourceLocation LI_DAO_INCREASE_EFFECT =
+            ResourceLocation.fromNamespaceAndPath("guzhenren", "linkage/li_dao_increase_effect");
+    private static final ResourceLocation XUE_DAO_INCREASE_EFFECT =
+            ResourceLocation.fromNamespaceAndPath("guzhenren", "linkage/xue_dao_increase_effect");
+    private static final ResourceLocation GU_DAO_INCREASE_EFFECT =
+            ResourceLocation.fromNamespaceAndPath("guzhenren", "linkage/gu_dao_increase_effect");
+    private static final ResourceLocation BLEED_EFFECT_ID = ResourceLocation.fromNamespaceAndPath("guzhenren", "lliuxue");
+
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    private static final int CHARGE_DURATION_TICKS = 200;
+    private static final int COST_INTERVAL_TICKS = 20;
+    private static final float HEALTH_COST = 2.0f;
+    private static final double ZHENYUAN_COST = 20.0;
+    private static final double JINGLI_COST = 10.0;
+
+    private static final double PROJECTILE_SPEED = 3.75;
+    private static final int PROJECTILE_LIFETIME = 60;
+    private static final double PROJECTILE_RADIUS = 0.4;
+
+    private static final DustParticleOptions BLOOD_SWIRL =
+            new DustParticleOptions(new Vector3f(0.82f, 0.07f, 0.09f), 1.0f);
+    private static final DustParticleOptions BONE_GLINT =
+            new DustParticleOptions(new Vector3f(0.92f, 0.88f, 0.78f), 0.8f);
+    private static final DustParticleOptions PROJECTILE_TRAIL =
+            new DustParticleOptions(new Vector3f(0.78f, 0.04f, 0.08f), 1.2f);
+
+    private static final Map<UUID, ChargeState> ACTIVE_CHARGES = new java.util.concurrent.ConcurrentHashMap<>();
+    private static final List<ProjectileState> ACTIVE_PROJECTILES = new ArrayList<>();
+    private static final Map<ServerLevel, Long> LAST_PROJECTILE_TICK = new WeakHashMap<>();
+
+    private BloodBoneBombAbility() {
+    }
+
+    /** Attempts to begin the Bloodbone Bomb charge sequence. */
+    public static void tryActivate(LivingEntity entity, ChestCavityInstance cc) {
+        if (!(entity instanceof ServerPlayer player)) {
+            return;
+        }
+        if (entity.level().isClientSide()) {
+            return;
+        }
+        if (!entity.isAlive() || player.isSpectator()) {
+            return;
+        }
+        if (GuzhenrenResourceBridge.open(player).isEmpty()) {
+            return;
+        }
+        if (ACTIVE_CHARGES.containsKey(player.getUUID())) {
+            return;
+        }
+        if (!hasRequiredOrgans(cc)) {
+            return;
+        }
+        ChargeState state = new ChargeState(cc);
+        ACTIVE_CHARGES.put(player.getUUID(), state);
+        applyChannelImmobilise(player);
+        playChargeStartCue(player);
+    }
+
+    @SubscribeEvent
+    public static void onEntityTick(EntityTickEvent.Post event) {
+        if (!(event.getEntity().level() instanceof ServerLevel server)) {
+            return;
+        }
+        tickProjectiles(server);
+        if (!(event.getEntity() instanceof ServerPlayer player)) {
+            return;
+        }
+        ChargeState state = ACTIVE_CHARGES.get(player.getUUID());
+        if (state != null) {
+            tickCharge(player, state);
+        }
+    }
+
+    private static void tickProjectiles(ServerLevel level) {
+        long gameTime = level.getGameTime();
+        Long lastTick = LAST_PROJECTILE_TICK.get(level);
+        if (lastTick != null && lastTick >= gameTime) {
+            return;
+        }
+        LAST_PROJECTILE_TICK.put(level, gameTime);
+
+        Iterator<ProjectileState> iterator = ACTIVE_PROJECTILES.iterator();
+        while (iterator.hasNext()) {
+            ProjectileState state = iterator.next();
+            if (state.level != level) {
+                continue;
+            }
+            if (!state.tick()) {
+                iterator.remove();
+            }
+        }
+    }
+
+    private static void tickCharge(ServerPlayer player, ChargeState state) {
+        if (!player.isAlive()) {
+            ACTIVE_CHARGES.remove(player.getUUID());
+            return;
+        }
+
+        maintainImmobility(player);
+        state.ticksElapsed++;
+        state.ticksRemaining = Math.max(0, state.ticksRemaining - 1);
+        state.costTimer = Math.max(0, state.costTimer - 1);
+
+        spawnChargingParticles(player, state);
+
+        if (state.costTimer == 0) {
+            state.costTimer = COST_INTERVAL_TICKS;
+            if (!payChargeCosts(player, state)) {
+                triggerCatastrophicFailure(player);
+                return;
+            }
+            state.soundStep++;
+            playHeartbeatCue(player, state);
+        }
+
+        if (state.ticksRemaining <= 0) {
+            ACTIVE_CHARGES.remove(player.getUUID());
+            releaseImmobilise(player);
+            launchProjectile(player, state);
+        }
+    }
+
+    private static boolean payChargeCosts(ServerPlayer player, ChargeState state) {
+        if (player.getHealth() + player.getAbsorptionAmount() <= HEALTH_COST) {
+            return false;
+        }
+        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+        if (handleOpt.isEmpty()) {
+            return false;
+        }
+        GuzhenrenResourceBridge.ResourceHandle handle = handleOpt.get();
+
+        OptionalDouble zhenBeforeOpt = handle.getZhenyuan();
+        OptionalDouble jingliBeforeOpt = handle.getJingli();
+        if (zhenBeforeOpt.isEmpty() || jingliBeforeOpt.isEmpty()) {
+            return false;
+        }
+        double zhenBefore = zhenBeforeOpt.getAsDouble();
+        double jingliBefore = jingliBeforeOpt.getAsDouble();
+        if (jingliBefore + 1.0E-6 < JINGLI_COST) {
+            return false;
+        }
+
+        OptionalDouble zhenAfterOpt = handle.consumeScaledZhenyuan(ZHENYUAN_COST);
+        if (zhenAfterOpt.isEmpty()) {
+            return false;
+        }
+        double zhenAfter = zhenAfterOpt.getAsDouble();
+        double consumedZhenyuan = zhenBefore - zhenAfter;
+
+        OptionalDouble jingliAfterOpt = handle.adjustJingli(-JINGLI_COST, true);
+        if (jingliAfterOpt.isEmpty()) {
+            handle.adjustZhenyuan(consumedZhenyuan, true);
+            return false;
+        }
+        double jingliAfter = jingliAfterOpt.getAsDouble();
+        if ((jingliBefore - jingliAfter) + 1.0E-5 < JINGLI_COST) {
+            handle.adjustZhenyuan(consumedZhenyuan, true);
+            handle.setJingli(jingliBefore);
+            return false;
+        }
+
+        if (!drainHealth(player, HEALTH_COST)) {
+            handle.adjustZhenyuan(consumedZhenyuan, true);
+            handle.setJingli(jingliBefore);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static boolean drainHealth(ServerPlayer player, float amount) {
+        if (amount <= 0.0f) {
+            return true;
+        }
+        float startingHealth = player.getHealth();
+        float startingAbsorption = player.getAbsorptionAmount();
+        if (startingHealth + startingAbsorption <= amount) {
+            return false;
+        }
+        player.invulnerableTime = 0;
+        DamageSource source = player.damageSources().generic();
+        player.hurt(source, amount);
+        player.invulnerableTime = 0;
+
+        float remaining = amount;
+        float absorptionConsumed = Math.min(startingAbsorption, remaining);
+        remaining -= absorptionConsumed;
+        player.setAbsorptionAmount(Math.max(0.0f, startingAbsorption - absorptionConsumed));
+        if (remaining > 0.0f && player.getHealth() > startingHealth - remaining) {
+            player.setHealth(Math.max(0.0f, startingHealth - remaining));
+        }
+        player.hurtTime = 0;
+        player.hurtDuration = 0;
+        return true;
+    }
+
+    private static void launchProjectile(ServerPlayer player, ChargeState state) {
+        ServerLevel level = player.serverLevel();
+        ActiveLinkageContext context = GuzhenrenLinkageManager.getContext(state.chestCavity);
+        double liIncrease = ensureChannel(context, LI_DAO_INCREASE_EFFECT).get();
+        double xueIncrease = ensureChannel(context, XUE_DAO_INCREASE_EFFECT).get();
+        double guIncrease = ensureChannel(context, GU_DAO_INCREASE_EFFECT).get();
+        double multiplier = Math.max(0.0, (1.0 + liIncrease) * (1.0 + xueIncrease) * (1.0 + guIncrease));
+        double damage = 80.0 * multiplier;
+
+        Vec3 origin = player.getEyePosition().add(player.getLookAngle().scale(0.4));
+        Vec3 velocity = player.getLookAngle().normalize().scale(PROJECTILE_SPEED);
+
+        ACTIVE_PROJECTILES.add(new ProjectileState(level, player.getUUID(), origin, velocity, damage, multiplier));
+        level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.GENERIC_EXPLODE, SoundSource.PLAYERS, 1.1f, 0.7f + player.getRandom().nextFloat() * 0.2f);
+        level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.WARDEN_SONIC_BOOM, SoundSource.PLAYERS, 0.6f, 0.5f);
+        level.gameEvent(player, GameEvent.EXPLODE, player.blockPosition());
+        spawnProjectileIgnition(level, origin, velocity);
+    }
+
+    private static LinkageChannel ensureChannel(ActiveLinkageContext context, ResourceLocation id) {
+        return context.getOrCreateChannel(id).addPolicy(NON_NEGATIVE);
+    }
+
+    private static void triggerCatastrophicFailure(ServerPlayer player) {
+        ACTIVE_CHARGES.remove(player.getUUID());
+        releaseImmobilise(player);
+        ServerLevel level = player.serverLevel();
+        Vec3 pos = player.position();
+        level.explode(player, pos.x, pos.y, pos.z, 4.0f, Level.ExplosionInteraction.MOB);
+        level.playSound(null, pos.x, pos.y, pos.z, SoundEvents.GENERIC_EXPLODE, SoundSource.PLAYERS, 1.0f, 0.6f);
+        level.playSound(null, pos.x, pos.y, pos.z, SoundEvents.GHAST_SCREAM, SoundSource.PLAYERS, 1.0f, 0.5f);
+        level.sendParticles(ParticleTypes.CRIMSON_SPORE, pos.x, pos.y + player.getBbHeight() * 0.5, pos.z, 120, 0.6, 0.5, 0.6, 0.1);
+        applyTrueDamage(player, player, 50.0f);
+    }
+
+    private static void spawnProjectileIgnition(ServerLevel level, Vec3 origin, Vec3 velocity) {
+        RandomSource random = level.getRandom();
+        for (int i = 0; i < 30; i++) {
+            double progress = i / 30.0;
+            Vec3 point = origin.add(velocity.scale(progress * 0.2));
+            level.sendParticles(BONE_GLINT, point.x, point.y, point.z, 1, 0.05, 0.05, 0.05, 0.01);
+        }
+        level.sendParticles(ParticleTypes.EXPLOSION, origin.x, origin.y, origin.z, 1, 0.0, 0.0, 0.0, 0.0);
+    }
+
+    private static void spawnChargingParticles(ServerPlayer player, ChargeState state) {
+        ServerLevel level = player.serverLevel();
+        double centerY = player.getY() + player.getBbHeight() * 0.5;
+        double radius = 0.7 + 0.25 * Math.sin(state.ticksElapsed / 6.0);
+        int strands = 6;
+        for (int i = 0; i < strands; i++) {
+            double angle = (state.ticksElapsed * 0.25) + (i * (Math.PI * 2.0 / strands));
+            double x = player.getX() + Math.cos(angle) * radius;
+            double z = player.getZ() + Math.sin(angle) * radius;
+            level.sendParticles(BLOOD_SWIRL, x, centerY, z, 1, 0.0, 0.05, 0.0, 0.0);
+        }
+        level.sendParticles(BONE_GLINT, player.getX(), centerY - 0.3, player.getZ(), 2, 0.25, 0.15, 0.25, 0.02);
+    }
+
+    private static void playChargeStartCue(ServerPlayer player) {
+        ServerLevel level = player.serverLevel();
+        level.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.WARDEN_HEARTBEAT, SoundSource.PLAYERS, 0.8f, 0.55f);
+        level.sendParticles(ParticleTypes.CRIMSON_SPORE, player.getX(), player.getY() + player.getBbHeight() * 0.5, player.getZ(), 20, 0.3, 0.3, 0.3, 0.05);
+    }
+
+    private static void playHeartbeatCue(ServerPlayer player, ChargeState state) {
+        float pitch = 0.6f + (state.soundStep / 10.0f);
+        float volume = 0.6f + (state.soundStep / 12.0f);
+        player.serverLevel().playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.WARDEN_HEARTBEAT, SoundSource.PLAYERS, volume, pitch);
+    }
+
+    private static void applyChannelImmobilise(ServerPlayer player) {
+        player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, CHARGE_DURATION_TICKS + 40, 255, false, false, true));
+        player.addEffect(new MobEffectInstance(MobEffects.DIG_SLOWDOWN, CHARGE_DURATION_TICKS + 40, 4, false, false, true));
+        player.setDeltaMovement(Vec3.ZERO);
+        player.getAbilities().flying = false;
+        player.hurtMarked = true;
+    }
+
+    private static void maintainImmobility(ServerPlayer player) {
+        player.setDeltaMovement(Vec3.ZERO);
+        player.fallDistance = 0.0f;
+        player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, 6, 255, false, false, true));
+        player.addEffect(new MobEffectInstance(MobEffects.DIG_SLOWDOWN, 6, 4, false, false, true));
+    }
+
+    private static void releaseImmobilise(ServerPlayer player) {
+        player.removeEffect(MobEffects.MOVEMENT_SLOWDOWN);
+        player.removeEffect(MobEffects.DIG_SLOWDOWN);
+    }
+
+    private static boolean hasRequiredOrgans(ChestCavityInstance cc) {
+        if (cc == null || cc.inventory == null) {
+            return false;
+        }
+        java.util.Set<ResourceLocation> found = new java.util.HashSet<>();
+        for (int i = 0; i < cc.inventory.getContainerSize(); i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (stack.isEmpty()) {
+                continue;
+            }
+            ResourceLocation id = BuiltInRegistries.ITEM.getKey(stack.getItem());
+            if (id != null && REQUIRED_ORGANS.contains(id)) {
+                found.add(id);
+                if (found.size() == REQUIRED_ORGANS.size()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static void applyTrueDamage(ServerPlayer source, LivingEntity target, float amount) {
+        if (target == null || amount <= 0.0f) {
+            return;
+        }
+        float startingHealth = target.getHealth();
+        float startingAbsorption = target.getAbsorptionAmount();
+        target.invulnerableTime = 0;
+        DamageSource damageSource = source == null
+                ? target.damageSources().magic()
+                : target.damageSources().playerAttack(source);
+        target.hurt(damageSource, amount);
+        target.invulnerableTime = 0;
+
+        float remaining = amount;
+        float absorptionConsumed = Math.min(startingAbsorption, remaining);
+        remaining -= absorptionConsumed;
+        target.setAbsorptionAmount(Math.max(0.0f, startingAbsorption - absorptionConsumed));
+
+        if (!target.isDeadOrDying() && remaining > 0.0f) {
+            float expectedHealth = Math.max(0.0f, startingHealth - remaining);
+            if (target.getHealth() > expectedHealth) {
+                target.setHealth(expectedHealth);
+            }
+        }
+        target.hurtTime = 0;
+    }
+
+    private static final class ChargeState {
+        private final ChestCavityInstance chestCavity;
+        private int ticksElapsed;
+        private int ticksRemaining = CHARGE_DURATION_TICKS;
+        private int costTimer = COST_INTERVAL_TICKS;
+        private int soundStep;
+
+        private ChargeState(ChestCavityInstance chestCavity) {
+            this.chestCavity = chestCavity;
+        }
+    }
+
+    private static final class ProjectileState {
+        private final ServerLevel level;
+        private final UUID ownerId;
+        private Vec3 position;
+        private final Vec3 velocity;
+        private final double damage;
+        private final double multiplier;
+        private int age;
+
+        private ProjectileState(ServerLevel level, UUID ownerId, Vec3 position, Vec3 velocity, double damage, double multiplier) {
+            this.level = level;
+            this.ownerId = ownerId;
+            this.position = position;
+            this.velocity = velocity;
+            this.damage = damage;
+            this.multiplier = multiplier;
+        }
+
+        private boolean tick() {
+            age++;
+            if (age > PROJECTILE_LIFETIME) {
+                spawnFade();
+                return false;
+            }
+            Vec3 nextPos = position.add(velocity);
+
+            HitResult blockHit = level.clip(new ClipContext(position, nextPos, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, CollisionContext.empty()));
+            if (blockHit.getType() != HitResult.Type.MISS) {
+                Vec3 impact = blockHit.getLocation();
+                onImpact(null, impact);
+                return false;
+            }
+
+            LivingEntity victim = findHitEntity(position, nextPos);
+            if (victim != null) {
+                Vec3 impact = victim.position().add(0.0, victim.getBbHeight() * 0.5, 0.0);
+                onImpact(victim, impact);
+                return false;
+            }
+
+            spawnTrail(nextPos);
+            position = nextPos;
+            return true;
+        }
+
+        private LivingEntity findHitEntity(Vec3 start, Vec3 end) {
+            AABB box = new AABB(start, end).inflate(PROJECTILE_RADIUS);
+            List<LivingEntity> entities = level.getEntitiesOfClass(LivingEntity.class, box, entity -> entity.isAlive() && !entity.getUUID().equals(ownerId));
+            LivingEntity closest = null;
+            double closestDistance = Double.MAX_VALUE;
+            for (LivingEntity entity : entities) {
+                Optional<Vec3> clip = entity.getBoundingBox().inflate(0.2).clip(start, end);
+                if (clip.isEmpty()) {
+                    continue;
+                }
+                double distance = clip.get().distanceToSqr(start);
+                if (distance < closestDistance) {
+                    closestDistance = distance;
+                    closest = entity;
+                }
+            }
+            return closest;
+        }
+
+        private void onImpact(LivingEntity victim, Vec3 impact) {
+            level.playSound(null, impact.x, impact.y, impact.z, SoundEvents.GENERIC_EXPLODE, SoundSource.PLAYERS, 0.6f, 1.2f);
+            level.playSound(null, impact.x, impact.y, impact.z, SoundEvents.BONE_BLOCK_BREAK, SoundSource.PLAYERS, 0.8f, 0.6f);
+            level.sendParticles(ParticleTypes.CRIMSON_SPORE, impact.x, impact.y, impact.z, 60, 0.4, 0.4, 0.4, 0.08);
+            level.sendParticles(ParticleTypes.EXPLOSION_EMITTER, impact.x, impact.y, impact.z, 1, 0.0, 0.0, 0.0, 0.0);
+
+            if (victim != null) {
+                ServerPlayer owner = level.getServer().getPlayerList().getPlayer(ownerId);
+                applyTrueDamage(owner, victim, (float) damage);
+                applyStatusEffects(victim, multiplier);
+            }
+        }
+
+        private void spawnTrail(Vec3 nextPos) {
+            Vec3 mid = position.add(nextPos).scale(0.5);
+            level.sendParticles(PROJECTILE_TRAIL, mid.x, mid.y, mid.z, 4, 0.05, 0.05, 0.05, 0.02);
+        }
+
+        private void spawnFade() {
+            level.sendParticles(ParticleTypes.SMOKE, position.x, position.y, position.z, 12, 0.2, 0.2, 0.2, 0.01);
+        }
+
+        private void applyStatusEffects(LivingEntity target, double multiplier) {
+            int bleedAmplifier = scaledAmplifier(1, multiplier);
+            int slowAmplifier = scaledAmplifier(2, multiplier);
+            int weakAmplifier = scaledAmplifier(1, multiplier);
+
+            int duration = 100;
+            Optional<? extends Holder<MobEffect>> bleedOpt = BuiltInRegistries.MOB_EFFECT.getHolder(BLEED_EFFECT_ID);
+            bleedOpt.ifPresent(holder -> target.addEffect(new MobEffectInstance(holder, duration, bleedAmplifier, false, true, true)));
+            target.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, duration, slowAmplifier, false, true, true));
+            target.addEffect(new MobEffectInstance(MobEffects.WEAKNESS, duration, weakAmplifier, false, true, true));
+        }
+
+        private int scaledAmplifier(int baseLevel, double multiplier) {
+            double scaled = Math.max(1.0, baseLevel * multiplier);
+            return Math.max(0, (int) Math.floor(scaled) - 1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add BloodboneBombAbility to implement the combined Guzhenren organ kill move with charge, failure, and projectile logic
- hook the new ability into the Guzhenren ability registry so it can be triggered via the existing attack keybind

## Testing
- ./gradlew check --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d4b936a25c83268288998090ed840e