### PR TITLE
Ensure GuScript triggers execute all compiled roots

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/guscript/command/GuScriptCommands.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/command/GuScriptCommands.java
@@ -18,7 +18,6 @@ import net.tigereye.chestcavity.guscript.ast.LeafGuNode;
 import net.tigereye.chestcavity.guscript.ast.OperatorGuNode;
 import net.tigereye.chestcavity.guscript.runtime.action.DefaultGuScriptExecutionBridge;
 import net.tigereye.chestcavity.guscript.runtime.exec.DefaultGuScriptContext;
-import net.tigereye.chestcavity.guscript.runtime.exec.GuScriptContext;
 import net.tigereye.chestcavity.guscript.runtime.exec.GuScriptRuntime;
 import net.tigereye.chestcavity.guscript.runtime.reduce.GuScriptReducer;
 import net.tigereye.chestcavity.guscript.runtime.reduce.ReactionRule;
@@ -75,10 +74,9 @@ public final class GuScriptCommands {
             return 0;
         }
 
-        DefaultGuScriptExecutionBridge bridge = DefaultGuScriptExecutionBridge.forPlayer(player);
-        GuScriptContext context = new DefaultGuScriptContext(player, player, bridge);
         GuScriptRuntime runtime = new GuScriptRuntime();
-        runtime.executeAll(result.roots(), context);
+        runtime.executeAll(result.roots(), index ->
+                new DefaultGuScriptContext(player, player, new DefaultGuScriptExecutionBridge(player, player, index)));
 
         source.sendSuccess(() -> Component.literal("已执行 GuScript 示例，生成 " + result.roots().size() + " 个根节点"), true);
         return result.roots().size();

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutor.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutor.java
@@ -36,9 +36,10 @@ public final class GuScriptExecutor {
                         .map(root -> root.kind() + ":" + root.name())
                         .toList()
         );
-        RUNTIME.executeAll(cache.roots(), () -> {
-            DefaultGuScriptExecutionBridge bridge = new DefaultGuScriptExecutionBridge(player, target == null ? player : target);
-            return new DefaultGuScriptContext(player, target == null ? player : target, bridge);
+        RUNTIME.executeAll(cache.roots(), index -> {
+            LivingEntity actualTarget = target == null ? player : target;
+            DefaultGuScriptExecutionBridge bridge = new DefaultGuScriptExecutionBridge(player, actualTarget, index);
+            return new DefaultGuScriptContext(player, actualTarget, bridge);
         });
     }
 }


### PR DESCRIPTION
## Summary
- allow the GuScript runtime to request contexts with the executing root index so we can create isolated state per composite
- update the executor and demo command to build a fresh DefaultGuScriptExecutionBridge/DefaultGuScriptContext per root
- log projectile emissions with their root index and apply small yaw/lateral offsets so simultaneous casts are visible during debugging

## Testing
- ./gradlew compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d87f0bff6c83269293791caadccf10