### PR TITLE
Avoid duplicate Guzhenren removal hook registrations

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/common/AbstractGuzhenrenOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/common/AbstractGuzhenrenOrganBehavior.java
@@ -57,13 +57,17 @@ public abstract class AbstractGuzhenrenOrganBehavior {
             return RemovalRegistration.EMPTY;
         }
         int slotIndex = ChestCavityUtil.findOrganSlot(cc, organ);
-        boolean alreadyRegistered = false;
         if (staleRemovalContexts != null) {
-            alreadyRegistered = staleRemovalContexts.removeIf(
+            staleRemovalContexts.removeIf(
                     old -> ChestCavityUtil.matchesRemovalContext(old, slotIndex, organ, listener)
             );
         }
-        cc.onRemovedListeners.add(new OrganRemovalContext(slotIndex, organ, listener));
+
+        boolean alreadyRegistered = cc.onRemovedListeners.stream()
+                .anyMatch(existing -> ChestCavityUtil.matchesRemovalContext(existing, slotIndex, organ, listener));
+        if (!alreadyRegistered) {
+            cc.onRemovedListeners.add(new OrganRemovalContext(slotIndex, organ, listener));
+        }
         return new RemovalRegistration(slotIndex, alreadyRegistered);
     }
 


### PR DESCRIPTION
## Summary
- avoid duplicating Guzhenren removal contexts by reusing existing listener slots during on-equip hooks

## Testing
- ./gradlew compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d7bd4680808326a3f0209ad2aeeb81