### PR TITLE
Make GuScript UI spacing configurable

### DIFF
--- a/docs/design/guscript-module.md
+++ b/docs/design/guscript-module.md
@@ -79,6 +79,16 @@ The top-level package highlights the AST and UI folders explicitly while still a
 - Item insertion uses vanilla slot mechanics. Special binding slots use custom `Slot` subclasses that either block items or accept token items that stand in for listeners.
 - Each page exposes一个“模拟”按钮：运行脚本于模拟上下文（无伤害/消耗），并在 UI 上逐步展示执行路径，便于迭代。
 
+### UI configuration knobs
+
+The responsive layout parameters for `GuScriptScreen` live inside the new `guscript_ui` block of `CCConfig`. They are saved to the standard `config/chestcavity.json` file, so downstream packs can rebalance spacing without recompiling the mod.
+
+- `bindingRightPaddingSlots`, `bindingTopPaddingSlots`, `bindingVerticalSpacingSlots`, and `bindingButtonWidthFraction` scale the listener/binding buttons relative to the slot grid.
+- `bindingButtonHeightPx`, `minBindingButtonWidthPx`, `minTopGutterPx`, `minHorizontalGutterPx`, and `minBindingSpacingPx` provide hard floors that keep controls readable on narrow screens.
+- `pageButtonWidthPx`, `pageButtonHeightPx`, `pageButtonLeftPaddingSlots`, `pageButtonTopPaddingSlots`, `pageButtonHorizontalSpacingSlots`, and `minPageButtonSpacingPx` control the page navigation row.
+
+Tweaking these values automatically updates button placement the next time the UI opens, ensuring the gutter between controls and the inventory rows stays intact across aspect ratios.
+
 ## Listener & Keybind Integration
 
 - `ListenerBindingDefinition` enumerates supported trigger types: `ORGAN_SLOW_TICK`, `ORGAN_ON_HIT`, `ORGAN_ON_DAMAGE`, `CLIENT_KEY`, etc. Each definition stores optional filters (organ id, player state) parsed from the UI.

--- a/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
+++ b/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
@@ -118,4 +118,41 @@ public class CCConfig implements ConfigData {
     @ConfigEntry.Category("integration")
     public boolean GUZHENREN_NUDAO_LOGGING = true;
 
+    @ConfigEntry.Category("guscript_ui")
+    @ConfigEntry.Gui.CollapsibleObject
+    public GuScriptUIConfig GUSCRIPT_UI = new GuScriptUIConfig();
+
+    public static class GuScriptUIConfig {
+        @ConfigEntry.Gui.Tooltip
+        public double bindingRightPaddingSlots = 0.5D;
+        @ConfigEntry.Gui.Tooltip
+        public double bindingTopPaddingSlots = 1.5D;
+        @ConfigEntry.Gui.Tooltip
+        public double bindingVerticalSpacingSlots = 0.35D;
+        @ConfigEntry.Gui.Tooltip
+        public double bindingButtonWidthFraction = 0.56D;
+        @ConfigEntry.Gui.Tooltip
+        public int bindingButtonHeightPx = 20;
+        @ConfigEntry.Gui.Tooltip
+        public int minBindingButtonWidthPx = 88;
+        @ConfigEntry.Gui.Tooltip
+        public int minTopGutterPx = 6;
+        @ConfigEntry.Gui.Tooltip
+        public int minHorizontalGutterPx = 4;
+        @ConfigEntry.Gui.Tooltip
+        public int minBindingSpacingPx = 4;
+        @ConfigEntry.Gui.Tooltip
+        public int pageButtonWidthPx = 20;
+        @ConfigEntry.Gui.Tooltip
+        public int pageButtonHeightPx = 20;
+        @ConfigEntry.Gui.Tooltip
+        public double pageButtonLeftPaddingSlots = 0.5D;
+        @ConfigEntry.Gui.Tooltip
+        public double pageButtonTopPaddingSlots = 0.9D;
+        @ConfigEntry.Gui.Tooltip
+        public double pageButtonHorizontalSpacingSlots = 0.2D;
+        @ConfigEntry.Gui.Tooltip
+        public int minPageButtonSpacingPx = 4;
+    }
+
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/ui/GuScriptScreen.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/ui/GuScriptScreen.java
@@ -5,10 +5,13 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Inventory;
 import net.tigereye.chestcavity.guscript.data.BindingTarget;
 import net.tigereye.chestcavity.guscript.data.ListenerType;
 import net.tigereye.chestcavity.guscript.network.packets.GuScriptBindingTogglePayload;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.config.CCConfig;
 
 public class GuScriptScreen extends AbstractContainerScreen<GuScriptMenu> {
     private static final ResourceLocation BACKGROUND = ResourceLocation.fromNamespaceAndPath("minecraft", "textures/gui/container/generic_54.png");
@@ -18,6 +21,8 @@ public class GuScriptScreen extends AbstractContainerScreen<GuScriptMenu> {
     private Button prevPageButton;
     private Button nextPageButton;
     private Button addPageButton;
+    private int pageInfoY;
+    private int navButtonHeight;
 
     public GuScriptScreen(GuScriptMenu menu, Inventory inventory, Component title) {
         super(menu, inventory, title);
@@ -30,35 +35,66 @@ public class GuScriptScreen extends AbstractContainerScreen<GuScriptMenu> {
         super.init();
         this.titleLabelX = (this.imageWidth - this.font.width(this.title)) / 2;
 
-        int buttonWidth = 98;
-        int offset = 4;
-        int slotSize = 18;
-        int rightX = this.leftPos + this.imageWidth - offset - slotSize;
-        int baseY = this.topPos - 24 - slotSize - slotSize / 2;
+        CCConfig.GuScriptUIConfig ui = ChestCavity.config.GUSCRIPT_UI;
+        int slotSize = computeSlotSize();
+
+        int bindingSpacing = Math.max(ui.minBindingSpacingPx, (int) Math.round(slotSize * ui.bindingVerticalSpacingSlots));
+        int bindingButtonHeight = Math.max(1, ui.bindingButtonHeightPx);
+        int bindingStackHeight = bindingButtonHeight * 2 + bindingSpacing;
+        int bindingTopPadding = Math.max(ui.minTopGutterPx, (int) Math.round(slotSize * ui.bindingTopPaddingSlots));
+        int bindingBaseY = this.topPos - bindingTopPadding - bindingStackHeight;
+
+        int rightPadding = Math.max(ui.minHorizontalGutterPx, (int) Math.round(slotSize * ui.bindingRightPaddingSlots));
+        int bindingButtonWidth = (int) Math.round(this.imageWidth * ui.bindingButtonWidthFraction);
+        int minBindingWidth = Math.max(ui.minBindingButtonWidthPx, 1);
+        int maxBindingWidth = Math.max(this.imageWidth - ui.minHorizontalGutterPx - rightPadding, minBindingWidth);
+        bindingButtonWidth = Mth.clamp(bindingButtonWidth, minBindingWidth, maxBindingWidth);
+
+        int minAnchorX = this.leftPos + ui.minHorizontalGutterPx;
+        int maxAnchorX = this.leftPos + this.imageWidth - bindingButtonWidth - ui.minHorizontalGutterPx;
+        if (maxAnchorX < minAnchorX) {
+            maxAnchorX = minAnchorX;
+        }
+        int bindingAnchorX = this.leftPos + this.imageWidth - rightPadding - bindingButtonWidth;
+        bindingAnchorX = Mth.clamp(bindingAnchorX, minAnchorX, maxAnchorX);
 
         bindingTargetButton = addRenderableWidget(Button.builder(Component.empty(), button -> sendToggle(GuScriptBindingTogglePayload.Operation.TOGGLE_TARGET))
-                .bounds(rightX - buttonWidth, baseY, buttonWidth, 20)
+                .bounds(bindingAnchorX, bindingBaseY, bindingButtonWidth, bindingButtonHeight)
                 .build());
 
         listenerButton = addRenderableWidget(Button.builder(Component.empty(), button -> sendToggle(GuScriptBindingTogglePayload.Operation.CYCLE_LISTENER))
-                .bounds(rightX - buttonWidth, baseY + 22, buttonWidth, 20)
+                .bounds(bindingAnchorX, bindingBaseY + bindingButtonHeight + bindingSpacing, bindingButtonWidth, bindingButtonHeight)
                 .build());
 
-        int pageButtonWidth = 20;
-        int pageButtonY = this.topPos - 18;
-        int pageButtonX = this.leftPos + 8;
+        int pageButtonWidth = Math.max(1, ui.pageButtonWidthPx);
+        this.navButtonHeight = Math.max(1, ui.pageButtonHeightPx);
+        int pageButtonSpacing = Math.max(ui.minPageButtonSpacingPx, (int) Math.round(slotSize * ui.pageButtonHorizontalSpacingSlots));
+        int pageButtonRowWidth = pageButtonWidth * 3 + pageButtonSpacing * 2;
+        int pageButtonLeftPadding = Math.max(ui.minHorizontalGutterPx, (int) Math.round(slotSize * ui.pageButtonLeftPaddingSlots));
+        int preferredPageButtonX = this.leftPos + pageButtonLeftPadding;
+        int minPageButtonX = this.leftPos + ui.minHorizontalGutterPx;
+        int maxPageButtonX = this.leftPos + this.imageWidth - pageButtonRowWidth - ui.minHorizontalGutterPx;
+        if (maxPageButtonX < minPageButtonX) {
+            maxPageButtonX = minPageButtonX;
+        }
+        int pageButtonX = Mth.clamp(preferredPageButtonX, minPageButtonX, maxPageButtonX);
+
+        int pageButtonTopPadding = Math.max(ui.minTopGutterPx, (int) Math.round(slotSize * ui.pageButtonTopPaddingSlots));
+        int pageButtonY = this.topPos - pageButtonTopPadding - this.navButtonHeight;
 
         prevPageButton = addRenderableWidget(Button.builder(Component.literal("<"), button -> sendPageChange(false))
-                .bounds(pageButtonX, pageButtonY, pageButtonWidth, 20)
+                .bounds(pageButtonX, pageButtonY, pageButtonWidth, this.navButtonHeight)
                 .build());
 
         nextPageButton = addRenderableWidget(Button.builder(Component.literal(">"), button -> sendPageChange(true))
-                .bounds(pageButtonX + pageButtonWidth + 2, pageButtonY, pageButtonWidth, 20)
+                .bounds(pageButtonX + pageButtonWidth + pageButtonSpacing, pageButtonY, pageButtonWidth, this.navButtonHeight)
                 .build());
 
         addPageButton = addRenderableWidget(Button.builder(Component.literal("+"), button -> sendAddPage())
-                .bounds(pageButtonX + (pageButtonWidth + 2) * 2, pageButtonY, pageButtonWidth, 20)
+                .bounds(pageButtonX + (pageButtonWidth + pageButtonSpacing) * 2, pageButtonY, pageButtonWidth, this.navButtonHeight)
                 .build());
+
+        this.pageInfoY = pageButtonY + (this.navButtonHeight - this.font.lineHeight) / 2;
 
         updateButtonStates();
     }
@@ -77,7 +113,8 @@ public class GuScriptScreen extends AbstractContainerScreen<GuScriptMenu> {
         renderBackground(graphics, mouseX, mouseY, partialTick);
         super.render(graphics, mouseX, mouseY, partialTick);
         Component pageInfo = Component.translatable("gui.chestcavity.guscript.page", this.menu.getPageIndex() + 1, Math.max(1, this.menu.getPageCount()));
-        graphics.drawString(this.font, pageInfo, this.leftPos + 60, this.topPos - 12, 0xFFFFFF, false);
+        int pageInfoX = this.leftPos + (this.imageWidth - this.font.width(pageInfo)) / 2;
+        graphics.drawString(this.font, pageInfo, pageInfoX, this.pageInfoY, 0xFFFFFF, false);
         renderTooltip(graphics, mouseX, mouseY);
     }
 
@@ -145,5 +182,17 @@ public class GuScriptScreen extends AbstractContainerScreen<GuScriptMenu> {
         if (connection != null) {
             connection.send(new net.tigereye.chestcavity.guscript.network.packets.GuScriptPageChangePayload(net.tigereye.chestcavity.guscript.network.packets.GuScriptPageChangePayload.Operation.ADD, 0));
         }
+    }
+
+    private int computeSlotSize() {
+        int rows = this.menu.getRows();
+        if (rows <= 0) {
+            return 18;
+        }
+        int contentHeight = this.imageHeight - 114;
+        if (contentHeight <= 0) {
+            return 18;
+        }
+        return Math.max(1, contentHeight / rows);
     }
 }


### PR DESCRIPTION
## Summary
- replace the GuScript screen's hard-coded button offsets with layout math that scales from slot size and respects configurable gutters
- add a `guscript_ui` block to `CCConfig` so button spacing and sizing can be tuned without recompiling
- document the new layout knobs in `docs/design/guscript-module.md`

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68d86c2fe7008326b5337a5fcd80fd21