### PR TITLE
Implement health-based cost fallback for Hu Gugu

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/HuGuguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/HuGuguOrganBehavior.java
@@ -16,7 +16,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
-import net.tigereye.chestcavity.compat.guzhenren.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.compat.guzhenren.item.tu_dao.behavior.TuDaoNonPlayerHandler;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.ActiveLinkageContext;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.GuzhenrenLinkageManager;
 import net.tigereye.chestcavity.compat.guzhenren.linkage.IncreaseEffectContributor;
@@ -27,9 +27,6 @@ import net.tigereye.chestcavity.listeners.OrganIncomingDamageListener;
 import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
 import net.tigereye.chestcavity.util.NBTCharge;
 import net.tigereye.chestcavity.util.NetworkUtil;
-
-import java.util.Optional;
-import java.util.OptionalDouble;
 
 import net.minecraft.util.RandomSource;
 import org.joml.Vector3f;
@@ -71,7 +68,6 @@ public enum HuGuguOrganBehavior implements OrganSlowTickListener, OrganIncomingD
 
     private static final int BASE_BUFF_DURATION = 20 * 60; // 1 minute in ticks
 
-    private static final double EPSILON = 1.0E-4;
     private static final int DAMAGE_TRIGGER_COST_UNITS = CHARGE_SCALE;
 
     private static final double HU_GUGU_CONE_HALF_ANGLE_RADIANS = Math.toRadians(20.0);
@@ -128,38 +124,7 @@ public enum HuGuguOrganBehavior implements OrganSlowTickListener, OrganIncomingD
     }
 
     private static boolean tryConsumeLowChargeResources(Player player) {
-        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
-        if (handleOpt.isEmpty()) {
-            return false;
-        }
-        GuzhenrenResourceBridge.ResourceHandle handle = handleOpt.get();
-
-        OptionalDouble jingliBeforeOpt = handle.getJingli();
-        if (jingliBeforeOpt.isEmpty()) {
-            return false;
-        }
-        double jingliBefore = jingliBeforeOpt.getAsDouble();
-        if (jingliBefore + EPSILON < BASE_JINGLI_COST) {
-            return false;
-        }
-
-        OptionalDouble jingliAfterOpt = handle.adjustJingli(-BASE_JINGLI_COST, true);
-        if (jingliAfterOpt.isEmpty()) {
-            return false;
-        }
-        double jingliAfter = jingliAfterOpt.getAsDouble();
-        if ((jingliBefore - jingliAfter) + EPSILON < BASE_JINGLI_COST) {
-            handle.setJingli(jingliBefore);
-            return false;
-        }
-
-        OptionalDouble zhenyuanResult = handle.consumeScaledZhenyuan(BASE_ZHENYUAN_COST);
-        if (zhenyuanResult.isPresent()) {
-            return true;
-        }
-
-        handle.setJingli(jingliBefore);
-        return false;
+        return TuDaoNonPlayerHandler.handleNonPlayer(player, BASE_ZHENYUAN_COST, BASE_JINGLI_COST);
     }
 
     @Override

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/tu_dao/behavior/TuDaoNonPlayerHandler.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/tu_dao/behavior/TuDaoNonPlayerHandler.java
@@ -1,0 +1,84 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.tu_dao.behavior;
+
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+
+/**
+ * Utility for emulating Guzhenren resource costs on entities that lack
+ * zhenyuan/jingli pools (e.g. mobs controlled through Chest Cavity).
+ *
+ * <p>The Guzhenren mod normally deducts both zhenyuan and jingli when certain
+ * Tu Dao organs trigger. When a non-player entity uses these behaviours the
+ * compat layer replaces that consumption with a direct health payment at a
+ * fixed ratio of {@code 1 health : 100 (zhenyuan + jingli)}.</p>
+ */
+public final class TuDaoNonPlayerHandler {
+
+    private static final double RESOURCE_TO_HEALTH_RATIO = 100.0;
+    private static final float EPSILON = 1.0E-4f;
+
+    private TuDaoNonPlayerHandler() {
+    }
+
+    /**
+     * Attempts to deduct an equivalent amount of health from the given entity
+     * for the provided resource costs. Health is drained after absorption and
+     * will never outright kill the entity; failure is reported via {@code false}.
+     *
+     * @param entity        the living entity paying the cost
+     * @param zhenyuanCost  zhenyuan that would normally be consumed
+     * @param jingliCost    jingli that would normally be consumed
+     * @return {@code true} if enough health (or absorption) was available and
+     *         the deduction succeeded, {@code false} otherwise
+     */
+    public static boolean handleNonPlayer(LivingEntity entity, double zhenyuanCost, double jingliCost) {
+        if (entity == null || !entity.isAlive()) {
+            return false;
+        }
+
+        double totalResource = Math.max(0.0, zhenyuanCost) + Math.max(0.0, jingliCost);
+        if (!Double.isFinite(totalResource) || totalResource <= 0.0) {
+            return true;
+        }
+
+        float healthCost = (float) (totalResource / RESOURCE_TO_HEALTH_RATIO);
+        if (!Float.isFinite(healthCost) || healthCost <= 0.0f) {
+            return false;
+        }
+
+        float absorption = Math.max(0.0f, entity.getAbsorptionAmount());
+        float remaining = healthCost;
+        if (absorption > EPSILON) {
+            float absorbed = Math.min(absorption, remaining);
+            entity.setAbsorptionAmount(absorption - absorbed);
+            remaining -= absorbed;
+        }
+
+        if (remaining <= EPSILON) {
+            return true;
+        }
+
+        float currentHealth = entity.getHealth();
+        float available = currentHealth + Math.max(0.0f, entity.getAbsorptionAmount());
+        if (available - remaining <= EPSILON) {
+            return false;
+        }
+
+        float targetHealth = Math.max(0.0f, currentHealth - remaining);
+
+        entity.invulnerableTime = 0;
+        DamageSource damageSource = entity.damageSources().generic();
+        entity.hurt(damageSource, remaining);
+        entity.invulnerableTime = 0;
+
+        if (!entity.isDeadOrDying()) {
+            if (entity.getHealth() > targetHealth) {
+                entity.setHealth(targetHealth);
+            }
+            entity.hurtTime = 0;
+            entity.hurtDuration = 0;
+        }
+
+        return !entity.isDeadOrDying();
+    }
+}


### PR DESCRIPTION
## Summary
- add `TuDaoNonPlayerHandler` to convert Guzhenren resource costs into health loss at a 1:100 ratio
- update Hu Gugu's slow-tick bonus recovery to deduct health instead of Guzhenren zhenyuan/jingli

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68d51dab07cc832682abeb45a2fc7920