### PR TITLE
Fix scoreboard upgrade slot locking before item insertion

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/util/ScoreboardUpgradeManager.java
+++ b/src/main/java/net/tigereye/chestcavity/util/ScoreboardUpgradeManager.java
@@ -60,11 +60,12 @@ public final class ScoreboardUpgradeManager {
             ChestCavity.LOGGER.warn("Scoreboard upgrade {} could not generate item stack", upgrade.id());
             return;
         }
-        cc.addScoreboardUpgrade(upgrade.id());
-        if (cc.inventory.getItem(upgrade.slotIndex()).isEmpty()) {
-            cc.inventory.setItem(upgrade.slotIndex(), generated.copy());
-            cc.inventory.setChanged();
+        if (!cc.inventory.getItem(upgrade.slotIndex()).isEmpty()) {
+            return;
         }
+        cc.addScoreboardUpgrade(upgrade.id());
+        cc.inventory.setItem(upgrade.slotIndex(), generated.copy());
+        cc.inventory.setChanged();
     }
 
     private static boolean meetsScoreRequirement(Player player, ScoreboardUpgrade upgrade) {


### PR DESCRIPTION
## Summary
- only record a scoreboard upgrade once the generated item is actually inserted, avoiding premature slot locking

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d4ade8a38c8326b85297d5adf171f3