### PR TITLE
Implement global GuScript keybind dispatch with logging and limits

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
+++ b/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
@@ -122,6 +122,10 @@ public class CCConfig implements ConfigData {
     @ConfigEntry.Gui.CollapsibleObject
     public GuScriptUIConfig GUSCRIPT_UI = new GuScriptUIConfig();
 
+    @ConfigEntry.Category("guscript_execution")
+    @ConfigEntry.Gui.CollapsibleObject
+    public GuScriptExecutionConfig GUSCRIPT_EXECUTION = new GuScriptExecutionConfig();
+
     public static class GuScriptUIConfig {
         @ConfigEntry.Gui.Tooltip
         public double bindingRightPaddingSlots = 0.5D;
@@ -159,6 +163,13 @@ public class CCConfig implements ConfigData {
         public int pageButtonHorizontalOffsetPx = -50;
         @ConfigEntry.Gui.Tooltip
         public int pageInfoBelowNavSpacingPx = 6;
+    }
+
+    public static class GuScriptExecutionConfig {
+        @ConfigEntry.Gui.Tooltip
+        public int maxKeybindPagesPerTrigger = 16;
+        @ConfigEntry.Gui.Tooltip
+        public int maxKeybindRootsPerTrigger = 64;
     }
 
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/network/packets/GuScriptTriggerPayload.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/network/packets/GuScriptTriggerPayload.java
@@ -36,7 +36,7 @@ public record GuScriptTriggerPayload(int pageIndex) implements CustomPacketPaylo
             if (payload.pageIndex >= 0) {
                 attachment.setCurrentPage(payload.pageIndex);
             }
-            GuScriptExecutor.trigger(player, player, attachment);
+            GuScriptExecutor.triggerKeybind(player, player, attachment);
         });
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptCompiler.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptCompiler.java
@@ -30,7 +30,18 @@ public final class GuScriptCompiler {
     }
 
     public static GuScriptProgramCache compileIfNeeded(GuScriptAttachment attachment, long gameTime) {
-        GuScriptPageState page = attachment.activePage();
+        return compilePageIfNeeded(attachment, attachment.activePage(), attachment.getCurrentPageIndex(), gameTime);
+    }
+
+    public static GuScriptProgramCache compilePageIfNeeded(
+            GuScriptAttachment attachment,
+            GuScriptPageState page,
+            int pageIndex,
+            long gameTime
+    ) {
+        if (attachment == null || page == null) {
+            return new GuScriptProgramCache(List.of(), 0, gameTime);
+        }
         int signature = computeSignature(page);
         GuScriptProgramCache cached = page.compiledProgram();
         if (cached != null && cached.inventorySignature() == signature && !page.consumeDirtyFlag()) {
@@ -57,7 +68,7 @@ public final class GuScriptCompiler {
             roots.addAll(result.roots());
             ChestCavity.LOGGER.info(
                     "[GuScript] Compiled page {} (binding={}, listener={}) -> {} roots: {}",
-                    attachment.getCurrentPageIndex(),
+                    pageIndex,
                     page.bindingTarget(),
                     page.listenerType(),
                     roots.size(),
@@ -68,7 +79,7 @@ public final class GuScriptCompiler {
         } else {
             ChestCavity.LOGGER.info(
                     "[GuScript] Compiled page {} (binding={}, listener={}) -> empty root set",
-                    attachment.getCurrentPageIndex(),
+                    pageIndex,
                     page.bindingTarget(),
                     page.listenerType()
             );

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutor.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutor.java
@@ -3,11 +3,16 @@ package net.tigereye.chestcavity.guscript.runtime.exec;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.LivingEntity;
 import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.config.CCConfig;
+import net.tigereye.chestcavity.guscript.ast.GuNode;
 import net.tigereye.chestcavity.guscript.data.BindingTarget;
 import net.tigereye.chestcavity.guscript.data.GuScriptAttachment;
+import net.tigereye.chestcavity.guscript.data.GuScriptPageState;
 import net.tigereye.chestcavity.guscript.data.GuScriptProgramCache;
-import net.tigereye.chestcavity.guscript.data.ListenerType;
 import net.tigereye.chestcavity.guscript.runtime.action.DefaultGuScriptExecutionBridge;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Executes compiled GuScript programs for a player.
@@ -15,6 +20,8 @@ import net.tigereye.chestcavity.guscript.runtime.action.DefaultGuScriptExecution
 public final class GuScriptExecutor {
 
     private static final GuScriptRuntime RUNTIME = new GuScriptRuntime();
+    private static final int DEFAULT_MAX_KEYBIND_PAGES = 16;
+    private static final int DEFAULT_MAX_KEYBIND_ROOTS = 64;
 
     private GuScriptExecutor() {
     }
@@ -23,20 +30,153 @@ public final class GuScriptExecutor {
         if (player == null || attachment == null) {
             return;
         }
-        GuScriptProgramCache cache = GuScriptCompiler.compileIfNeeded(attachment, player.level().getGameTime());
+        int pageIndex = attachment.getCurrentPageIndex();
+        GuScriptProgramCache cache = GuScriptCompiler.compilePageIfNeeded(
+                attachment,
+                attachment.activePage(),
+                pageIndex,
+                player.level().getGameTime()
+        );
         if (cache.roots().isEmpty()) {
             ChestCavity.LOGGER.debug("[GuScript] No compiled roots to execute for {}", player.getGameProfile().getName());
             return;
         }
         ChestCavity.LOGGER.info(
-                "[GuScript] Trigger dispatch for {}: {} roots -> {}",
+                "[GuScript] Trigger dispatch for {} on page {}: {} roots -> {}",
                 player.getGameProfile().getName(),
+                pageIndex,
                 cache.roots().size(),
                 cache.roots().stream()
                         .map(root -> root.kind() + ":" + root.name())
                         .toList()
         );
         RUNTIME.executeAll(cache.roots(), index -> {
+            LivingEntity actualTarget = target == null ? player : target;
+            DefaultGuScriptExecutionBridge bridge = new DefaultGuScriptExecutionBridge(player, actualTarget, index);
+            return new DefaultGuScriptContext(player, actualTarget, bridge);
+        });
+    }
+
+    public static void triggerKeybind(ServerPlayer player, LivingEntity target, GuScriptAttachment attachment) {
+        if (player == null || attachment == null) {
+            return;
+        }
+
+        CCConfig.GuScriptExecutionConfig executionConfig = ChestCavity.config != null
+                ? ChestCavity.config.GUSCRIPT_EXECUTION
+                : null;
+        int maxPages = executionConfig != null ? executionConfig.maxKeybindPagesPerTrigger : DEFAULT_MAX_KEYBIND_PAGES;
+        int maxRoots = executionConfig != null ? executionConfig.maxKeybindRootsPerTrigger : DEFAULT_MAX_KEYBIND_ROOTS;
+        boolean unlimitedPages = maxPages <= 0;
+        boolean unlimitedRoots = maxRoots <= 0;
+        if (unlimitedPages) {
+            maxPages = Integer.MAX_VALUE;
+        }
+        if (unlimitedRoots) {
+            maxRoots = Integer.MAX_VALUE;
+        }
+
+        List<GuNode> aggregatedRoots = new ArrayList<>();
+        int eligiblePages = 0;
+        int executedPages = 0;
+        int totalRoots = 0;
+        boolean pageLimitReached = false;
+        boolean rootLimitReached = false;
+        long gameTime = player.level().getGameTime();
+
+        List<GuScriptPageState> pages = attachment.pages();
+        for (int pageIndex = 0; pageIndex < pages.size(); pageIndex++) {
+            GuScriptPageState page = pages.get(pageIndex);
+            if (page.bindingTarget() != BindingTarget.KEYBIND) {
+                continue;
+            }
+            eligiblePages++;
+            if (executedPages >= maxPages) {
+                pageLimitReached = true;
+                continue;
+            }
+            if (totalRoots >= maxRoots) {
+                rootLimitReached = true;
+                break;
+            }
+
+            GuScriptProgramCache cache = GuScriptCompiler.compilePageIfNeeded(attachment, page, pageIndex, gameTime);
+            List<GuNode> roots = cache.roots();
+            if (roots.isEmpty()) {
+                ChestCavity.LOGGER.debug("[GuScript] Keybind page {} contributed no roots", pageIndex);
+                continue;
+            }
+
+            int remainingRootBudget = maxRoots - totalRoots;
+            if (roots.size() > remainingRootBudget) {
+                if (remainingRootBudget <= 0) {
+                    rootLimitReached = true;
+                    if (!unlimitedRoots) {
+                        ChestCavity.LOGGER.warn(
+                                "[GuScript] Keybind trigger hit max root limit {} before processing page {}",
+                                maxRoots,
+                                pageIndex
+                        );
+                    }
+                    break;
+                }
+                aggregatedRoots.addAll(roots.subList(0, remainingRootBudget));
+                totalRoots += remainingRootBudget;
+                executedPages++;
+                rootLimitReached = true;
+                ChestCavity.LOGGER.warn(
+                        "[GuScript] Keybind page {} truncated to {} roots due to max root limit {} (running total {})",
+                        pageIndex,
+                        remainingRootBudget,
+                        unlimitedRoots ? "unlimited" : maxRoots,
+                        totalRoots
+                );
+                break;
+            }
+
+            aggregatedRoots.addAll(roots);
+            totalRoots += roots.size();
+            executedPages++;
+            ChestCavity.LOGGER.info(
+                    "[GuScript] Keybind page {} queued {} roots (running total {})",
+                    pageIndex,
+                    roots.size(),
+                    totalRoots
+            );
+        }
+
+        if (aggregatedRoots.isEmpty()) {
+            ChestCavity.LOGGER.info(
+                    "[GuScript] Keybind trigger for {} found {} eligible pages but no executable roots",
+                    player.getGameProfile().getName(),
+                    eligiblePages
+            );
+            return;
+        }
+
+        ChestCavity.LOGGER.info(
+                "[GuScript] Keybind trigger for {}: {} keybind pages ({} executed) -> {} roots. Limits: pages={}, roots={}. Executing sequentially.",
+                player.getGameProfile().getName(),
+                eligiblePages,
+                executedPages,
+                totalRoots,
+                unlimitedPages ? "unlimited" : maxPages,
+                unlimitedRoots ? "unlimited" : maxRoots
+        );
+        if (pageLimitReached) {
+            ChestCavity.LOGGER.warn(
+                    "[GuScript] Keybind trigger skipped remaining pages due to max page limit {}",
+                    unlimitedPages ? "unlimited" : maxPages
+            );
+        }
+        if (rootLimitReached && !unlimitedRoots) {
+            ChestCavity.LOGGER.warn(
+                    "[GuScript] Keybind trigger reached max root limit {}. Additional roots were not executed.",
+                    maxRoots
+            );
+        }
+
+        RUNTIME.executeAll(aggregatedRoots, index -> {
             LivingEntity actualTarget = target == null ? player : target;
             DefaultGuScriptExecutionBridge bridge = new DefaultGuScriptExecutionBridge(player, actualTarget, index);
             return new DefaultGuScriptContext(player, actualTarget, bridge);


### PR DESCRIPTION
## Summary
- execute GuScript keybind triggers across every page marked for keybind use and aggregate their compiled roots
- add logging and configurable safeguards that cap the number of pages and roots run per trigger
- expose the new execution limits through the config so they can be tuned without code changes

## Testing
- ./gradlew --console=plain compileJava

------
https://chatgpt.com/codex/tasks/task_e_68d8850b2fd88326888a4529a3399411