### PR TITLE
Auto trigger xue dao abilities on damage

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/XueDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/XueDaoOrganRegistry.java
@@ -45,6 +45,7 @@ public final class XueDaoOrganRegistry {
 
         GuzhenrenLinkageEffectRegistry.registerSingle(XUE_FEI_GU_ID, context -> {
             context.addSlowTickListener(XieFeiguOrganBehavior.INSTANCE);
+            context.addIncomingDamageListener(XieFeiguOrganBehavior.INSTANCE);
             context.addRemovalListener(XieFeiguOrganBehavior.INSTANCE);
             XieFeiguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
             XieFeiguOrganBehavior.INSTANCE.onEquip(
@@ -70,6 +71,7 @@ public final class XueDaoOrganRegistry {
 
         GuzhenrenLinkageEffectRegistry.registerSingle(XIE_DI_GU_ID, context -> {
             context.addSlowTickListener(XiediguOrganBehavior.INSTANCE);
+            context.addIncomingDamageListener(XiediguOrganBehavior.INSTANCE);
             context.addRemovalListener(XiediguOrganBehavior.INSTANCE);
             XiediguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
             XiediguOrganBehavior.INSTANCE.onEquip(


### PR DESCRIPTION
## Summary
- automatically try to fire Xie Fei Gu's blood fog ability when its wielder is hit, converting the resource costs from incoming attacks into a 10% health-based trigger chance
- mirror the same 10% incoming damage trigger for Xie Di Gu and register both organs for incoming damage callbacks in the Guzhenren linkage registry

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d51cf58a4483269d66afe565c3d8c3