### PR TITLE
Ensure GuScript triggers execute each root with a fresh context

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/guscript/command/GuScriptCommands.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/command/GuScriptCommands.java
@@ -23,6 +23,7 @@ import net.tigereye.chestcavity.guscript.runtime.reduce.GuScriptReducer;
 import net.tigereye.chestcavity.guscript.runtime.reduce.ReactionRule;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public final class GuScriptCommands {
 
@@ -75,8 +76,12 @@ public final class GuScriptCommands {
         }
 
         GuScriptRuntime runtime = new GuScriptRuntime();
-        runtime.executeAll(result.roots(), index ->
-                new DefaultGuScriptContext(player, player, new DefaultGuScriptExecutionBridge(player, player, index)));
+        AtomicInteger rootIndex = new AtomicInteger();
+        runtime.executeAll(result.roots(), () -> {
+            int index = rootIndex.getAndIncrement();
+            DefaultGuScriptExecutionBridge bridge = new DefaultGuScriptExecutionBridge(player, player, index);
+            return new DefaultGuScriptContext(player, player, bridge);
+        });
 
         source.sendSuccess(() -> Component.literal("已执行 GuScript 示例，生成 " + result.roots().size() + " 个根节点"), true);
         return result.roots().size();

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutor.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutor.java
@@ -13,6 +13,7 @@ import net.tigereye.chestcavity.guscript.runtime.action.DefaultGuScriptExecution
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Executes compiled GuScript programs for a player.
@@ -50,8 +51,10 @@ public final class GuScriptExecutor {
                         .map(root -> root.kind() + ":" + root.name())
                         .toList()
         );
-        RUNTIME.executeAll(cache.roots(), index -> {
-            LivingEntity actualTarget = target == null ? player : target;
+        LivingEntity actualTarget = target == null ? player : target;
+        AtomicInteger rootIndex = new AtomicInteger();
+        RUNTIME.executeAll(cache.roots(), () -> {
+            int index = rootIndex.getAndIncrement();
             DefaultGuScriptExecutionBridge bridge = new DefaultGuScriptExecutionBridge(player, actualTarget, index);
             return new DefaultGuScriptContext(player, actualTarget, bridge);
         });
@@ -176,8 +179,10 @@ public final class GuScriptExecutor {
             );
         }
 
-        RUNTIME.executeAll(aggregatedRoots, index -> {
-            LivingEntity actualTarget = target == null ? player : target;
+        LivingEntity actualTarget = target == null ? player : target;
+        AtomicInteger rootIndex = new AtomicInteger();
+        RUNTIME.executeAll(aggregatedRoots, () -> {
+            int index = rootIndex.getAndIncrement();
             DefaultGuScriptExecutionBridge bridge = new DefaultGuScriptExecutionBridge(player, actualTarget, index);
             return new DefaultGuScriptContext(player, actualTarget, bridge);
         });


### PR DESCRIPTION
## Summary
- update `GuScriptRuntime` to accept `Supplier<GuScriptContext>` and create dedicated contexts per root with additional diagnostics
- refactor trigger paths to build a new `DefaultGuScriptContext`/`DefaultGuScriptExecutionBridge` for every executed root
- adjust the GuScript demo command to follow the new supplier-based runtime API

## Testing
- ./gradlew compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d8b35c12c88326a3af7558b34e5c09