### PR TITLE
Refactor Guzhenren compatibility bootstrap

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/ChestCavity.java
+++ b/src/main/java/net/tigereye/chestcavity/ChestCavity.java
@@ -30,24 +30,7 @@ import net.tigereye.chestcavity.listeners.KeybindingClientListeners;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import net.tigereye.chestcavity.compat.guzhenren.ability.Abilities;
-import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoClientAbilities;
-import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoClientRenderLayers;
-import net.tigereye.chestcavity.compat.guzhenren.ability.blood_bone_bomb.BloodBoneBombClient;
-import net.tigereye.chestcavity.compat.guzhenren.item.mu_dao.MuDaoClientAbilities;
-import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoClientAbilities;
-import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoClientRenderers;
-import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoEntityAttributes;
-import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JianYingGuEvents;
-
-import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.ShiDaoClientAbilities;
-
-import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.XueDaoClientAbilities;
-import net.neoforged.neoforge.client.event.EntityRenderersEvent;
-import net.tigereye.chestcavity.guzhenren.network.GuzhenrenNetworkBridge;
-import net.tigereye.chestcavity.guscript.command.GuScriptCommands;
-import net.tigereye.chestcavity.guscript.GuScriptModule;
-import net.tigereye.chestcavity.compat.guzhenren.item.kongqiao.KongqiaoOrganRegistry;
+import net.tigereye.chestcavity.guzhenren.GuzhenrenModule;
 
 @Mod(ChestCavity.MODID)
 public class ChestCavity { //TODO: fix 1.19 version to include color thing, fix organUtil class, possibly update to 4?, add alexs mobs and other mods compat
@@ -78,25 +61,7 @@ public class ChestCavity { //TODO: fix 1.19 version to include color thing, fix 
 		bus.addListener(this::doClientStuff);
 		bus.addListener(this::registerMenuScreens);
 		bus.addListener(this::doServerStuff);
-		bus.addListener(NetworkHandler::registerCommon);
-        // Mod lifecycle listeners for Guzhenren Jian Dao entities
-        bus.addListener(JiandaoEntityAttributes::onAttributeCreation);
-
-    if (FMLEnvironment.dist.isClient()) {
-            bus.addListener(Abilities::onClientSetup);
-            bus.addListener(GuDaoClientAbilities::onClientSetup);
-            bus.addListener(MuDaoClientAbilities::onClientSetup);
-
-            bus.addListener(ShiDaoClientAbilities::onClientSetup);
-            bus.addListener(JiandaoClientAbilities::onClientSetup);
-            bus.addListener(XueDaoClientAbilities::onClientSetup);
-            bus.addListener(BloodBoneBombClient::onRegisterRenderers);
-            bus.addListener(JiandaoClientRenderers::onRegisterRenderers);
-    }
-
-    if (FMLEnvironment.dist.isClient()) {
-            bus.addListener(GuDaoClientRenderLayers::onAddLayers);
-        }
+        bus.addListener(NetworkHandler::registerCommon);
 
 
 		NeoForge.EVENT_BUS.addListener(ServerEvents::onPlayerLogin);
@@ -105,10 +70,9 @@ public class ChestCavity { //TODO: fix 1.19 version to include color thing, fix 
 		NeoForge.EVENT_BUS.addListener(ServerEvents::onPlayerChangedDimension);
                 NeoForge.EVENT_BUS.addListener(ServerEvents::onLivingDeath);
                 NeoForge.EVENT_BUS.addListener(this::registerReloadListeners);
-                NeoForge.EVENT_BUS.addListener(JianYingGuEvents::onServerTick);
-		if (FMLEnvironment.dist.isClient()) {
-			NeoForge.EVENT_BUS.addListener(KeybindingClientListeners::onClientTick);
-		}
+                if (FMLEnvironment.dist.isClient()) {
+                        NeoForge.EVENT_BUS.addListener(KeybindingClientListeners::onClientTick);
+                }
 
 		AutoConfig.register(CCConfig.class, GsonConfigSerializer::new);
 		config = AutoConfig.getConfigHolder(CCConfig.class).getConfig();
@@ -127,13 +91,11 @@ public class ChestCavity { //TODO: fix 1.19 version to include color thing, fix 
 		CCStatusEffects.MOB_EFFECTS.register(bus);
 		bus.addListener(CCKeybindings::register);
 		CCTagOrgans.init();
-		OrganRetentionRules.registerNamespace(MODID);
-		OrganRetentionRules.registerNamespace("guzhenren");
-		if (ModList.get().isLoaded("guzhenren")) {
-			KongqiaoOrganRegistry.bootstrap();
-			GuzhenrenNetworkBridge.bootstrap();
-			GuScriptModule.bootstrap();
-		}
+                OrganRetentionRules.registerNamespace(MODID);
+                OrganRetentionRules.registerNamespace("guzhenren");
+                if (ModList.get().isLoaded("guzhenren")) {
+                        GuzhenrenModule.bootstrap(bus, NeoForge.EVENT_BUS);
+                }
 		//CCCommands.register();
 		//CCNetworkingPackets.register();
 		//ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(new OrganManager());

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/GuzhenrenOrganHandlers.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/GuzhenrenOrganHandlers.java
@@ -7,22 +7,8 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.neoforged.fml.ModList;
 import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
-import net.tigereye.chestcavity.compat.guzhenren.ability.Abilities;
-import net.tigereye.chestcavity.compat.guzhenren.item.du_dao.DuDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.gu_cai.GuCaiOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.kongqiao.KongqiaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.lei_dao.LeiDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.san_zhuan.wu_hang.WuHangOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.ShiDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.mu_dao.MuDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.tu_dao.TuDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.ShuiDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.XueDaoOrganRegistry;
 import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
 import net.tigereye.chestcavity.linkage.LinkageManager;
 import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
@@ -55,10 +41,7 @@ public final class GuzhenrenOrganHandlers {
             Map<ResourceLocation, Integer> cachedCounts,
             Map<ResourceLocation, List<ItemStack>> cachedStacks
     ) {
-        if (stack.isEmpty() || !ModList.get().isLoaded(MOD_ID)) {
-            if (ChestCavity.LOGGER.isDebugEnabled() && !stack.isEmpty()) {
-                ChestCavity.LOGGER.debug("[Guzhenren] Skipping listener registration for {} because the mod is not loaded", stack);
-            }
+        if (stack.isEmpty()) {
             return;
         }
         if (ChestCavity.LOGGER.isDebugEnabled()) {
@@ -69,19 +52,6 @@ public final class GuzhenrenOrganHandlers {
             );
         }
         ActiveLinkageContext context = LinkageManager.getContext(cc);
-        Abilities.bootstrap();
-        GuCaiOrganRegistry.bootstrap();
-        DuDaoOrganRegistry.bootstrap();
-        GuDaoOrganRegistry.bootstrap();
-        LeiDaoOrganRegistry.bootstrap();
-        KongqiaoOrganRegistry.bootstrap();
-        MuDaoOrganRegistry.bootstrap();
-        TuDaoOrganRegistry.bootstrap();
-        ShuiDaoOrganRegistry.bootstrap();
-        XueDaoOrganRegistry.bootstrap();
-        WuHangOrganRegistry.bootstrap();
-        ShiDaoOrganRegistry.bootstrap();
-        JiandaoOrganRegistry.bootstrap();
         GuzhenrenLinkageEffectRegistry.applyEffects(
                 cc,
                 stack,

--- a/src/main/java/net/tigereye/chestcavity/guzhenren/GuzhenrenModule.java
+++ b/src/main/java/net/tigereye/chestcavity/guzhenren/GuzhenrenModule.java
@@ -1,0 +1,133 @@
+package net.tigereye.chestcavity.guzhenren;
+
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.loading.FMLEnvironment;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.compat.guzhenren.ability.Abilities;
+import net.tigereye.chestcavity.compat.guzhenren.item.du_dao.DuDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_cai.GuCaiOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoClientAbilities;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoClientRenderLayers;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoClientAbilities;
+import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoClientRenderers;
+import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoEntityAttributes;
+import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JianYingGuEvents;
+import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.kongqiao.KongqiaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.lei_dao.LeiDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.mu_dao.MuDaoClientAbilities;
+import net.tigereye.chestcavity.compat.guzhenren.item.mu_dao.MuDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.san_zhuan.wu_hang.WuHangOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.ShiDaoClientAbilities;
+import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.ShiDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.ShuiDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.tu_dao.TuDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.XueDaoClientAbilities;
+import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.XueDaoOrganRegistry;
+import net.tigereye.chestcavity.guscript.GuScriptModule;
+import net.tigereye.chestcavity.compat.guzhenren.ability.blood_bone_bomb.BloodBoneBombClient;
+import net.tigereye.chestcavity.guzhenren.network.GuzhenrenNetworkBridge;
+import net.tigereye.chestcavity.util.retention.OrganRetentionRules;
+
+import java.util.Objects;
+
+/**
+ * Central bootstrap for Guzhenren compatibility hooks. All optional wiring lives here so other
+ * callers can simply invoke {@link #bootstrap(IEventBus, IEventBus)} when the compat mod is present.
+ */
+public final class GuzhenrenModule {
+
+    private static final String MOD_ID = "guzhenren";
+    private static final Object LOCK = new Object();
+
+    private static IEventBus registeredModBus;
+    private static IEventBus registeredForgeBus;
+    private static boolean initialised;
+
+    private GuzhenrenModule() {
+    }
+
+    public static void bootstrap(IEventBus modBus, IEventBus forgeBus) {
+        Objects.requireNonNull(modBus, "GuzhenrenModule requires the mod event bus");
+        Objects.requireNonNull(forgeBus, "GuzhenrenModule requires the NeoForge event bus");
+
+        if (!ModList.get().isLoaded(MOD_ID)) {
+            if (ChestCavity.LOGGER.isDebugEnabled()) {
+                ChestCavity.LOGGER.debug("[compat/guzhenren] bootstrap skipped: mod not loaded");
+            }
+            return;
+        }
+
+        boolean registerModListeners = false;
+        boolean registerForgeListeners = false;
+        boolean runInitialisation = false;
+
+        synchronized (LOCK) {
+            if (registeredModBus != modBus) {
+                registeredModBus = modBus;
+                registerModListeners = true;
+            }
+            if (registeredForgeBus != forgeBus) {
+                registeredForgeBus = forgeBus;
+                registerForgeListeners = true;
+            }
+            if (!initialised) {
+                initialised = true;
+                runInitialisation = true;
+            }
+        }
+
+        if (registerModListeners) {
+            installModListeners(modBus);
+        }
+        if (registerForgeListeners) {
+            installForgeListeners(forgeBus);
+        }
+        if (runInitialisation) {
+            initialiseCompat();
+        }
+    }
+
+    private static void installModListeners(IEventBus modBus) {
+        modBus.addListener(JiandaoEntityAttributes::onAttributeCreation);
+        if (FMLEnvironment.dist.isClient()) {
+            modBus.addListener(Abilities::onClientSetup);
+            modBus.addListener(GuDaoClientAbilities::onClientSetup);
+            modBus.addListener(MuDaoClientAbilities::onClientSetup);
+            modBus.addListener(ShiDaoClientAbilities::onClientSetup);
+            modBus.addListener(JiandaoClientAbilities::onClientSetup);
+            modBus.addListener(XueDaoClientAbilities::onClientSetup);
+            modBus.addListener(BloodBoneBombClient::onRegisterRenderers);
+            modBus.addListener(JiandaoClientRenderers::onRegisterRenderers);
+            modBus.addListener(GuDaoClientRenderLayers::onAddLayers);
+        }
+    }
+
+    private static void installForgeListeners(IEventBus forgeBus) {
+        forgeBus.addListener(JianYingGuEvents::onServerTick);
+    }
+
+    private static void initialiseCompat() {
+        if (ChestCavity.LOGGER.isDebugEnabled()) {
+            ChestCavity.LOGGER.debug("[compat/guzhenren] installing compatibility hooks");
+        }
+        OrganRetentionRules.registerNamespace(MOD_ID);
+        Abilities.bootstrap();
+        GuCaiOrganRegistry.bootstrap();
+        DuDaoOrganRegistry.bootstrap();
+        GuDaoOrganRegistry.bootstrap();
+        LeiDaoOrganRegistry.bootstrap();
+        KongqiaoOrganRegistry.bootstrap();
+        MuDaoOrganRegistry.bootstrap();
+        TuDaoOrganRegistry.bootstrap();
+        ShuiDaoOrganRegistry.bootstrap();
+        XueDaoOrganRegistry.bootstrap();
+        WuHangOrganRegistry.bootstrap();
+        ShiDaoOrganRegistry.bootstrap();
+        JiandaoOrganRegistry.bootstrap();
+        GuzhenrenNetworkBridge.bootstrap();
+        GuScriptModule.bootstrap();
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `GuzhenrenModule` that centralises compatibility detection, event wiring, and registry bootstrap
- update the mod constructor to delegate optional Guzhenren setup to the new module instead of scattering listeners
- streamline `GuzhenrenOrganHandlers` so it only applies linkage effects once the module has initialised

## Testing
- `./gradlew --console=plain compileJava`


------
https://chatgpt.com/codex/tasks/task_e_68d7aab65eb48326bdc495c02b86f1aa