### PR TITLE
Add GuScript FX registry and client emitters

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/guscript/actions/TriggerFxAction.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/actions/TriggerFxAction.java
@@ -1,0 +1,48 @@
+package net.tigereye.chestcavity.guscript.actions;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.guscript.ast.Action;
+import net.tigereye.chestcavity.guscript.fx.FxEventParameters;
+import net.tigereye.chestcavity.guscript.runtime.exec.GuScriptContext;
+
+import java.util.Objects;
+
+/**
+ * Action that dispatches a configured FX bundle through the execution bridge.
+ */
+public final class TriggerFxAction implements Action {
+
+    public static final String ID = "emit.fx";
+
+    private final ResourceLocation fxId;
+    private final FxEventParameters parameters;
+
+    public TriggerFxAction(ResourceLocation fxId, FxEventParameters parameters) {
+        this.fxId = Objects.requireNonNull(fxId, "FX id");
+        this.parameters = parameters == null ? FxEventParameters.DEFAULT : parameters;
+    }
+
+    @Override
+    public String id() {
+        return ID;
+    }
+
+    @Override
+    public String description() {
+        return "Trigger FX " + fxId;
+    }
+
+    @Override
+    public void execute(GuScriptContext context) {
+        if (context == null || context.bridge() == null) {
+            return;
+        }
+        context.bridge().playFx(fxId, parameters);
+    }
+
+    public static TriggerFxAction from(ResourceLocation fxId, Vec3 originOffset, Vec3 targetOffset, float intensity) {
+        FxEventParameters parameters = new FxEventParameters(originOffset, targetOffset, intensity);
+        return new TriggerFxAction(fxId, parameters);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/fx/FxDefinition.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/fx/FxDefinition.java
@@ -1,0 +1,60 @@
+package net.tigereye.chestcavity.guscript.fx;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.List;
+
+/**
+ * Data-driven FX definition parsed from resource JSON.
+ */
+public record FxDefinition(List<FxModule> modules) {
+
+    public FxDefinition {
+        modules = modules == null ? List.of() : List.copyOf(modules);
+    }
+
+    public interface FxModule {
+    }
+
+    public record ParticleModule(ParticleSettings settings, Vec3 offset, int count) implements FxModule {
+        public ParticleModule {
+            settings = settings == null ? ParticleSettings.DEFAULT : settings;
+            offset = offset == null ? Vec3.ZERO : offset;
+            count = Math.max(1, count);
+        }
+    }
+
+    public record SoundModule(ResourceLocation soundId, float volume, float pitch) implements FxModule {
+        public SoundModule {
+            volume = Math.max(0.0F, volume);
+            pitch = Math.max(0.0F, pitch);
+        }
+    }
+
+    public record ScreenShakeModule(float intensity, int durationTicks) implements FxModule {
+        public ScreenShakeModule {
+            intensity = Math.max(0.0F, intensity);
+            durationTicks = Math.max(0, durationTicks);
+        }
+    }
+
+    public record TrailModule(ParticleSettings settings, Vec3 offset, int segments, double spacing) implements FxModule {
+        public TrailModule {
+            settings = settings == null ? ParticleSettings.DEFAULT : settings;
+            offset = offset == null ? Vec3.ZERO : offset;
+            segments = Math.max(1, segments);
+            spacing = spacing <= 0.0D ? 0.2D : spacing;
+        }
+    }
+
+    public record ParticleSettings(ResourceLocation particleId, double speed, Vec3 spread, Integer color, float size) {
+        static final ParticleSettings DEFAULT = new ParticleSettings(ResourceLocation.fromNamespaceAndPath("minecraft", "crit"), 0.0D, Vec3.ZERO, null, 1.0F);
+
+        public ParticleSettings {
+            speed = Math.max(0.0D, speed);
+            spread = spread == null ? Vec3.ZERO : spread;
+            size = Math.max(0.0F, size);
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/fx/FxEventParameters.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/fx/FxEventParameters.java
@@ -1,0 +1,17 @@
+package net.tigereye.chestcavity.guscript.fx;
+
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Additional parameters supplied when dispatching an FX event from the server.
+ */
+public record FxEventParameters(Vec3 originOffset, Vec3 targetOffset, float intensity) {
+
+    public static final FxEventParameters DEFAULT = new FxEventParameters(Vec3.ZERO, Vec3.ZERO, 1.0F);
+
+    public FxEventParameters {
+        originOffset = originOffset == null ? Vec3.ZERO : originOffset;
+        targetOffset = targetOffset == null ? Vec3.ZERO : targetOffset;
+        intensity = Float.isNaN(intensity) || intensity <= 0.0F ? 1.0F : intensity;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/fx/FxRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/fx/FxRegistry.java
@@ -1,0 +1,168 @@
+package net.tigereye.chestcavity.guscript.fx;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.particles.DustParticleOptions;
+import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.core.particles.ParticleType;
+import net.minecraft.core.particles.SimpleParticleType;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.guscript.fx.FxDefinition.ParticleModule;
+import net.tigereye.chestcavity.guscript.fx.FxDefinition.ParticleSettings;
+import net.tigereye.chestcavity.guscript.fx.FxDefinition.ScreenShakeModule;
+import net.tigereye.chestcavity.guscript.fx.FxDefinition.SoundModule;
+import net.tigereye.chestcavity.guscript.fx.FxDefinition.TrailModule;
+import net.tigereye.chestcavity.guscript.fx.client.FxClientHooks;
+import org.joml.Vector3f;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Registry storing FX definitions and providing client-side playback utilities.
+ */
+public final class FxRegistry {
+
+    private static final Map<ResourceLocation, FxDefinition> DEFINITIONS = new HashMap<>();
+
+    private FxRegistry() {}
+
+    public static synchronized void updateDefinitions(Map<ResourceLocation, FxDefinition> definitions) {
+        DEFINITIONS.clear();
+        DEFINITIONS.putAll(definitions);
+        ChestCavity.LOGGER.info("[GuScript] Loaded {} FX definitions", DEFINITIONS.size());
+    }
+
+    public static synchronized Optional<FxDefinition> definition(ResourceLocation id) {
+        return Optional.ofNullable(DEFINITIONS.get(id));
+    }
+
+    public static synchronized Map<ResourceLocation, FxDefinition> snapshot() {
+        return Collections.unmodifiableMap(new HashMap<>(DEFINITIONS));
+    }
+
+    public static void play(ResourceLocation id, FxContext context) {
+        if (id == null || context == null) {
+            return;
+        }
+        FxDefinition definition = definition(id).orElse(null);
+        if (definition == null) {
+            ChestCavity.LOGGER.warn("[GuScript] Unknown FX id {}", id);
+            return;
+        }
+        Minecraft minecraft = Minecraft.getInstance();
+        ClientLevel level = minecraft.level;
+        if (level == null) {
+            return;
+        }
+        RandomSource random = level.getRandom();
+        for (FxDefinition.FxModule module : definition.modules()) {
+            if (module instanceof SoundModule soundModule) {
+                playSound(level, context, soundModule);
+            } else if (module instanceof ParticleModule particleModule) {
+                spawnParticles(level, context, particleModule, random);
+            } else if (module instanceof TrailModule trailModule) {
+                spawnTrail(level, context, trailModule, random);
+            } else if (module instanceof ScreenShakeModule screenShake) {
+                FxClientHooks.addScreenShake(screenShake.intensity() * context.intensity(), screenShake.durationTicks());
+            }
+        }
+    }
+
+    private static void playSound(ClientLevel level, FxContext context, SoundModule module) {
+        SoundEvent event = BuiltInRegistries.SOUND_EVENT.get(module.soundId());
+        if (event == null) {
+            ChestCavity.LOGGER.warn("[GuScript] Unknown sound event {}", module.soundId());
+            return;
+        }
+        level.playLocalSound(context.origin().x, context.origin().y, context.origin().z, event, SoundSource.PLAYERS, module.volume() * context.intensity(), module.pitch(), false);
+    }
+
+    private static void spawnParticles(ClientLevel level, FxContext context, ParticleModule module, RandomSource random) {
+        ParticleOptions options = resolveParticleOptions(module.settings());
+        if (options == null) {
+            return;
+        }
+        int count = Math.max(1, Math.round(module.count() * context.intensity()));
+        Vec3 origin = context.origin().add(module.offset());
+        Vec3 spread = module.settings().spread();
+        double speed = module.settings().speed();
+        for (int i = 0; i < count; i++) {
+            double dx = random.nextGaussian() * spread.x;
+            double dy = random.nextGaussian() * spread.y;
+            double dz = random.nextGaussian() * spread.z;
+            level.addParticle(options, origin.x + dx, origin.y + dy, origin.z + dz, dx * speed, dy * speed, dz * speed);
+        }
+    }
+
+    private static void spawnTrail(ClientLevel level, FxContext context, TrailModule module, RandomSource random) {
+        ParticleOptions options = resolveParticleOptions(module.settings());
+        if (options == null) {
+            return;
+        }
+        Vec3 direction = context.resolveDirection();
+        if (direction.lengthSqr() < 1.0E-4) {
+            direction = new Vec3(0.0, 1.0, 0.0);
+        }
+        direction = direction.normalize().scale(module.spacing());
+        Vec3 start = context.origin().add(module.offset());
+        Vec3 current = start;
+        int segments = Math.max(1, Math.round(module.segments() * context.intensity()));
+        Vec3 spread = module.settings().spread();
+        double speed = module.settings().speed();
+        for (int i = 0; i < segments; i++) {
+            double dx = random.nextGaussian() * spread.x;
+            double dy = random.nextGaussian() * spread.y;
+            double dz = random.nextGaussian() * spread.z;
+            level.addParticle(options, current.x + dx, current.y + dy, current.z + dz, dx * speed, dy * speed, dz * speed);
+            current = current.add(direction);
+        }
+    }
+
+    private static ParticleOptions resolveParticleOptions(ParticleSettings settings) {
+        ParticleType<?> type = BuiltInRegistries.PARTICLE_TYPE.get(settings.particleId());
+        if (type == null) {
+            ChestCavity.LOGGER.warn("[GuScript] Unknown particle type {}", settings.particleId());
+            return null;
+        }
+        if (type instanceof SimpleParticleType simple) {
+            return simple;
+        }
+        if ("minecraft:dust".equals(settings.particleId().toString()) && settings.color() != null) {
+            float r = ((settings.color() >> 16) & 0xFF) / 255.0F;
+            float g = ((settings.color() >> 8) & 0xFF) / 255.0F;
+            float b = (settings.color() & 0xFF) / 255.0F;
+            float size = settings.size() <= 0.0F ? 1.0F : settings.size();
+            return new DustParticleOptions(new Vector3f(r, g, b), size);
+        }
+        ChestCavity.LOGGER.warn("[GuScript] Unsupported particle type {} for FX", settings.particleId());
+        return null;
+    }
+
+    public record FxContext(Vec3 origin, Vec3 fallbackDirection, Vec3 look, Vec3 target, float intensity, int performerId, int targetId) {
+        public FxContext {
+            origin = origin == null ? Vec3.ZERO : origin;
+            fallbackDirection = fallbackDirection == null ? Vec3.ZERO : fallbackDirection;
+            look = look == null ? Vec3.ZERO : look;
+            intensity = Float.isNaN(intensity) || intensity <= 0.0F ? 1.0F : intensity;
+        }
+
+        public Vec3 resolveDirection() {
+            if (target != null) {
+                return target.subtract(origin);
+            }
+            if (fallbackDirection.lengthSqr() > 1.0E-4) {
+                return fallbackDirection;
+            }
+            return look;
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/fx/client/FxClientDispatcher.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/fx/client/FxClientDispatcher.java
@@ -1,0 +1,22 @@
+package net.tigereye.chestcavity.guscript.fx.client;
+
+import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.guscript.fx.FxRegistry;
+import net.tigereye.chestcavity.guscript.network.packets.FxEventPayload;
+
+/**
+ * Applies incoming FX network payloads on the client.
+ */
+public final class FxClientDispatcher {
+
+    private FxClientDispatcher() {}
+
+    public static void handle(FxEventPayload payload) {
+        Vec3 origin = new Vec3(payload.originX(), payload.originY(), payload.originZ());
+        Vec3 fallback = new Vec3(payload.directionX(), payload.directionY(), payload.directionZ());
+        Vec3 look = new Vec3(payload.lookX(), payload.lookY(), payload.lookZ());
+        Vec3 target = payload.hasTarget() ? new Vec3(payload.targetX(), payload.targetY(), payload.targetZ()) : null;
+        FxRegistry.FxContext context = new FxRegistry.FxContext(origin, fallback, look, target, payload.intensity(), payload.performerId(), payload.targetId());
+        FxRegistry.play(payload.effectId(), context);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/fx/client/FxClientHooks.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/fx/client/FxClientHooks.java
@@ -1,0 +1,77 @@
+package net.tigereye.chestcavity.guscript.fx.client;
+
+import net.minecraft.util.RandomSource;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
+import net.neoforged.neoforge.client.event.ViewportEvent;
+import net.neoforged.neoforge.common.NeoForge;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Client-only helpers for registering FX event hooks such as screen shake.
+ */
+public final class FxClientHooks {
+
+    private static final List<ScreenShakeInstance> SHAKES = new ArrayList<>();
+    private static final RandomSource RANDOM = RandomSource.create();
+    private static boolean registered = false;
+
+    private FxClientHooks() {}
+
+    public static void init() {
+        if (registered) {
+            return;
+        }
+        registered = true;
+        NeoForge.EVENT_BUS.addListener(FxClientHooks::onClientTick);
+        NeoForge.EVENT_BUS.addListener(FxClientHooks::onComputeCameraAngles);
+    }
+
+    public static void addScreenShake(double intensity, int durationTicks) {
+        if (intensity <= 0.0D || durationTicks <= 0) {
+            return;
+        }
+        SHAKES.add(new ScreenShakeInstance(intensity, durationTicks));
+    }
+
+    private static void onClientTick(ClientTickEvent.Post event) {
+        Iterator<ScreenShakeInstance> iterator = SHAKES.iterator();
+        while (iterator.hasNext()) {
+            ScreenShakeInstance instance = iterator.next();
+            instance.remainingTicks--;
+            if (instance.remainingTicks <= 0) {
+                iterator.remove();
+            }
+        }
+    }
+
+    private static void onComputeCameraAngles(ViewportEvent.ComputeCameraAngles event) {
+        if (SHAKES.isEmpty()) {
+            return;
+        }
+        double yaw = 0.0D;
+        double pitch = 0.0D;
+        double roll = 0.0D;
+        for (ScreenShakeInstance instance : SHAKES) {
+            double strength = instance.intensity;
+            yaw += (RANDOM.nextDouble() - 0.5D) * 2.0D * strength;
+            pitch += (RANDOM.nextDouble() - 0.5D) * 2.0D * strength;
+            roll += (RANDOM.nextDouble() - 0.5D) * strength;
+        }
+        event.setYaw((float) (event.getYaw() + yaw));
+        event.setPitch((float) (event.getPitch() + pitch));
+        event.setRoll((float) (event.getRoll() + roll));
+    }
+
+    private static final class ScreenShakeInstance {
+        private final double intensity;
+        private int remainingTicks;
+
+        private ScreenShakeInstance(double intensity, int duration) {
+            this.intensity = intensity;
+            this.remainingTicks = duration;
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/network/packets/FxEventPayload.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/network/packets/FxEventPayload.java
@@ -1,0 +1,93 @@
+package net.tigereye.chestcavity.guscript.network.packets;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.guscript.fx.client.FxClientDispatcher;
+
+/**
+ * Server-to-client payload for dispatching GuScript FX events.
+ */
+public record FxEventPayload(
+        ResourceLocation effectId,
+        double originX,
+        double originY,
+        double originZ,
+        float directionX,
+        float directionY,
+        float directionZ,
+        float lookX,
+        float lookY,
+        float lookZ,
+        float intensity,
+        boolean hasTarget,
+        double targetX,
+        double targetY,
+        double targetZ,
+        int performerId,
+        int targetId
+) implements CustomPacketPayload {
+
+    public static final Type<FxEventPayload> TYPE = new Type<>(ChestCavity.id("guscript_fx_event"));
+
+    public static final StreamCodec<FriendlyByteBuf, FxEventPayload> STREAM_CODEC = StreamCodec.of(
+            (buf, payload) -> {
+                buf.writeResourceLocation(payload.effectId);
+                buf.writeDouble(payload.originX);
+                buf.writeDouble(payload.originY);
+                buf.writeDouble(payload.originZ);
+                buf.writeFloat(payload.directionX);
+                buf.writeFloat(payload.directionY);
+                buf.writeFloat(payload.directionZ);
+                buf.writeFloat(payload.lookX);
+                buf.writeFloat(payload.lookY);
+                buf.writeFloat(payload.lookZ);
+                buf.writeFloat(payload.intensity);
+                buf.writeBoolean(payload.hasTarget);
+                if (payload.hasTarget) {
+                    buf.writeDouble(payload.targetX);
+                    buf.writeDouble(payload.targetY);
+                    buf.writeDouble(payload.targetZ);
+                }
+                buf.writeVarInt(payload.performerId);
+                buf.writeVarInt(payload.targetId);
+            },
+            buf -> {
+                ResourceLocation effectId = buf.readResourceLocation();
+                double originX = buf.readDouble();
+                double originY = buf.readDouble();
+                double originZ = buf.readDouble();
+                float directionX = buf.readFloat();
+                float directionY = buf.readFloat();
+                float directionZ = buf.readFloat();
+                float lookX = buf.readFloat();
+                float lookY = buf.readFloat();
+                float lookZ = buf.readFloat();
+                float intensity = buf.readFloat();
+                boolean hasTarget = buf.readBoolean();
+                double targetX = hasTarget ? buf.readDouble() : 0.0D;
+                double targetY = hasTarget ? buf.readDouble() : 0.0D;
+                double targetZ = hasTarget ? buf.readDouble() : 0.0D;
+                int performerId = buf.readVarInt();
+                int targetId = buf.readVarInt();
+                return new FxEventPayload(effectId, originX, originY, originZ, directionX, directionY, directionZ, lookX, lookY, lookZ, intensity, hasTarget, targetX, targetY, targetZ, performerId, targetId);
+            }
+    );
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+
+    public static void handle(FxEventPayload payload, IPayloadContext context) {
+        context.enqueueWork(() -> {
+            if (FMLEnvironment.dist.isClient()) {
+                FxClientDispatcher.handle(payload);
+            }
+        });
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/registry/FxDefinitionLoader.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/registry/FxDefinitionLoader.java
@@ -1,0 +1,146 @@
+package net.tigereye.chestcavity.guscript.registry;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.guscript.fx.FxDefinition;
+import net.tigereye.chestcavity.guscript.fx.FxDefinition.ParticleModule;
+import net.tigereye.chestcavity.guscript.fx.FxDefinition.ParticleSettings;
+import net.tigereye.chestcavity.guscript.fx.FxDefinition.ScreenShakeModule;
+import net.tigereye.chestcavity.guscript.fx.FxDefinition.SoundModule;
+import net.tigereye.chestcavity.guscript.fx.FxDefinition.TrailModule;
+import net.tigereye.chestcavity.guscript.fx.FxRegistry;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Loads FX definitions for GuScript from resource data packs.
+ */
+public final class FxDefinitionLoader extends SimpleJsonResourceReloadListener {
+
+    private static final Gson GSON = new GsonBuilder().setLenient().create();
+
+    public FxDefinitionLoader() {
+        super(GSON, "guscript/fx");
+    }
+
+    @Override
+    protected void apply(Map<ResourceLocation, JsonElement> object, ResourceManager resourceManager, ProfilerFiller profiler) {
+        Map<ResourceLocation, FxDefinition> definitions = new HashMap<>();
+        object.forEach((id, element) -> {
+            try {
+                JsonObject json = element.getAsJsonObject();
+                List<FxDefinition.FxModule> modules = new ArrayList<>();
+                JsonArray moduleArray = GsonHelper.getAsJsonArray(json, "modules", new JsonArray());
+                for (JsonElement moduleElement : moduleArray) {
+                    if (!moduleElement.isJsonObject()) {
+                        continue;
+                    }
+                    JsonObject moduleJson = moduleElement.getAsJsonObject();
+                    String type = GsonHelper.getAsString(moduleJson, "type", "particle");
+                    switch (type) {
+                        case "particle" -> modules.add(parseParticleModule(moduleJson));
+                        case "sound" -> modules.add(parseSoundModule(moduleJson));
+                        case "screen_shake" -> modules.add(parseScreenShakeModule(moduleJson));
+                        case "trail" -> modules.add(parseTrailModule(moduleJson));
+                        default -> ChestCavity.LOGGER.warn("[GuScript] Unknown FX module type {} in {}", type, id);
+                    }
+                }
+                definitions.put(id, new FxDefinition(modules));
+            } catch (Exception ex) {
+                ChestCavity.LOGGER.error("[GuScript] Failed to parse FX definition {}", id, ex);
+            }
+        });
+        FxRegistry.updateDefinitions(definitions);
+    }
+
+    private static ParticleModule parseParticleModule(JsonObject json) {
+        ParticleSettings settings = parseParticleSettings(json);
+        Vec3 offset = readVec3(json, "offset");
+        int count = GsonHelper.getAsInt(json, "count", 6);
+        return new ParticleModule(settings, offset, count);
+    }
+
+    private static SoundModule parseSoundModule(JsonObject json) {
+        ResourceLocation soundId = ResourceLocation.parse(GsonHelper.getAsString(json, "sound"));
+        float volume = GsonHelper.getAsFloat(json, "volume", 1.0F);
+        float pitch = GsonHelper.getAsFloat(json, "pitch", 1.0F);
+        return new SoundModule(soundId, volume, pitch);
+    }
+
+    private static ScreenShakeModule parseScreenShakeModule(JsonObject json) {
+        float intensity = GsonHelper.getAsFloat(json, "intensity", 0.2F);
+        int duration = GsonHelper.getAsInt(json, "duration", 5);
+        return new ScreenShakeModule(intensity, duration);
+    }
+
+    private static TrailModule parseTrailModule(JsonObject json) {
+        ParticleSettings settings = parseParticleSettings(json);
+        Vec3 offset = readVec3(json, "offset");
+        int segments = GsonHelper.getAsInt(json, "segments", 8);
+        double spacing = GsonHelper.getAsDouble(json, "spacing", 0.25D);
+        return new TrailModule(settings, offset, segments, spacing);
+    }
+
+    private static ParticleSettings parseParticleSettings(JsonObject json) {
+        ResourceLocation particleId = ResourceLocation.parse(GsonHelper.getAsString(json, "particle", "minecraft:crit"));
+        double speed = GsonHelper.getAsDouble(json, "speed", 0.05D);
+        Vec3 spread = readVec3(json, "spread", 0.15D);
+        Integer color = json.has("color") ? parseColor(json.get("color")) : null;
+        float size = GsonHelper.getAsFloat(json, "size", 1.0F);
+        return new ParticleSettings(particleId, speed, spread, color, size);
+    }
+
+    private static Vec3 readVec3(JsonObject json, String key) {
+        return readVec3(json, key, 0.0D);
+    }
+
+    private static Vec3 readVec3(JsonObject json, String key, double defaultComponent) {
+        if (!json.has(key)) {
+            return new Vec3(defaultComponent, defaultComponent, defaultComponent);
+        }
+        JsonElement element = json.get(key);
+        if (element.isJsonArray()) {
+            JsonArray array = element.getAsJsonArray();
+            double x = array.size() > 0 ? array.get(0).getAsDouble() : defaultComponent;
+            double y = array.size() > 1 ? array.get(1).getAsDouble() : defaultComponent;
+            double z = array.size() > 2 ? array.get(2).getAsDouble() : defaultComponent;
+            return new Vec3(x, y, z);
+        }
+        double value = element.getAsDouble();
+        return new Vec3(value, value, value);
+    }
+
+    private static Integer parseColor(JsonElement element) {
+        if (element == null) {
+            return null;
+        }
+        if (element.isJsonPrimitive()) {
+            String raw = element.getAsString().trim();
+            try {
+                if (raw.startsWith("#")) {
+                    return Integer.parseInt(raw.substring(1), 16);
+                }
+                if (raw.startsWith("0x")) {
+                    return Integer.parseInt(raw.substring(2), 16);
+                }
+                return Integer.parseInt(raw, 16);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        ChestCavity.LOGGER.warn("[GuScript] Invalid color value {}", element);
+        return null;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/action/ActionRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/action/ActionRegistry.java
@@ -1,14 +1,18 @@
 package net.tigereye.chestcavity.guscript.runtime.action;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import net.tigereye.chestcavity.guscript.actions.AddDamageMultiplierAction;
 import net.tigereye.chestcavity.guscript.actions.AddFlatDamageAction;
 import net.tigereye.chestcavity.guscript.actions.ConsumeHealthAction;
 import net.tigereye.chestcavity.guscript.actions.ConsumeZhenyuanAction;
 import net.tigereye.chestcavity.guscript.actions.EmitProjectileAction;
+import net.tigereye.chestcavity.guscript.actions.TriggerFxAction;
 import net.tigereye.chestcavity.guscript.ast.Action;
 import net.tigereye.chestcavity.guscript.actions.ExportFlatModifierAction;
 import net.tigereye.chestcavity.guscript.actions.ExportMultiplierModifierAction;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.phys.Vec3;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,6 +44,12 @@ public final class ActionRegistry {
         register(AddFlatDamageAction.ID, json -> new AddFlatDamageAction(json.get("amount").getAsDouble()));
         register(ExportMultiplierModifierAction.ID, json -> new ExportMultiplierModifierAction(json.get("amount").getAsDouble()));
         register(ExportFlatModifierAction.ID, json -> new ExportFlatModifierAction(json.get("amount").getAsDouble()));
+        register(TriggerFxAction.ID, json -> TriggerFxAction.from(
+                ResourceLocation.parse(json.get("fxId").getAsString()),
+                readVec3(json, "originOffset"),
+                readVec3(json, "targetOffset"),
+                json.has("intensity") ? json.get("intensity").getAsFloat() : 1.0F
+        ));
     }
 
     public static void register(String id, Function<JsonObject, Action> factory) {
@@ -56,5 +66,19 @@ public final class ActionRegistry {
             throw new IllegalArgumentException("Unknown action id: " + id);
         }
         return factory.apply(json);
+    }
+
+    private static Vec3 readVec3(JsonObject json, String key) {
+        if (!json.has(key)) {
+            return Vec3.ZERO;
+        }
+        JsonArray array = json.getAsJsonArray(key);
+        if (array == null || array.size() == 0) {
+            return Vec3.ZERO;
+        }
+        double x = array.size() > 0 ? array.get(0).getAsDouble() : 0.0D;
+        double y = array.size() > 1 ? array.get(1).getAsDouble() : 0.0D;
+        double z = array.size() > 2 ? array.get(2).getAsDouble() : 0.0D;
+        return new Vec3(x, y, z);
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutionBridge.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutionBridge.java
@@ -1,9 +1,13 @@
 package net.tigereye.chestcavity.guscript.runtime.exec;
 
+import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.guscript.fx.FxEventParameters;
+
 /**
  * Bridge exposed to action execution for resource manipulation and effect dispatch.
  * Concrete implementations should wire into ChestCavity/Guzhenren systems.
  */
+
 public interface GuScriptExecutionBridge {
 
     void consumeZhenyuan(int amount);
@@ -11,4 +15,6 @@ public interface GuScriptExecutionBridge {
     void consumeHealth(int amount);
 
     void emitProjectile(String projectileId, double damage);
+
+    void playFx(ResourceLocation fxId, FxEventParameters parameters);
 }

--- a/src/main/java/net/tigereye/chestcavity/network/NetworkHandler.java
+++ b/src/main/java/net/tigereye/chestcavity/network/NetworkHandler.java
@@ -21,6 +21,7 @@ import net.tigereye.chestcavity.guscript.network.packets.GuScriptBindingTogglePa
 import net.tigereye.chestcavity.guscript.network.packets.GuScriptOpenPayload;
 import net.tigereye.chestcavity.guscript.network.packets.GuScriptPageChangePayload;
 import net.tigereye.chestcavity.guscript.network.packets.GuScriptTriggerPayload;
+import net.tigereye.chestcavity.guscript.network.packets.FxEventPayload;
 
 public final class NetworkHandler {
 
@@ -37,6 +38,7 @@ public final class NetworkHandler {
         registrar.playToClient(ChestCavityUpdatePayload.TYPE, ChestCavityUpdatePayload.STREAM_CODEC, ChestCavityUpdatePayload::handle);
         registrar.playToClient(OrganDataPayload.TYPE, OrganDataPayload.STREAM_CODEC, OrganDataPayload::handle);
         registrar.playToClient(ChestCavityOrganSlotUpdatePayload.TYPE, ChestCavityOrganSlotUpdatePayload.STREAM_CODEC, ChestCavityOrganSlotUpdatePayload::handle);
+        registrar.playToClient(FxEventPayload.TYPE, FxEventPayload.STREAM_CODEC, FxEventPayload::handle);
     }
 
 

--- a/src/main/resources/data/chestcavity/guscript/fx/burst.json
+++ b/src/main/resources/data/chestcavity/guscript/fx/burst.json
@@ -1,0 +1,24 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:entity.generic.explode",
+      "volume": 0.6,
+      "pitch": 0.9
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:dust",
+      "color": "#ff4422",
+      "size": 1.2,
+      "count": 18,
+      "speed": 0.25,
+      "spread": [0.45, 0.3, 0.45]
+    },
+    {
+      "type": "screen_shake",
+      "intensity": 0.22,
+      "duration": 8
+    }
+  ]
+}

--- a/src/main/resources/data/chestcavity/guscript/fx/slash.json
+++ b/src/main/resources/data/chestcavity/guscript/fx/slash.json
@@ -1,0 +1,33 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:entity.player.attack.sweep",
+      "volume": 0.9,
+      "pitch": 1.05
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:crit",
+      "count": 12,
+      "speed": 0.15,
+      "spread": [0.35, 0.15, 0.35],
+      "offset": [0.0, 0.8, 0.0]
+    },
+    {
+      "type": "screen_shake",
+      "intensity": 0.18,
+      "duration": 6
+    },
+    {
+      "type": "trail",
+      "particle": "minecraft:dust",
+      "color": "#ffcc55",
+      "size": 1.0,
+      "segments": 8,
+      "spacing": 0.25,
+      "spread": [0.05, 0.05, 0.05],
+      "offset": [0.0, 0.6, 0.0]
+    }
+  ]
+}

--- a/src/main/resources/data/chestcavity/guscript/leaves/gunpowder.json
+++ b/src/main/resources/data/chestcavity/guscript/leaves/gunpowder.json
@@ -3,6 +3,12 @@
   "name": "爆发蛊",
   "tags": ["爆发"],
   "actions": [
-    { "id": "modifier.damage_multiplier", "amount": 0.5 }
+    { "id": "modifier.damage_multiplier", "amount": 0.5 },
+    {
+      "id": "emit.fx",
+      "fxId": "chestcavity:burst",
+      "intensity": 1.0,
+      "originOffset": [0.0, 0.75, 0.0]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- add a data-driven GuScript FX registry, loader, and client emitters for particles, sounds, trails, and screen shake
- introduce an FX trigger action plus networking payload so GuScript executions can dispatch FX bundles to clients
- register default FX definitions and wire gunpowder leaves to a burst effect

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68d8c65341e88326ab8fd0aa789aacb6