### PR TITLE
Fix GuScript page info overlap

### DIFF
--- a/docs/design/guscript-module.md
+++ b/docs/design/guscript-module.md
@@ -84,8 +84,8 @@ The top-level package highlights the AST and UI folders explicitly while still a
 The responsive layout parameters for `GuScriptScreen` live inside the new `guscript_ui` block of `CCConfig`. They are saved to the standard `config/chestcavity.json` file, so downstream packs can rebalance spacing without recompiling the mod.
 
 - `bindingRightPaddingSlots`, `bindingTopPaddingSlots`, `bindingVerticalSpacingSlots`, and `bindingButtonWidthFraction` scale the listener/binding buttons relative to the slot grid.
-- `bindingButtonHeightPx`, `minBindingButtonWidthPx`, `minTopGutterPx`, `minHorizontalGutterPx`, and `minBindingSpacingPx` provide hard floors that keep controls readable on narrow screens.
-- `pageButtonWidthPx`, `pageButtonHeightPx`, `pageButtonLeftPaddingSlots`, `pageButtonTopPaddingSlots`, `pageButtonHorizontalSpacingSlots`, and `minPageButtonSpacingPx` control the page navigation row.
+- `bindingButtonHeightPx`, `minBindingButtonWidthPx`, `minTopGutterPx`, `minHorizontalGutterPx`, and `minBindingSpacingPx` provide hard floors that keep controls readable on narrow screens. `minHorizontalGutterPx` now defaults to a positive value so controls always retain lateral breathing room.
+- `pageButtonWidthPx`, `pageButtonHeightPx`, `pageButtonLeftPaddingSlots`, `pageButtonTopPaddingSlots`, `pageButtonHorizontalSpacingSlots`, `minPageButtonSpacingPx`, `pageButtonHorizontalOffsetPx`, and `pageInfoBelowNavSpacingPx` control the page navigation row and the page info label spacing beneath it.
 
 Tweaking these values automatically updates button placement the next time the UI opens, ensuring the gutter between controls and the inventory rows stays intact across aspect ratios.
 

--- a/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
+++ b/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
@@ -140,7 +140,7 @@ public class CCConfig implements ConfigData {
         @ConfigEntry.Gui.Tooltip
         public int minTopGutterPx = 0;
         @ConfigEntry.Gui.Tooltip
-        public int minHorizontalGutterPx = 0;
+        public int minHorizontalGutterPx = 6;
         @ConfigEntry.Gui.Tooltip
         public int minBindingSpacingPx = 0;
         @ConfigEntry.Gui.Tooltip
@@ -157,6 +157,8 @@ public class CCConfig implements ConfigData {
         public int minPageButtonSpacingPx = 0;
         @ConfigEntry.Gui.Tooltip
         public int pageButtonHorizontalOffsetPx = -50;
+        @ConfigEntry.Gui.Tooltip
+        public int pageInfoBelowNavSpacingPx = 6;
     }
 
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/ui/GuScriptScreen.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/ui/GuScriptScreen.java
@@ -96,7 +96,8 @@ public class GuScriptScreen extends AbstractContainerScreen<GuScriptMenu> {
                 .bounds(pageButtonX + (pageButtonWidth + pageButtonSpacing) * 2, pageButtonY, pageButtonWidth, this.navButtonHeight)
                 .build());
 
-        this.pageInfoY = pageButtonY + (this.navButtonHeight - this.font.lineHeight) / 2;
+        int pageInfoSpacing = Math.max(0, ui.pageInfoBelowNavSpacingPx);
+        this.pageInfoY = pageButtonY + this.navButtonHeight + pageInfoSpacing;
 
         updateButtonStates();
     }


### PR DESCRIPTION
## Summary
- move the GuScript page information label below the navigation buttons with configurable spacing to avoid overlap with controls
- raise the default horizontal gutter and document the new layout knobs in the GuScript UI design notes

## Testing
- ./gradlew --console=plain compileJava

------
https://chatgpt.com/codex/tasks/task_e_68d87ef87d9c8326bcf27921d8deb202