### PR TITLE
Refactor Guzhenren organ integration registration

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/ChestCavity.java
+++ b/src/main/java/net/tigereye/chestcavity/ChestCavity.java
@@ -47,7 +47,7 @@ import net.neoforged.neoforge.client.event.EntityRenderersEvent;
 import net.tigereye.chestcavity.guzhenren.network.GuzhenrenNetworkBridge;
 import net.tigereye.chestcavity.guscript.command.GuScriptCommands;
 import net.tigereye.chestcavity.guscript.GuScriptModule;
-import net.tigereye.chestcavity.compat.guzhenren.item.kongqiao.KongqiaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.module.GuzhenrenModule;
 
 @Mod(ChestCavity.MODID)
 public class ChestCavity { //TODO: fix 1.19 version to include color thing, fix organUtil class, possibly update to 4?, add alexs mobs and other mods compat
@@ -130,7 +130,7 @@ public class ChestCavity { //TODO: fix 1.19 version to include color thing, fix 
 		OrganRetentionRules.registerNamespace(MODID);
 		OrganRetentionRules.registerNamespace("guzhenren");
 		if (ModList.get().isLoaded("guzhenren")) {
-			KongqiaoOrganRegistry.bootstrap();
+                        GuzhenrenModule.bootstrap();
 			GuzhenrenNetworkBridge.bootstrap();
 			GuScriptModule.bootstrap();
 		}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/GuzhenrenOrganHandlers.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/GuzhenrenOrganHandlers.java
@@ -11,18 +11,7 @@ import net.neoforged.fml.ModList;
 import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
 import net.tigereye.chestcavity.compat.guzhenren.ability.Abilities;
-import net.tigereye.chestcavity.compat.guzhenren.item.du_dao.DuDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.gu_cai.GuCaiOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.kongqiao.KongqiaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.lei_dao.LeiDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.san_zhuan.wu_hang.WuHangOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.ShiDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.mu_dao.MuDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.tu_dao.TuDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.ShuiDaoOrganRegistry;
-import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.XueDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.module.GuzhenrenModule;
 import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
 import net.tigereye.chestcavity.linkage.LinkageManager;
 import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
@@ -70,18 +59,7 @@ public final class GuzhenrenOrganHandlers {
         }
         ActiveLinkageContext context = LinkageManager.getContext(cc);
         Abilities.bootstrap();
-        GuCaiOrganRegistry.bootstrap();
-        DuDaoOrganRegistry.bootstrap();
-        GuDaoOrganRegistry.bootstrap();
-        LeiDaoOrganRegistry.bootstrap();
-        KongqiaoOrganRegistry.bootstrap();
-        MuDaoOrganRegistry.bootstrap();
-        TuDaoOrganRegistry.bootstrap();
-        ShuiDaoOrganRegistry.bootstrap();
-        XueDaoOrganRegistry.bootstrap();
-        WuHangOrganRegistry.bootstrap();
-        ShiDaoOrganRegistry.bootstrap();
-        JiandaoOrganRegistry.bootstrap();
+        GuzhenrenModule.bootstrap();
         GuzhenrenLinkageEffectRegistry.applyEffects(
                 cc,
                 stack,

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/du_dao/DuDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/du_dao/DuDaoOrganRegistry.java
@@ -2,7 +2,9 @@ package net.tigereye.chestcavity.compat.guzhenren.item.du_dao;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.du_dao.behavior.ChouPiGuOrganBehavior;
-import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
 
 /**
  * Declarative registration for 毒道蛊 (Du Dao) organ behaviours.
@@ -14,21 +16,23 @@ public final class DuDaoOrganRegistry {
     private static final ResourceLocation CHOU_PI_GU_ID =
             ResourceLocation.fromNamespaceAndPath(MOD_ID, "chou_pi_gu");
 
+    private static final List<OrganIntegrationSpec> SPECS;
+
     static {
         DuDaoOrganEvents.register();
-
-        GuzhenrenLinkageEffectRegistry.registerSingle(CHOU_PI_GU_ID, context -> {
-            context.addSlowTickListener(ChouPiGuOrganBehavior.INSTANCE);
-            context.addIncomingDamageListener(ChouPiGuOrganBehavior.INSTANCE);
-            ChouPiGuOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-        });
+        SPECS = List.of(
+                OrganIntegrationSpec.builder(CHOU_PI_GU_ID)
+                        .addSlowTickListener(ChouPiGuOrganBehavior.INSTANCE)
+                        .addIncomingDamageListener(ChouPiGuOrganBehavior.INSTANCE)
+                        .ensureAttached(ChouPiGuOrganBehavior.INSTANCE::ensureAttached)
+                        .build()
+        );
     }
 
     private DuDaoOrganRegistry() {
     }
 
-    /** Forces static initialisation so the registration block executes. */
-    public static void bootstrap() {
-        // no-op
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_cai/GuCaiOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_cai/GuCaiOrganRegistry.java
@@ -2,7 +2,9 @@ package net.tigereye.chestcavity.compat.guzhenren.item.gu_cai;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_cai.behavior.JianjitengOrganBehavior;
-import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
 
 /**
  * Declarative registry for 蛊材（Gu Cai）organ behaviours.
@@ -13,18 +15,17 @@ public final class GuCaiOrganRegistry {
 
     private static final ResourceLocation JIANJITENG_BLOCK_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "jianjiteng");
 
-    static {
-        GuzhenrenLinkageEffectRegistry.registerSingle(JIANJITENG_BLOCK_ID, context -> {
-            context.addSlowTickListener(JianjitengOrganBehavior.INSTANCE);
-            JianjitengOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-        });
-    }
+    private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(JIANJITENG_BLOCK_ID)
+                    .addSlowTickListener(JianjitengOrganBehavior.INSTANCE)
+                    .ensureAttached(JianjitengOrganBehavior.INSTANCE::ensureAttached)
+                    .build()
+    );
 
     private GuCaiOrganRegistry() {
     }
 
-    /** Forces static initialisation to occur. */
-    public static void bootstrap() {
-        // no-op
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganRegistry.java
@@ -7,7 +7,9 @@ import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.HuGuguOrga
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.LuoXuanGuQiangguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.RouBaiguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.YuGuguOrganBehavior; // 你需要自己写对应行为
-import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
 
 /**
  * Declarative registry for 骨道蛊 items. Each behaviour is registered through the
@@ -22,54 +24,48 @@ public final class GuDaoOrganRegistry {
     private static final ResourceLocation TIGER_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "hugugu");
     private static final ResourceLocation JADE_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "yu_gu_gu"); // 新增玉骨蛊
     private static final ResourceLocation ROU_BAI_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "rou_bai_gu");
+    private static final List<OrganIntegrationSpec> SPECS;
+
     static {
         GuDaoOrganEvents.register();
-
-        GuzhenrenLinkageEffectRegistry.registerSingle(BONE_BAMBOO_ID, context -> {
-            context.addSlowTickListener(GuzhuguOrganBehavior.INSTANCE);
-            GuzhuguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-        });
-
-        GuzhenrenLinkageEffectRegistry.registerSingle(BONE_SPEAR_ID, context -> {
-            context.addSlowTickListener(GuQiangguOrganBehavior.INSTANCE);
-            context.addOnHitListener(GuQiangguOrganBehavior.INSTANCE);
-            GuQiangguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-        });
-
-        GuzhenrenLinkageEffectRegistry.registerSingle(SPIRAL_BONE_SPEAR_ID, context -> {
-            context.addSlowTickListener(LuoXuanGuQiangguOrganBehavior.INSTANCE);
-            context.addOnHitListener(LuoXuanGuQiangguOrganBehavior.INSTANCE);
-            context.addIncomingDamageListener(LuoXuanGuQiangguOrganBehavior.INSTANCE);
-            LuoXuanGuQiangguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-        });
-        GuzhenrenLinkageEffectRegistry.registerSingle(TIGER_BONE_ID, context -> {
-            context.addSlowTickListener(HuGuguOrganBehavior.INSTANCE);
-            context.addIncomingDamageListener(HuGuguOrganBehavior.INSTANCE);
-            HuGuguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-        });
-
-        GuzhenrenLinkageEffectRegistry.registerSingle(JADE_BONE_ID, context -> {
-            context.addSlowTickListener(YuGuguOrganBehavior.INSTANCE);
-            YuGuguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-            YuGuguOrganBehavior.INSTANCE.onEquip(
-                    context.chestCavity(),
-                    context.sourceOrgan(),
-                    context.staleRemovalContexts()
-            );
-        });
-
-        GuzhenrenLinkageEffectRegistry.registerSingle(ROU_BAI_GU_ID, context -> {
-            context.addSlowTickListener(RouBaiguOrganBehavior.INSTANCE);
-            context.addOnHitListener(RouBaiguOrganBehavior.INSTANCE);
-            RouBaiguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-        });
+        SPECS = List.of(
+                OrganIntegrationSpec.builder(BONE_BAMBOO_ID)
+                        .addSlowTickListener(GuzhuguOrganBehavior.INSTANCE)
+                        .ensureAttached(GuzhuguOrganBehavior.INSTANCE::ensureAttached)
+                        .build(),
+                OrganIntegrationSpec.builder(BONE_SPEAR_ID)
+                        .addSlowTickListener(GuQiangguOrganBehavior.INSTANCE)
+                        .addOnHitListener(GuQiangguOrganBehavior.INSTANCE)
+                        .ensureAttached(GuQiangguOrganBehavior.INSTANCE::ensureAttached)
+                        .build(),
+                OrganIntegrationSpec.builder(SPIRAL_BONE_SPEAR_ID)
+                        .addSlowTickListener(LuoXuanGuQiangguOrganBehavior.INSTANCE)
+                        .addOnHitListener(LuoXuanGuQiangguOrganBehavior.INSTANCE)
+                        .addIncomingDamageListener(LuoXuanGuQiangguOrganBehavior.INSTANCE)
+                        .ensureAttached(LuoXuanGuQiangguOrganBehavior.INSTANCE::ensureAttached)
+                        .build(),
+                OrganIntegrationSpec.builder(TIGER_BONE_ID)
+                        .addSlowTickListener(HuGuguOrganBehavior.INSTANCE)
+                        .addIncomingDamageListener(HuGuguOrganBehavior.INSTANCE)
+                        .ensureAttached(HuGuguOrganBehavior.INSTANCE::ensureAttached)
+                        .build(),
+                OrganIntegrationSpec.builder(JADE_BONE_ID)
+                        .addSlowTickListener(YuGuguOrganBehavior.INSTANCE)
+                        .ensureAttached(YuGuguOrganBehavior.INSTANCE::ensureAttached)
+                        .onEquip(YuGuguOrganBehavior.INSTANCE::onEquip)
+                        .build(),
+                OrganIntegrationSpec.builder(ROU_BAI_GU_ID)
+                        .addSlowTickListener(RouBaiguOrganBehavior.INSTANCE)
+                        .addOnHitListener(RouBaiguOrganBehavior.INSTANCE)
+                        .ensureAttached(RouBaiguOrganBehavior.INSTANCE::ensureAttached)
+                        .build()
+        );
     }
 
     private GuDaoOrganRegistry() {
     }
 
-    /** Forces class initialisation so the static registration block runs. */
-    public static void bootstrap() {
-        // no-op
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/jian_dao/JiandaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/jian_dao/JiandaoOrganRegistry.java
@@ -2,7 +2,9 @@ package net.tigereye.chestcavity.compat.guzhenren.item.jian_dao;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.behavior.JianYingGuOrganBehavior;
-import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
 
 /**
  * Declarative registry for sword-path organs.
@@ -12,18 +14,18 @@ public final class JiandaoOrganRegistry {
     private static final String MOD_ID = "guzhenren";
     private static final ResourceLocation JIAN_YING_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "jian_ying_gu");
 
-    static {
-        GuzhenrenLinkageEffectRegistry.registerSingle(JIAN_YING_GU_ID, context -> {
-            context.addOnHitListener(JianYingGuOrganBehavior.INSTANCE);
-            JianYingGuOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-        });
-    }
+    private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(JIAN_YING_GU_ID)
+                    .addOnHitListener(JianYingGuOrganBehavior.INSTANCE)
+                    .ensureAttached(JianYingGuOrganBehavior.INSTANCE::ensureAttached)
+                    .build()
+    );
 
     private JiandaoOrganRegistry() {
     }
 
-    public static void bootstrap() {
-        // Trigger static initialiser
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
     }
 }
 

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/kongqiao/KongqiaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/kongqiao/KongqiaoOrganRegistry.java
@@ -1,6 +1,9 @@
 package net.tigereye.chestcavity.compat.guzhenren.item.kongqiao;
 
 import net.tigereye.chestcavity.compat.guzhenren.item.kongqiao.behavior.DaoHenBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
 
 /**
  * Registry hook for 空窍（Kong Qiao） organs. Currently only installs Dao Hen logging behaviour.
@@ -10,8 +13,14 @@ public final class KongqiaoOrganRegistry {
     private KongqiaoOrganRegistry() {
     }
 
+    private static final List<OrganIntegrationSpec> SPECS;
 
-    public static void bootstrap() {
+    static {
         DaoHenBehavior.bootstrap();
+        SPECS = List.of();
+    }
+
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/lei_dao/LeiDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/lei_dao/LeiDaoOrganRegistry.java
@@ -2,7 +2,9 @@ package net.tigereye.chestcavity.compat.guzhenren.item.lei_dao;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.lei_dao.behavior.DianLiuguOrganBehavior;
-import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
 
 /**
  * Declarative registry for 雷道（Lei Dao）organ behaviours.
@@ -13,19 +15,18 @@ public final class LeiDaoOrganRegistry {
 
     private static final ResourceLocation DIANLIUGU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "dianliugu");
 
-    static {
-        GuzhenrenLinkageEffectRegistry.registerSingle(DIANLIUGU_ID, context -> {
-            context.addSlowTickListener(DianLiuguOrganBehavior.INSTANCE);
-            context.addOnHitListener(DianLiuguOrganBehavior.INSTANCE);
-            DianLiuguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-        });
-    }
+    private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(DIANLIUGU_ID)
+                    .addSlowTickListener(DianLiuguOrganBehavior.INSTANCE)
+                    .addOnHitListener(DianLiuguOrganBehavior.INSTANCE)
+                    .ensureAttached(DianLiuguOrganBehavior.INSTANCE::ensureAttached)
+                    .build()
+    );
 
     private LeiDaoOrganRegistry() {
     }
 
-    /** Forces static initialisation to occur. */
-    public static void bootstrap() {
-        // no-op
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/mu_dao/MuDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/mu_dao/MuDaoOrganRegistry.java
@@ -2,7 +2,9 @@ package net.tigereye.chestcavity.compat.guzhenren.item.mu_dao;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.mu_dao.behavior.LiandaoGuOrganBehavior;
-import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
 
 /**
  * Registry wiring for 木道（Mu Dao） organs such as the 镰刀蛊.
@@ -12,17 +14,17 @@ public final class MuDaoOrganRegistry {
     private static final String MOD_ID = "guzhenren";
     private static final ResourceLocation LIANDAO_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "liandaogu");
 
-    static {
-        GuzhenrenLinkageEffectRegistry.registerSingle(LIANDAO_GU_ID, context -> {
-            context.addIncomingDamageListener(LiandaoGuOrganBehavior.INSTANCE);
-            LiandaoGuOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-        });
-    }
+    private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(LIANDAO_GU_ID)
+                    .addIncomingDamageListener(LiandaoGuOrganBehavior.INSTANCE)
+                    .ensureAttached(LiandaoGuOrganBehavior.INSTANCE::ensureAttached)
+                    .build()
+    );
 
     private MuDaoOrganRegistry() {
     }
 
-    public static void bootstrap() {
-        // no-op, forces class initialisation
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/san_zhuan/wu_hang/WuHangOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/san_zhuan/wu_hang/WuHangOrganRegistry.java
@@ -1,7 +1,9 @@
 package net.tigereye.chestcavity.compat.guzhenren.item.san_zhuan.wu_hang;
 
 import net.minecraft.resources.ResourceLocation;
-import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
 
 /**
  * Declarative registration for the Wu Hang (五行蛊) organ behaviours.
@@ -16,35 +18,30 @@ public final class WuHangOrganRegistry {
     private static final ResourceLocation JINFEIGU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "jinfeigu");
     private static final ResourceLocation SHUISHENGU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "shuishengu");
 
-    static {
-        GuzhenrenLinkageEffectRegistry.registerSingle(HUOXINGU_ID, context ->
-                context.addOnFireListener(HuoxinguOrganBehavior.INSTANCE)
-        );
-
-        GuzhenrenLinkageEffectRegistry.registerSingle(TUPIGU_ID, context -> {
-            context.addOnGroundListener(TupiguOrganBehavior.INSTANCE);
-            context.addSlowTickListener(TupiguOrganBehavior.INSTANCE);
-        });
-
-        GuzhenrenLinkageEffectRegistry.registerSingle(MUGANGU_ID, context ->
-                context.addSlowTickListener(MuganguOrganBehavior.INSTANCE)
-        );
-
-        GuzhenrenLinkageEffectRegistry.registerSingle(JINFEIGU_ID, context ->
-                context.addSlowTickListener(JinfeiguOrganBehavior.INSTANCE)
-        );
-
-        GuzhenrenLinkageEffectRegistry.registerSingle(SHUISHENGU_ID, context -> {
-            context.addSlowTickListener(ShuishenguOrganBehavior.INSTANCE);
-            context.addIncomingDamageListener(ShuishenguOrganBehavior.INSTANCE);
-        });
-    }
+    private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(HUOXINGU_ID)
+                    .addOnFireListener(HuoxinguOrganBehavior.INSTANCE)
+                    .build(),
+            OrganIntegrationSpec.builder(TUPIGU_ID)
+                    .addOnGroundListener(TupiguOrganBehavior.INSTANCE)
+                    .addSlowTickListener(TupiguOrganBehavior.INSTANCE)
+                    .build(),
+            OrganIntegrationSpec.builder(MUGANGU_ID)
+                    .addSlowTickListener(MuganguOrganBehavior.INSTANCE)
+                    .build(),
+            OrganIntegrationSpec.builder(JINFEIGU_ID)
+                    .addSlowTickListener(JinfeiguOrganBehavior.INSTANCE)
+                    .build(),
+            OrganIntegrationSpec.builder(SHUISHENGU_ID)
+                    .addSlowTickListener(ShuishenguOrganBehavior.INSTANCE)
+                    .addIncomingDamageListener(ShuishenguOrganBehavior.INSTANCE)
+                    .build()
+    );
 
     private WuHangOrganRegistry() {
     }
 
-    /** Forces static initialisation to occur. */
-    public static void bootstrap() {
-        // no-op
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shi_dao/ShiDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shi_dao/ShiDaoOrganRegistry.java
@@ -2,7 +2,9 @@ package net.tigereye.chestcavity.compat.guzhenren.item.shi_dao;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.behavior.JiuChongOrganBehavior;
-import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
 
 /**
  * Registry wiring for 食道（Shi Dao） organs such as the 酒虫.
@@ -12,19 +14,19 @@ public final class ShiDaoOrganRegistry {
     private static final String MOD_ID = "guzhenren";
     private static final ResourceLocation JIU_CHONG_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "jiu_chong");
 
-    static {
-        GuzhenrenLinkageEffectRegistry.registerSingle(JIU_CHONG_ID, context -> {
-            context.addSlowTickListener(JiuChongOrganBehavior.INSTANCE);
-            context.addOnHitListener(JiuChongOrganBehavior.INSTANCE);
-            context.addIncomingDamageListener(JiuChongOrganBehavior.INSTANCE);
-            JiuChongOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-        });
-    }
+    private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(JIU_CHONG_ID)
+                    .addSlowTickListener(JiuChongOrganBehavior.INSTANCE)
+                    .addOnHitListener(JiuChongOrganBehavior.INSTANCE)
+                    .addIncomingDamageListener(JiuChongOrganBehavior.INSTANCE)
+                    .ensureAttached(JiuChongOrganBehavior.INSTANCE::ensureAttached)
+                    .build()
+    );
 
     private ShiDaoOrganRegistry() {
     }
 
-    public static void bootstrap() {
-        // no-op, just triggers class initialisation
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shui_dao/ShuiDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shui_dao/ShuiDaoOrganRegistry.java
@@ -2,7 +2,9 @@ package net.tigereye.chestcavity.compat.guzhenren.item.shui_dao;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.behavior.LingXianguOrganBehavior;
-import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
 
 /**
  * Registry wiring for 水道（Shui Dao） organs.
@@ -14,18 +16,17 @@ public final class ShuiDaoOrganRegistry {
     private static final ResourceLocation LING_XIAN_GU_ID =
             ResourceLocation.fromNamespaceAndPath(MOD_ID, "ling_xian_gu");
 
-    static {
-        GuzhenrenLinkageEffectRegistry.registerSingle(LING_XIAN_GU_ID, context -> {
-            context.addSlowTickListener(LingXianguOrganBehavior.INSTANCE);
-            LingXianguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-        });
-    }
+    private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(LING_XIAN_GU_ID)
+                    .addSlowTickListener(LingXianguOrganBehavior.INSTANCE)
+                    .ensureAttached(LingXianguOrganBehavior.INSTANCE::ensureAttached)
+                    .build()
+    );
 
     private ShuiDaoOrganRegistry() {
     }
 
-    /** Forces static initialisation. */
-    public static void bootstrap() {
-        // no-op
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/tu_dao/TuDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/tu_dao/TuDaoOrganRegistry.java
@@ -2,7 +2,9 @@ package net.tigereye.chestcavity.compat.guzhenren.item.tu_dao;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.tu_dao.behavior.ShiPiGuOrganBehavior;
-import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
 
 /**
  * Declarative registration for 土道蛊 (Tu Dao) organ behaviours.
@@ -14,19 +16,18 @@ public final class TuDaoOrganRegistry {
     private static final ResourceLocation SHI_PI_GU_ID =
             ResourceLocation.fromNamespaceAndPath(MOD_ID, "shi_pi_gu");
 
-    static {
-        GuzhenrenLinkageEffectRegistry.registerSingle(SHI_PI_GU_ID, context -> {
-            context.addSlowTickListener(ShiPiGuOrganBehavior.INSTANCE);
-            context.addIncomingDamageListener(ShiPiGuOrganBehavior.INSTANCE);
-            ShiPiGuOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-        });
-    }
+    private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(SHI_PI_GU_ID)
+                    .addSlowTickListener(ShiPiGuOrganBehavior.INSTANCE)
+                    .addIncomingDamageListener(ShiPiGuOrganBehavior.INSTANCE)
+                    .ensureAttached(ShiPiGuOrganBehavior.INSTANCE::ensureAttached)
+                    .build()
+    );
 
     private TuDaoOrganRegistry() {
     }
 
-    /** Forces static initialisation to occur. */
-    public static void bootstrap() {
-        // no-op
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/XueDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/XueDaoOrganRegistry.java
@@ -2,15 +2,12 @@ package net.tigereye.chestcavity.compat.guzhenren.item.xue_dao;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.behavior.TiexueguOrganBehavior;
-
-
 import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.behavior.XieFeiguOrganBehavior;
-
-import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.behavior.XieyanguOrganBehavior;
-
 import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.behavior.XiediguOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.behavior.XieyanguOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
 
-import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
+import java.util.List;
 
 /**
  * Registry wiring for 血道（Xue Dao） organs.
@@ -29,64 +26,40 @@ public final class XueDaoOrganRegistry {
 
 
 
-    static {
-        GuzhenrenLinkageEffectRegistry.registerSingle(TIE_XUE_GU_ID, context -> {
-            context.addSlowTickListener(TiexueguOrganBehavior.INSTANCE);
-            context.addRemovalListener(TiexueguOrganBehavior.INSTANCE);
-            TiexueguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-            TiexueguOrganBehavior.INSTANCE.onEquip(
-                    context.chestCavity(),
-                    context.sourceOrgan(),
-                    context.staleRemovalContexts()
-            );
-        });
-
-
-
-        GuzhenrenLinkageEffectRegistry.registerSingle(XUE_FEI_GU_ID, context -> {
-            context.addSlowTickListener(XieFeiguOrganBehavior.INSTANCE);
-            context.addIncomingDamageListener(XieFeiguOrganBehavior.INSTANCE);
-            context.addRemovalListener(XieFeiguOrganBehavior.INSTANCE);
-            XieFeiguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-            XieFeiguOrganBehavior.INSTANCE.onEquip(
-                    context.chestCavity(),
-                    context.sourceOrgan(),
-                    context.staleRemovalContexts()
-            );
-        });
-
-
-        GuzhenrenLinkageEffectRegistry.registerSingle(XIE_YAN_GU_ID, context -> {
-            context.addSlowTickListener(XieyanguOrganBehavior.INSTANCE);
-            context.addOnHitListener(XieyanguOrganBehavior.INSTANCE);
-            context.addRemovalListener(XieyanguOrganBehavior.INSTANCE);
-            XieyanguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-            XieyanguOrganBehavior.INSTANCE.onEquip(
-                    context.chestCavity(),
-                    context.sourceOrgan(),
-                    context.staleRemovalContexts()
-            );
-        });
-
-
-        GuzhenrenLinkageEffectRegistry.registerSingle(XIE_DI_GU_ID, context -> {
-            context.addSlowTickListener(XiediguOrganBehavior.INSTANCE);
-            context.addIncomingDamageListener(XiediguOrganBehavior.INSTANCE);
-            context.addRemovalListener(XiediguOrganBehavior.INSTANCE);
-            XiediguOrganBehavior.INSTANCE.ensureAttached(context.chestCavity());
-            XiediguOrganBehavior.INSTANCE.onEquip(
-
-                    context.chestCavity(),
-                    context.sourceOrgan(),
-                    context.staleRemovalContexts()
-            );
-        });
-    }
+    private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(TIE_XUE_GU_ID)
+                    .addSlowTickListener(TiexueguOrganBehavior.INSTANCE)
+                    .addRemovalListener(TiexueguOrganBehavior.INSTANCE)
+                    .ensureAttached(TiexueguOrganBehavior.INSTANCE::ensureAttached)
+                    .onEquip(TiexueguOrganBehavior.INSTANCE::onEquip)
+                    .build(),
+            OrganIntegrationSpec.builder(XUE_FEI_GU_ID)
+                    .addSlowTickListener(XieFeiguOrganBehavior.INSTANCE)
+                    .addIncomingDamageListener(XieFeiguOrganBehavior.INSTANCE)
+                    .addRemovalListener(XieFeiguOrganBehavior.INSTANCE)
+                    .ensureAttached(XieFeiguOrganBehavior.INSTANCE::ensureAttached)
+                    .onEquip(XieFeiguOrganBehavior.INSTANCE::onEquip)
+                    .build(),
+            OrganIntegrationSpec.builder(XIE_YAN_GU_ID)
+                    .addSlowTickListener(XieyanguOrganBehavior.INSTANCE)
+                    .addOnHitListener(XieyanguOrganBehavior.INSTANCE)
+                    .addRemovalListener(XieyanguOrganBehavior.INSTANCE)
+                    .ensureAttached(XieyanguOrganBehavior.INSTANCE::ensureAttached)
+                    .onEquip(XieyanguOrganBehavior.INSTANCE::onEquip)
+                    .build(),
+            OrganIntegrationSpec.builder(XIE_DI_GU_ID)
+                    .addSlowTickListener(XiediguOrganBehavior.INSTANCE)
+                    .addIncomingDamageListener(XiediguOrganBehavior.INSTANCE)
+                    .addRemovalListener(XiediguOrganBehavior.INSTANCE)
+                    .ensureAttached(XiediguOrganBehavior.INSTANCE::ensureAttached)
+                    .onEquip(XiediguOrganBehavior.INSTANCE::onEquip)
+                    .build()
+    );
 
     private XueDaoOrganRegistry() {
     }
 
-    public static void bootstrap() {
-        // no-op, forces static initialisation
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/GuzhenrenModule.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/GuzhenrenModule.java
@@ -1,0 +1,80 @@
+package net.tigereye.chestcavity.compat.guzhenren.module;
+
+import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.compat.guzhenren.item.du_dao.DuDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_cai.GuCaiOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.kongqiao.KongqiaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.lei_dao.LeiDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.mu_dao.MuDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.san_zhuan.wu_hang.WuHangOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.ShiDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.ShuiDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.tu_dao.TuDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.XueDaoOrganRegistry;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Module entry point that wires up all Guzhenren organ integrations in the legacy order.
+ */
+public final class GuzhenrenModule {
+
+    private static final List<Supplier<List<OrganIntegrationSpec>>> SPEC_SUPPLIERS = List.of(
+            GuCaiOrganRegistry::specs,
+            DuDaoOrganRegistry::specs,
+            GuDaoOrganRegistry::specs,
+            LeiDaoOrganRegistry::specs,
+            KongqiaoOrganRegistry::specs,
+            MuDaoOrganRegistry::specs,
+            TuDaoOrganRegistry::specs,
+            ShuiDaoOrganRegistry::specs,
+            XueDaoOrganRegistry::specs,
+            WuHangOrganRegistry::specs,
+            ShiDaoOrganRegistry::specs,
+            JiandaoOrganRegistry::specs
+    );
+
+    private static boolean initialised;
+    private static List<ResourceLocation> registrationOrder = List.of();
+
+    private GuzhenrenModule() {
+    }
+
+    public static synchronized void bootstrap() {
+        if (initialised) {
+            return;
+        }
+        initialised = true;
+        List<OrganIntegrationSpec> specs = new ArrayList<>();
+        for (Supplier<List<OrganIntegrationSpec>> supplier : SPEC_SUPPLIERS) {
+            List<OrganIntegrationSpec> subset = supplier.get();
+            if (subset == null || subset.isEmpty()) {
+                continue;
+            }
+            specs.addAll(subset);
+        }
+        List<ResourceLocation> expectedOrder = specs.stream()
+                .map(OrganIntegrationSpec::organId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        registrationOrder = GuzhenrenOrganIntegrationRegistry.registerAll(specs);
+        if (!registrationOrder.equals(expectedOrder)) {
+            throw new IllegalStateException("Guzhenren integration registration order mismatch");
+        }
+        if (ChestCavity.LOGGER.isDebugEnabled()) {
+            ChestCavity.LOGGER.debug("[compat/guzhenren] Integration registration order: {}", registrationOrder);
+        }
+    }
+
+    public static List<ResourceLocation> registrationOrder() {
+        return Collections.unmodifiableList(registrationOrder);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/GuzhenrenOrganIntegrationRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/GuzhenrenOrganIntegrationRegistry.java
@@ -1,0 +1,44 @@
+package net.tigereye.chestcavity.compat.guzhenren.module;
+
+import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.linkage.effect.GuzhenrenLinkageEffectRegistry;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Centralised dispatcher that translates {@link OrganIntegrationSpec} data into
+ * runtime registrations with {@link GuzhenrenLinkageEffectRegistry}.
+ */
+public final class GuzhenrenOrganIntegrationRegistry {
+
+    private GuzhenrenOrganIntegrationRegistry() {
+    }
+
+    public static List<ResourceLocation> registerAll(Collection<OrganIntegrationSpec> specs) {
+        Objects.requireNonNull(specs, "specs");
+        List<ResourceLocation> registrationOrder = new ArrayList<>();
+        int index = 0;
+        for (OrganIntegrationSpec spec : specs) {
+            if (spec == null) {
+                continue;
+            }
+            ResourceLocation organId = Objects.requireNonNull(spec.organId(), "organId");
+            final int ordinal = ++index;
+            GuzhenrenLinkageEffectRegistry.registerSingle(organId, context -> {
+                if (ChestCavity.LOGGER.isTraceEnabled()) {
+                    ChestCavity.LOGGER.trace("[compat/guzhenren] Applying integration #{} for {}", ordinal, organId);
+                }
+                spec.apply(context);
+            });
+            registrationOrder.add(organId);
+            if (ChestCavity.LOGGER.isDebugEnabled()) {
+                ChestCavity.LOGGER.debug("[compat/guzhenren] Registered integration #{} for {}", ordinal, organId);
+            }
+        }
+        return List.copyOf(registrationOrder);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/OrganIntegrationSpec.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/OrganIntegrationSpec.java
@@ -1,0 +1,193 @@
+package net.tigereye.chestcavity.compat.guzhenren.module;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.linkage.effect.LinkageEffectContext;
+import net.tigereye.chestcavity.listeners.OrganHealListener;
+import net.tigereye.chestcavity.listeners.OrganIncomingDamageListener;
+import net.tigereye.chestcavity.listeners.OrganOnFireListener;
+import net.tigereye.chestcavity.listeners.OrganOnGroundListener;
+import net.tigereye.chestcavity.listeners.OrganOnHitListener;
+import net.tigereye.chestcavity.listeners.OrganRemovalContext;
+import net.tigereye.chestcavity.listeners.OrganRemovalListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Declarative wiring details for a single Guzhenren organ integration.
+ */
+public final class OrganIntegrationSpec {
+
+    private final ResourceLocation organId;
+    private final List<OrganSlowTickListener> slowTickListeners;
+    private final List<OrganOnHitListener> onHitListeners;
+    private final List<OrganIncomingDamageListener> incomingDamageListeners;
+    private final List<OrganOnFireListener> onFireListeners;
+    private final List<OrganOnGroundListener> onGroundListeners;
+    private final List<OrganHealListener> healListeners;
+    private final List<OrganRemovalListener> removalListeners;
+    private final List<Consumer<ChestCavityInstance>> ensureAttachedHooks;
+    private final List<OnEquipHook> onEquipHooks;
+
+    private OrganIntegrationSpec(Builder builder) {
+        this.organId = builder.organId;
+        this.slowTickListeners = List.copyOf(builder.slowTickListeners);
+        this.onHitListeners = List.copyOf(builder.onHitListeners);
+        this.incomingDamageListeners = List.copyOf(builder.incomingDamageListeners);
+        this.onFireListeners = List.copyOf(builder.onFireListeners);
+        this.onGroundListeners = List.copyOf(builder.onGroundListeners);
+        this.healListeners = List.copyOf(builder.healListeners);
+        this.removalListeners = List.copyOf(builder.removalListeners);
+        this.ensureAttachedHooks = List.copyOf(builder.ensureAttachedHooks);
+        this.onEquipHooks = List.copyOf(builder.onEquipHooks);
+    }
+
+    public ResourceLocation organId() {
+        return organId;
+    }
+
+    public List<OrganSlowTickListener> slowTickListeners() {
+        return slowTickListeners;
+    }
+
+    public List<OrganOnHitListener> onHitListeners() {
+        return onHitListeners;
+    }
+
+    public List<OrganIncomingDamageListener> incomingDamageListeners() {
+        return incomingDamageListeners;
+    }
+
+    public List<OrganOnFireListener> onFireListeners() {
+        return onFireListeners;
+    }
+
+    public List<OrganOnGroundListener> onGroundListeners() {
+        return onGroundListeners;
+    }
+
+    public List<OrganHealListener> healListeners() {
+        return healListeners;
+    }
+
+    public List<OrganRemovalListener> removalListeners() {
+        return removalListeners;
+    }
+
+    public List<Consumer<ChestCavityInstance>> ensureAttachedHooks() {
+        return ensureAttachedHooks;
+    }
+
+    public List<OnEquipHook> onEquipHooks() {
+        return onEquipHooks;
+    }
+
+    /** Applies all declared operations to the provided linkage context. */
+    public void apply(LinkageEffectContext context) {
+        Objects.requireNonNull(context, "context");
+        slowTickListeners.forEach(context::addSlowTickListener);
+        onHitListeners.forEach(context::addOnHitListener);
+        incomingDamageListeners.forEach(context::addIncomingDamageListener);
+        onFireListeners.forEach(context::addOnFireListener);
+        onGroundListeners.forEach(context::addOnGroundListener);
+        healListeners.forEach(context::addHealListener);
+        removalListeners.forEach(context::addRemovalListener);
+
+        ChestCavityInstance chestCavity = context.chestCavity();
+        if (chestCavity != null) {
+            ensureAttachedHooks.forEach(hook -> hook.accept(chestCavity));
+            if (!onEquipHooks.isEmpty()) {
+                List<OrganRemovalContext> staleRemovalContexts = context.staleRemovalContexts();
+                ItemStack sourceOrgan = context.sourceOrgan();
+                for (OnEquipHook hook : onEquipHooks) {
+                    hook.onEquip(chestCavity, sourceOrgan, staleRemovalContexts);
+                }
+            }
+        }
+    }
+
+    public static Builder builder(ResourceLocation organId) {
+        return new Builder(organId);
+    }
+
+    /** Fluent builder for {@link OrganIntegrationSpec}. */
+    public static final class Builder {
+        private final ResourceLocation organId;
+        private final List<OrganSlowTickListener> slowTickListeners = new ArrayList<>();
+        private final List<OrganOnHitListener> onHitListeners = new ArrayList<>();
+        private final List<OrganIncomingDamageListener> incomingDamageListeners = new ArrayList<>();
+        private final List<OrganOnFireListener> onFireListeners = new ArrayList<>();
+        private final List<OrganOnGroundListener> onGroundListeners = new ArrayList<>();
+        private final List<OrganHealListener> healListeners = new ArrayList<>();
+        private final List<OrganRemovalListener> removalListeners = new ArrayList<>();
+        private final List<Consumer<ChestCavityInstance>> ensureAttachedHooks = new ArrayList<>();
+        private final List<OnEquipHook> onEquipHooks = new ArrayList<>();
+
+        private Builder(ResourceLocation organId) {
+            this.organId = Objects.requireNonNull(organId, "organId");
+        }
+
+        public Builder addSlowTickListener(OrganSlowTickListener listener) {
+            slowTickListeners.add(Objects.requireNonNull(listener, "listener"));
+            return this;
+        }
+
+        public Builder addOnHitListener(OrganOnHitListener listener) {
+            onHitListeners.add(Objects.requireNonNull(listener, "listener"));
+            return this;
+        }
+
+        public Builder addIncomingDamageListener(OrganIncomingDamageListener listener) {
+            incomingDamageListeners.add(Objects.requireNonNull(listener, "listener"));
+            return this;
+        }
+
+        public Builder addOnFireListener(OrganOnFireListener listener) {
+            onFireListeners.add(Objects.requireNonNull(listener, "listener"));
+            return this;
+        }
+
+        public Builder addOnGroundListener(OrganOnGroundListener listener) {
+            onGroundListeners.add(Objects.requireNonNull(listener, "listener"));
+            return this;
+        }
+
+        public Builder addHealListener(OrganHealListener listener) {
+            healListeners.add(Objects.requireNonNull(listener, "listener"));
+            return this;
+        }
+
+        public Builder addRemovalListener(OrganRemovalListener listener) {
+            removalListeners.add(Objects.requireNonNull(listener, "listener"));
+            return this;
+        }
+
+        public Builder ensureAttached(Consumer<ChestCavityInstance> hook) {
+            ensureAttachedHooks.add(Objects.requireNonNull(hook, "hook"));
+            return this;
+        }
+
+        public Builder onEquip(OnEquipHook hook) {
+            onEquipHooks.add(Objects.requireNonNull(hook, "hook"));
+            return this;
+        }
+
+        public OrganIntegrationSpec build() {
+            return new OrganIntegrationSpec(this);
+        }
+    }
+
+    @FunctionalInterface
+    public interface OnEquipHook {
+        void onEquip(
+                ChestCavityInstance chestCavity,
+                ItemStack sourceOrgan,
+                List<OrganRemovalContext> staleRemovalContexts
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add an OrganIntegrationSpec data model and a GuzhenrenOrganIntegrationRegistry to centralise listener wiring
- convert all Guzhenren organ registries to expose spec lists and bootstrap them through the new GuzhenrenModule
- update ChestCavity and GuzhenrenOrganHandlers to initialise the module once and log the preserved registration order

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68d7aac05b208326bba8b1c99b56205b