### PR TITLE
Optimize Guzhenren linkage evaluation by caching organ counts

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/GuzhenrenOrganHandlers.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/GuzhenrenOrganHandlers.java
@@ -48,7 +48,13 @@ public final class GuzhenrenOrganHandlers {
         OrganRetentionRules.registerNamespace(MOD_ID);
     }
 
-    public static void registerListeners(ChestCavityInstance cc, ItemStack stack, List<OrganRemovalContext> staleRemovalContexts) {
+    public static void registerListeners(
+            ChestCavityInstance cc,
+            ItemStack stack,
+            List<OrganRemovalContext> staleRemovalContexts,
+            Map<ResourceLocation, Integer> cachedCounts,
+            Map<ResourceLocation, List<ItemStack>> cachedStacks
+    ) {
         if (stack.isEmpty() || !ModList.get().isLoaded(MOD_ID)) {
             if (ChestCavity.LOGGER.isDebugEnabled() && !stack.isEmpty()) {
                 ChestCavity.LOGGER.debug("[Guzhenren] Skipping listener registration for {} because the mod is not loaded", stack);
@@ -76,7 +82,13 @@ public final class GuzhenrenOrganHandlers {
         WuHangOrganRegistry.bootstrap();
         ShiDaoOrganRegistry.bootstrap();
         JiandaoOrganRegistry.bootstrap();
-        GuzhenrenLinkageEffectRegistry.applyEffects(cc, stack, staleRemovalContexts);
+        GuzhenrenLinkageEffectRegistry.applyEffects(
+                cc,
+                stack,
+                staleRemovalContexts,
+                cachedCounts,
+                cachedStacks
+        );
         if (stack.is(Items.WOODEN_SHOVEL)) {
             displayChannelSnapshot(cc, context);
         }


### PR DESCRIPTION
## Summary
- precompute per-item counts for each chest cavity evaluation to avoid repeated inventory scans
- pass cached counts into Guzhenren linkage application so linkage effects reuse the shared data
- extend listener registration helpers to use the cached maps when wiring Guzhenren behaviours

## Testing
- ./gradlew :compileJava

------
https://chatgpt.com/codex/tasks/task_e_68d676a1e0c48326a90e3a1e1d4db098