### PR TITLE
Add data-driven GuScript flow controller MVP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 - If an instruction would require code changes beyond documentation/notes, pause and request the user to route it to the web Codex worker.
 
 ## 2025-10-XX Pending tasks handoff (requires web Codex implementation)
+- **New request 2025-??-??**: Implement Flow core MVP (`feature/guscript-flow-modules`). Deliverables include FlowProgram/FlowInstance/FlowController with Idle/Charging/Charged/Releasing/Cooldown/Cancel states, resource/cooldown guards, edge actions (resource deduction, cooldown set, GuScript action triggers). Load and validate `data/chestcavity/guscript/flows/*.json` with error logging. Mirror state/time via `S2C FlowSyncPayload` containing minimal fields. Acceptance: server-driven "charge → release" demo stays in sync on client.
 - **Bug: multiple kill moves on shared trigger execute only one**
   - Scenario: same GuScript page stores several fully reduced “杀招” nodes with identical trigger (e.g., keybind or listener). Currently `GuScriptExecutor`/`GuScriptRuntime` only fires the first result; later roots never cast. Investigate `GuScriptCompiler` + `GuScriptRuntime.executeAll` to ensure every compiled root invokes its actions without being short-circuited.
   - Notes from CLI review: compiler now iterates all page slots (minus binding slot) when building leaf list. Verify reducer isn’t collapsing siblings or returning mixed leaf remnants. Add regression coverage once fixed.

--- a/src/main/java/net/tigereye/chestcavity/ChestCavity.java
+++ b/src/main/java/net/tigereye/chestcavity/ChestCavity.java
@@ -27,9 +27,11 @@ import net.tigereye.chestcavity.util.retention.OrganRetentionRules;
 import net.tigereye.chestcavity.ui.ChestCavityScreen;
 import net.tigereye.chestcavity.guscript.ui.GuScriptScreen;
 import net.tigereye.chestcavity.listeners.KeybindingClientListeners;
+import net.tigereye.chestcavity.guscript.registry.GuScriptFlowLoader;
 import net.tigereye.chestcavity.guscript.registry.GuScriptLeafLoader;
 import net.tigereye.chestcavity.guscript.registry.GuScriptRuleLoader;
 import net.tigereye.chestcavity.guscript.runtime.exec.GuScriptListenerHooks;
+import net.tigereye.chestcavity.guscript.runtime.flow.GuScriptFlowEvents;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -77,7 +79,9 @@ public class ChestCavity { //TODO: fix 1.19 version to include color thing, fix 
 		NeoForge.EVENT_BUS.addListener(ServerEvents::onLivingDeath);
 		NeoForge.EVENT_BUS.addListener(this::registerReloadListeners);
 		NeoForge.EVENT_BUS.addListener(GuScriptListenerHooks::onLivingDamage);
-		NeoForge.EVENT_BUS.addListener(GuScriptListenerHooks::onPlayerTick);
+                NeoForge.EVENT_BUS.addListener(GuScriptListenerHooks::onPlayerTick);
+                NeoForge.EVENT_BUS.addListener(GuScriptFlowEvents::onServerTick);
+                NeoForge.EVENT_BUS.addListener(GuScriptFlowEvents::onPlayerLogout);
 		if (FMLEnvironment.dist.isClient()) {
 			NeoForge.EVENT_BUS.addListener(KeybindingClientListeners::onClientTick);
 		}
@@ -139,8 +143,9 @@ public class ChestCavity { //TODO: fix 1.19 version to include color thing, fix 
 		event.addListener(new OrganManager());
 		event.addListener(new GeneratedChestCavityTypeManager());
 		event.addListener(new GeneratedChestCavityAssignmentManager());
-		event.addListener(new GuScriptLeafLoader());
-		event.addListener(new GuScriptRuleLoader());
+                event.addListener(new GuScriptLeafLoader());
+                event.addListener(new GuScriptRuleLoader());
+                event.addListener(new GuScriptFlowLoader());
 	}
 
 	public static boolean isDebugMode() {

--- a/src/main/java/net/tigereye/chestcavity/guscript/network/packets/FlowInputPayload.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/network/packets/FlowInputPayload.java
@@ -1,0 +1,36 @@
+package net.tigereye.chestcavity.guscript.network.packets;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowControllerManager;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowInput;
+
+/**
+ * Client-to-server input for flow release/cancel actions.
+ */
+public record FlowInputPayload(FlowInput input) implements CustomPacketPayload {
+
+    public static final Type<FlowInputPayload> TYPE = new Type<>(ChestCavity.id("guscript_flow_input"));
+
+    public static final StreamCodec<FriendlyByteBuf, FlowInputPayload> STREAM_CODEC = StreamCodec.of(
+            (buf, payload) -> buf.writeEnum(payload.input),
+            buf -> new FlowInputPayload(buf.readEnum(FlowInput.class))
+    );
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+
+    public static void handle(FlowInputPayload payload, IPayloadContext context) {
+        context.enqueueWork(() -> {
+            if (context.player() instanceof ServerPlayer player) {
+                FlowControllerManager.get(player).handleInput(payload.input, player.level().getGameTime());
+            }
+        });
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/network/packets/FlowSyncPayload.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/network/packets/FlowSyncPayload.java
@@ -1,0 +1,45 @@
+package net.tigereye.chestcavity.guscript.network.packets;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowState;
+import net.tigereye.chestcavity.guscript.runtime.flow.client.GuScriptClientFlows;
+
+/**
+ * Mirrors flow state changes to the client.
+ */
+public record FlowSyncPayload(int entityId, ResourceLocation programId, FlowState state, long stateGameTime, int ticksInState)
+        implements CustomPacketPayload {
+
+    public static final Type<FlowSyncPayload> TYPE = new Type<>(ChestCavity.id("guscript_flow_sync"));
+
+    public static final StreamCodec<FriendlyByteBuf, FlowSyncPayload> STREAM_CODEC = StreamCodec.of(
+            (buf, payload) -> {
+                buf.writeVarInt(payload.entityId);
+                buf.writeResourceLocation(payload.programId);
+                buf.writeEnum(payload.state);
+                buf.writeVarLong(payload.stateGameTime);
+                buf.writeVarInt(payload.ticksInState);
+            },
+            buf -> new FlowSyncPayload(
+                    buf.readVarInt(),
+                    buf.readResourceLocation(),
+                    buf.readEnum(FlowState.class),
+                    buf.readVarLong(),
+                    buf.readVarInt()
+            )
+    );
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+
+    public static void handle(FlowSyncPayload payload, IPayloadContext context) {
+        context.enqueueWork(() -> GuScriptClientFlows.handleSync(payload));
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/network/packets/GuScriptTriggerPayload.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/network/packets/GuScriptTriggerPayload.java
@@ -8,6 +8,8 @@ import net.neoforged.neoforge.network.handling.IPayloadContext;
 import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.guscript.data.GuScriptAttachment;
 import net.tigereye.chestcavity.guscript.runtime.exec.GuScriptExecutor;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowControllerManager;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowProgramRegistry;
 import net.tigereye.chestcavity.registration.CCAttachments;
 
 /**
@@ -36,6 +38,9 @@ public record GuScriptTriggerPayload(int pageIndex) implements CustomPacketPaylo
             if (payload.pageIndex >= 0) {
                 attachment.setCurrentPage(payload.pageIndex);
             }
+            FlowProgramRegistry.get(ChestCavity.id("demo_charge_release"))
+                    .ifPresent(program -> FlowControllerManager.get(player)
+                            .start(program, player, player.level().getGameTime()));
             GuScriptExecutor.triggerKeybind(player, player, attachment);
         });
     }

--- a/src/main/java/net/tigereye/chestcavity/guscript/registry/GuScriptFlowLoader.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/registry/GuScriptFlowLoader.java
@@ -1,0 +1,138 @@
+package net.tigereye.chestcavity.guscript.registry;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.util.profiling.ProfilerFiller;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.guscript.ast.Action;
+import net.tigereye.chestcavity.guscript.runtime.action.ActionRegistry;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowGuard;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowProgram;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowProgramRegistry;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowState;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowStateDefinition;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowTransition;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowTrigger;
+import net.tigereye.chestcavity.guscript.runtime.flow.actions.FlowActions;
+import net.tigereye.chestcavity.guscript.runtime.flow.guards.FlowGuards;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Loads flow programs from data packs.
+ */
+public final class GuScriptFlowLoader extends SimpleJsonResourceReloadListener {
+
+    private static final Gson GSON = new GsonBuilder().setLenient().create();
+
+    public GuScriptFlowLoader() {
+        super(GSON, "guscript/flows");
+    }
+
+    @Override
+    protected void apply(Map<ResourceLocation, JsonElement> object, ResourceManager resourceManager, ProfilerFiller profiler) {
+        Map<ResourceLocation, FlowProgram> programs = new HashMap<>();
+        object.forEach((id, element) -> {
+            try {
+                programs.put(id, parseProgram(id, element.getAsJsonObject()));
+            } catch (Exception ex) {
+                ChestCavity.LOGGER.error("[Flow] Failed to parse flow program {}", id, ex);
+            }
+        });
+        FlowProgramRegistry.update(programs);
+    }
+
+    private static FlowProgram parseProgram(ResourceLocation id, JsonObject json) {
+        FlowState initial = FlowState.fromName(GsonHelper.getAsString(json, "initial_state", "idle"));
+        JsonObject statesObject = GsonHelper.getAsJsonObject(json, "states");
+        Map<FlowState, FlowStateDefinition> definitions = new EnumMap<>(FlowState.class);
+        for (Map.Entry<String, JsonElement> entry : statesObject.entrySet()) {
+            FlowState state = FlowState.fromName(entry.getKey());
+            definitions.put(state, parseStateDefinition(entry.getValue().getAsJsonObject()));
+        }
+        ensureRequiredStates(definitions, id);
+        return new FlowProgram(id, initial, definitions);
+    }
+
+    private static FlowStateDefinition parseStateDefinition(JsonObject json) {
+        List<FlowTransition> transitions = new ArrayList<>();
+        if (json.has("transitions")) {
+            for (JsonElement element : json.getAsJsonArray("transitions")) {
+                transitions.add(parseTransition(element.getAsJsonObject()));
+            }
+        }
+        List<Action> enterActions = new ArrayList<>();
+        if (json.has("enter_actions")) {
+            for (JsonElement element : json.getAsJsonArray("enter_actions")) {
+                enterActions.add(ActionRegistry.fromJson(element.getAsJsonObject()));
+            }
+        }
+        return new FlowStateDefinition(enterActions.isEmpty() ? List.of() : List.of(FlowActions.runActions(enterActions)), transitions);
+    }
+
+    private static FlowTransition parseTransition(JsonObject json) {
+        FlowTrigger trigger = FlowTrigger.fromName(GsonHelper.getAsString(json, "trigger"));
+        FlowState target = FlowState.fromName(GsonHelper.getAsString(json, "target"));
+        int minTicks = GsonHelper.getAsInt(json, "min_ticks", 0);
+        List<FlowGuard> guards = new ArrayList<>();
+        if (json.has("guards")) {
+            for (JsonElement element : json.getAsJsonArray("guards")) {
+                guards.add(parseGuard(element.getAsJsonObject()));
+            }
+        }
+        List<net.tigereye.chestcavity.guscript.runtime.flow.FlowEdgeAction> actions = new ArrayList<>();
+        if (json.has("actions")) {
+            for (JsonElement element : json.getAsJsonArray("actions")) {
+                actions.add(parseAction(element.getAsJsonObject()));
+            }
+        }
+        return new FlowTransition(trigger, target, guards, actions, minTicks);
+    }
+
+    private static FlowGuard parseGuard(JsonObject json) {
+        String type = GsonHelper.getAsString(json, "type");
+        return switch (type) {
+            case "resource" -> FlowGuards.hasResource(GsonHelper.getAsString(json, "identifier"), GsonHelper.getAsDouble(json, "minimum"));
+            case "cooldown" -> FlowGuards.cooldownReady(GsonHelper.getAsString(json, "key"));
+            default -> throw new IllegalArgumentException("Unknown flow guard type: " + type);
+        };
+    }
+
+    private static net.tigereye.chestcavity.guscript.runtime.flow.FlowEdgeAction parseAction(JsonObject json) {
+        String type = GsonHelper.getAsString(json, "type");
+        return switch (type) {
+            case "consume_resource" -> FlowActions.consumeResource(GsonHelper.getAsString(json, "identifier"), GsonHelper.getAsDouble(json, "amount"));
+            case "set_cooldown" -> FlowActions.setCooldown(GsonHelper.getAsString(json, "key"), GsonHelper.getAsLong(json, "ticks"));
+            case "trigger_actions" -> FlowActions.runActions(parseActions(json));
+            default -> throw new IllegalArgumentException("Unknown flow action type: " + type);
+        };
+    }
+
+    private static List<Action> parseActions(JsonObject json) {
+        List<Action> actions = new ArrayList<>();
+        if (json.has("actions")) {
+            for (JsonElement element : json.getAsJsonArray("actions")) {
+                actions.add(ActionRegistry.fromJson(element.getAsJsonObject()));
+            }
+        }
+        return actions;
+    }
+
+    private static void ensureRequiredStates(Map<FlowState, FlowStateDefinition> definitions, ResourceLocation id) {
+        for (FlowState state : FlowState.values()) {
+            if (!definitions.containsKey(state)) {
+                ChestCavity.LOGGER.warn("[Flow] Program {} is missing definition for state {}", id, state);
+            }
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowController.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowController.java
@@ -1,0 +1,81 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.guscript.runtime.flow.sync.FlowSyncDispatcher;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Runtime controller binding a {@link FlowProgram} to a performer.
+ */
+public final class FlowController {
+
+    private final ServerPlayer performer;
+    private final Map<String, Long> cooldowns = new java.util.HashMap<>();
+    private FlowInstance instance;
+
+    public FlowController(ServerPlayer performer) {
+        this.performer = Objects.requireNonNull(performer, "performer");
+    }
+
+    public ServerPlayer performer() {
+        return performer;
+    }
+
+    public boolean isRunning() {
+        return instance != null && !instance.isFinished();
+    }
+
+    public void tick(Level level) {
+        if (!(level instanceof ServerLevel serverLevel)) {
+            return;
+        }
+        if (instance != null) {
+            instance.tick(serverLevel);
+            if (instance.isFinished()) {
+                FlowSyncDispatcher.syncStopped(performer, instance);
+                instance = null;
+            }
+        }
+    }
+
+    public void start(FlowProgram program, LivingEntity target, long gameTime) {
+        if (program == null) {
+            return;
+        }
+        if (isRunning()) {
+            ChestCavity.LOGGER.debug("[Flow] Ignoring start for {} because flow {} already running", performer.getGameProfile().getName(), instance.program().id());
+            return;
+        }
+        instance = new FlowInstance(program, performer, target, this, gameTime);
+        FlowSyncDispatcher.syncState(performer, instance);
+        if (!instance.attemptStart(gameTime)) {
+            ChestCavity.LOGGER.debug("[Flow] Flow {} stayed in {} after start trigger", program.id(), instance.state());
+        }
+    }
+
+    public void handleInput(FlowInput input, long gameTime) {
+        if (instance == null || input == null) {
+            return;
+        }
+        instance.handleInput(input, gameTime);
+    }
+
+    public void handleStateChanged(FlowInstance flowInstance) {
+        FlowSyncDispatcher.syncState(performer, flowInstance);
+    }
+
+    public boolean isCooldownReady(String key, long gameTime) {
+        Long cooldown = cooldowns.get(key);
+        return cooldown == null || cooldown <= gameTime;
+    }
+
+    public void setCooldown(String key, long readyTick) {
+        cooldowns.put(key, readyTick);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowControllerManager.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowControllerManager.java
@@ -1,0 +1,28 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Allocates and caches {@link FlowController} instances per player.
+ */
+public final class FlowControllerManager {
+
+    private static final Map<UUID, FlowController> CONTROLLERS = new ConcurrentHashMap<>();
+
+    private FlowControllerManager() {
+    }
+
+    public static FlowController get(ServerPlayer player) {
+        return CONTROLLERS.computeIfAbsent(player.getUUID(), uuid -> new FlowController(player));
+    }
+
+    public static void remove(ServerPlayer player) {
+        if (player != null) {
+            CONTROLLERS.remove(player.getUUID());
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowEdgeAction.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowEdgeAction.java
@@ -1,0 +1,14 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * Side-effect performed when a transition fires.
+ */
+public interface FlowEdgeAction {
+
+    void apply(Player performer, LivingEntity target, FlowController controller, long gameTime);
+
+    String describe();
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowGuard.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowGuard.java
@@ -1,0 +1,14 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * Predicate that must pass for a transition to proceed.
+ */
+public interface FlowGuard {
+
+    boolean test(Player performer, LivingEntity target, FlowController controller, long gameTime);
+
+    String describe();
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowInput.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowInput.java
@@ -1,0 +1,29 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import java.util.Locale;
+
+/**
+ * External input types a flow can react to.
+ */
+public enum FlowInput {
+    RELEASE,
+    CANCEL;
+
+    public static FlowInput fromName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Flow input name must not be blank");
+        }
+        return FlowInput.valueOf(name.trim().toUpperCase(Locale.ROOT));
+    }
+
+    public String serializedName() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+    public FlowTrigger toTrigger() {
+        return switch (this) {
+            case RELEASE -> FlowTrigger.RELEASE;
+            case CANCEL -> FlowTrigger.CANCEL;
+        };
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowInstance.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowInstance.java
@@ -1,0 +1,146 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.tigereye.chestcavity.ChestCavity;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Mutable runtime for a {@link FlowProgram} bound to a performer and optional target.
+ */
+public final class FlowInstance {
+
+    private final FlowProgram program;
+    private final Player performer;
+    private final LivingEntity target;
+    private final FlowController controller;
+    private FlowState state;
+    private long stateEnteredGameTime;
+    private int ticksInState;
+    private boolean finished;
+
+    FlowInstance(FlowProgram program, Player performer, LivingEntity target, FlowController controller, long gameTime) {
+        this.program = program;
+        this.performer = performer;
+        this.target = target;
+        this.controller = controller;
+        enterState(program.initialState(), gameTime);
+    }
+
+    public FlowProgram program() {
+        return program;
+    }
+
+    public FlowState state() {
+        return state;
+    }
+
+    public long stateEnteredGameTime() {
+        return stateEnteredGameTime;
+    }
+
+    public int ticksInState() {
+        return ticksInState;
+    }
+
+    public boolean isFinished() {
+        return finished;
+    }
+
+    void tick(ServerLevel level) {
+        if (finished) {
+            return;
+        }
+        ticksInState++;
+        attemptTransitions(FlowTrigger.AUTO, level.getGameTime());
+        if (state == FlowState.IDLE && ticksInState > 0) {
+            finished = true;
+        }
+    }
+
+    void handleInput(FlowInput input, long gameTime) {
+        if (finished) {
+            return;
+        }
+        attemptTransitions(input.toTrigger(), gameTime);
+    }
+
+    boolean attemptStart(long gameTime) {
+        if (finished) {
+            return false;
+        }
+        List<FlowTransition> transitions = definition().map(def -> def.transitionsFor(FlowTrigger.START)).orElse(List.of());
+        return fireFirstTransition(transitions, gameTime);
+    }
+
+    private void attemptTransitions(FlowTrigger trigger, long gameTime) {
+        List<FlowTransition> transitions = definition().map(def -> def.transitionsFor(trigger)).orElse(List.of());
+        fireFirstTransition(transitions, gameTime);
+    }
+
+    private boolean fireFirstTransition(List<FlowTransition> transitions, long gameTime) {
+        if (transitions.isEmpty()) {
+            return false;
+        }
+        for (FlowTransition transition : transitions) {
+            if (ticksInState < transition.minTicksInState()) {
+                continue;
+            }
+            if (!guardsPass(transition, gameTime)) {
+                continue;
+            }
+            executeActions(transition, gameTime);
+            enterState(transition.target(), gameTime);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean guardsPass(FlowTransition transition, long gameTime) {
+        for (FlowGuard guard : transition.guards()) {
+            try {
+                if (!guard.test(performer, target, controller, gameTime)) {
+                    return false;
+                }
+            } catch (Exception ex) {
+                ChestCavity.LOGGER.error("[Flow] Guard {} threw for program {}", guard.describe(), program.id(), ex);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void executeActions(FlowTransition transition, long gameTime) {
+        for (FlowEdgeAction action : transition.actions()) {
+            try {
+                action.apply(performer, target, controller, gameTime);
+            } catch (Exception ex) {
+                ChestCavity.LOGGER.error("[Flow] Action {} failed for program {}", action.describe(), program.id(), ex);
+            }
+        }
+    }
+
+    private void enterState(FlowState nextState, long gameTime) {
+        this.state = nextState;
+        this.stateEnteredGameTime = gameTime;
+        this.ticksInState = 0;
+        controller.handleStateChanged(this);
+        Optional<FlowStateDefinition> definition = definition();
+        if (definition.isPresent()) {
+            for (FlowEdgeAction action : definition.get().enterActions()) {
+                try {
+                    action.apply(performer, target, controller, gameTime);
+                } catch (Exception ex) {
+                    ChestCavity.LOGGER.error("[Flow] Enter action {} failed for program {}", action.describe(), program.id(), ex);
+                }
+            }
+        }
+    }
+
+    private Optional<FlowStateDefinition> definition() {
+        return program.definition(state);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowProgram.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowProgram.java
@@ -1,0 +1,41 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable description of a flow state machine loaded from data.
+ */
+public final class FlowProgram {
+
+    private final ResourceLocation id;
+    private final FlowState initialState;
+    private final Map<FlowState, FlowStateDefinition> states;
+
+    public FlowProgram(ResourceLocation id, FlowState initialState, Map<FlowState, FlowStateDefinition> states) {
+        this.id = Objects.requireNonNull(id, "id");
+        this.initialState = Objects.requireNonNull(initialState, "initialState");
+        this.states = new EnumMap<>(FlowState.class);
+        this.states.putAll(states);
+    }
+
+    public ResourceLocation id() {
+        return id;
+    }
+
+    public FlowState initialState() {
+        return initialState;
+    }
+
+    public Optional<FlowStateDefinition> definition(FlowState state) {
+        return Optional.ofNullable(states.get(state));
+    }
+
+    public Map<FlowState, FlowStateDefinition> states() {
+        return Map.copyOf(states);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowProgramRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowProgramRegistry.java
@@ -1,0 +1,29 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.ChestCavity;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Global registry of flow programs loaded from data packs.
+ */
+public final class FlowProgramRegistry {
+
+    private static final Map<ResourceLocation, FlowProgram> PROGRAMS = new ConcurrentHashMap<>();
+
+    private FlowProgramRegistry() {
+    }
+
+    public static void update(Map<ResourceLocation, FlowProgram> programs) {
+        PROGRAMS.clear();
+        PROGRAMS.putAll(programs);
+        ChestCavity.LOGGER.info("[Flow] Loaded {} flow programs", PROGRAMS.size());
+    }
+
+    public static Optional<FlowProgram> get(ResourceLocation id) {
+        return Optional.ofNullable(PROGRAMS.get(id));
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowState.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowState.java
@@ -1,0 +1,26 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import java.util.Locale;
+
+/**
+ * Enumerates the canonical states a flow program can occupy.
+ */
+public enum FlowState {
+    IDLE,
+    CHARGING,
+    CHARGED,
+    RELEASING,
+    COOLDOWN,
+    CANCEL;
+
+    public static FlowState fromName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Flow state name must not be blank");
+        }
+        return FlowState.valueOf(name.trim().toUpperCase(Locale.ROOT));
+    }
+
+    public String serializedName() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowStateDefinition.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowStateDefinition.java
@@ -1,0 +1,39 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configuration for a single flow state.
+ */
+public final class FlowStateDefinition {
+
+    private final List<FlowEdgeAction> enterActions;
+    private final List<FlowTransition> transitions;
+
+    public FlowStateDefinition(List<FlowEdgeAction> enterActions, List<FlowTransition> transitions) {
+        this.enterActions = enterActions == null ? List.of() : List.copyOf(enterActions);
+        this.transitions = transitions == null ? List.of() : List.copyOf(transitions);
+    }
+
+    public List<FlowEdgeAction> enterActions() {
+        return enterActions;
+    }
+
+    public List<FlowTransition> transitions() {
+        return transitions;
+    }
+
+    public List<FlowTransition> transitionsFor(FlowTrigger trigger) {
+        if (transitions.isEmpty()) {
+            return List.of();
+        }
+        List<FlowTransition> matches = new ArrayList<>();
+        for (FlowTransition transition : transitions) {
+            if (transition.trigger() == trigger) {
+                matches.add(transition);
+            }
+        }
+        return matches;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowTransition.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowTransition.java
@@ -1,0 +1,43 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import java.util.List;
+
+/**
+ * Transition from one state to another, optionally gated by guards and performing actions.
+ */
+public final class FlowTransition {
+
+    private final FlowTrigger trigger;
+    private final FlowState target;
+    private final List<FlowGuard> guards;
+    private final List<FlowEdgeAction> actions;
+    private final int minTicksInState;
+
+    public FlowTransition(FlowTrigger trigger, FlowState target, List<FlowGuard> guards, List<FlowEdgeAction> actions, int minTicksInState) {
+        this.trigger = trigger;
+        this.target = target;
+        this.guards = guards == null ? List.of() : List.copyOf(guards);
+        this.actions = actions == null ? List.of() : List.copyOf(actions);
+        this.minTicksInState = Math.max(0, minTicksInState);
+    }
+
+    public FlowTrigger trigger() {
+        return trigger;
+    }
+
+    public FlowState target() {
+        return target;
+    }
+
+    public List<FlowGuard> guards() {
+        return guards;
+    }
+
+    public List<FlowEdgeAction> actions() {
+        return actions;
+    }
+
+    public int minTicksInState() {
+        return minTicksInState;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowTrigger.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowTrigger.java
@@ -1,0 +1,24 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import java.util.Locale;
+
+/**
+ * Triggers that can drive flow transitions.
+ */
+public enum FlowTrigger {
+    START,
+    AUTO,
+    RELEASE,
+    CANCEL;
+
+    public static FlowTrigger fromName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Flow trigger name must not be blank");
+        }
+        return FlowTrigger.valueOf(name.trim().toUpperCase(Locale.ROOT));
+    }
+
+    public String serializedName() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/GuScriptFlowEvents.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/GuScriptFlowEvents.java
@@ -1,0 +1,32 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
+
+/**
+ * Server event hooks for ticking and cleaning up flow controllers.
+ */
+public final class GuScriptFlowEvents {
+
+    private GuScriptFlowEvents() {
+    }
+
+    @SubscribeEvent
+    public static void onServerTick(ServerTickEvent.Post event) {
+        for (ServerLevel level : event.getServer().getAllLevels()) {
+            for (ServerPlayer player : level.players()) {
+                FlowControllerManager.get(player).tick(level);
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLogout(PlayerEvent.PlayerLoggedOutEvent event) {
+        if (event.getEntity() instanceof ServerPlayer player) {
+            FlowControllerManager.remove(player);
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/FlowActions.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/FlowActions.java
@@ -1,0 +1,104 @@
+package net.tigereye.chestcavity.guscript.runtime.flow.actions;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.guscript.ast.Action;
+import net.tigereye.chestcavity.guscript.runtime.action.DefaultGuScriptExecutionBridge;
+import net.tigereye.chestcavity.guscript.runtime.exec.DefaultGuScriptContext;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowController;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowEdgeAction;
+import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
+
+import java.util.List;
+
+/**
+ * Built-in flow actions used by the MVP implementation.
+ */
+public final class FlowActions {
+
+    private FlowActions() {
+    }
+
+    public static FlowEdgeAction consumeResource(String identifier, double amount) {
+        if (amount <= 0) {
+            return describe(() -> "consume_resource(nop)");
+        }
+        return new FlowEdgeAction() {
+            @Override
+            public void apply(Player performer, LivingEntity target, FlowController controller, long gameTime) {
+                if (performer == null || identifier == null) {
+                    return;
+                }
+                GuzhenrenResourceBridge.open(performer).ifPresent(handle -> {
+                    double delta = -Math.abs(amount);
+                    handle.adjustDouble(identifier, delta, true);
+                });
+            }
+
+            @Override
+            public String describe() {
+                return "consume_resource(" + identifier + ", " + amount + ")";
+            }
+        };
+    }
+
+    public static FlowEdgeAction setCooldown(String key, long durationTicks) {
+        return new FlowEdgeAction() {
+            @Override
+            public void apply(Player performer, LivingEntity target, FlowController controller, long gameTime) {
+                if (controller == null || key == null) {
+                    return;
+                }
+                controller.setCooldown(key, gameTime + Math.max(0L, durationTicks));
+            }
+
+            @Override
+            public String describe() {
+                return "set_cooldown(" + key + ", " + durationTicks + ")";
+            }
+        };
+    }
+
+    public static FlowEdgeAction runActions(List<Action> actions) {
+        List<Action> immutable = actions == null ? List.of() : List.copyOf(actions);
+        if (immutable.isEmpty()) {
+            return describe(() -> "run_actions(nop)");
+        }
+        return new FlowEdgeAction() {
+            @Override
+            public void apply(Player performer, LivingEntity target, FlowController controller, long gameTime) {
+                if (performer == null) {
+                    return;
+                }
+                DefaultGuScriptExecutionBridge bridge = new DefaultGuScriptExecutionBridge(performer, target);
+                DefaultGuScriptContext context = new DefaultGuScriptContext(performer, target, bridge);
+                for (Action action : immutable) {
+                    try {
+                        action.execute(context);
+                    } catch (Exception ex) {
+                        ChestCavity.LOGGER.error("[Flow] Failed to run embedded action {}", action.id(), ex);
+                    }
+                }
+            }
+
+            @Override
+            public String describe() {
+                return "run_actions(" + immutable.size() + ")";
+            }
+        };
+    }
+
+    private static FlowEdgeAction describe(java.util.function.Supplier<String> description) {
+        return new FlowEdgeAction() {
+            @Override
+            public void apply(Player performer, LivingEntity target, FlowController controller, long gameTime) {
+            }
+
+            @Override
+            public String describe() {
+                return description.get();
+            }
+        };
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/client/GuScriptClientFlows.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/client/GuScriptClientFlows.java
@@ -1,0 +1,41 @@
+package net.tigereye.chestcavity.guscript.runtime.flow.client;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.minecraft.client.Minecraft;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.guscript.network.packets.FlowSyncPayload;
+
+import java.util.Map;
+
+/**
+ * Lightweight client mirror keeping track of server flow state.
+ */
+public final class GuScriptClientFlows {
+
+    private static final Map<Integer, FlowMirror> MIRRORS = new Int2ObjectOpenHashMap<>();
+
+    private GuScriptClientFlows() {
+    }
+
+    public static void handleSync(FlowSyncPayload payload) {
+        FlowMirror mirror = MIRRORS.computeIfAbsent(payload.entityId(), FlowMirror::new);
+        mirror.update(payload);
+    }
+
+    public static final class FlowMirror {
+        private final int entityId;
+        private FlowSyncPayload lastPayload;
+
+        FlowMirror(int entityId) {
+            this.entityId = entityId;
+        }
+
+        void update(FlowSyncPayload payload) {
+            this.lastPayload = payload;
+            ChestCavity.LOGGER.debug("[Flow][Client] Entity {} program {} -> {} (t={} start={})", entityId, payload.programId(), payload.state(), payload.ticksInState(), payload.stateGameTime());
+            if (Minecraft.getInstance().player != null && Minecraft.getInstance().player.getId() == entityId) {
+                // Future: drive client-side FX. For now only log.
+            }
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/guards/FlowGuards.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/guards/FlowGuards.java
@@ -1,0 +1,55 @@
+package net.tigereye.chestcavity.guscript.runtime.flow.guards;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowController;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowGuard;
+import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
+
+/**
+ * Built-in flow guards.
+ */
+public final class FlowGuards {
+
+    private FlowGuards() {
+    }
+
+    public static FlowGuard hasResource(String identifier, double minimum) {
+        return new FlowGuard() {
+            @Override
+            public boolean test(Player performer, LivingEntity target, FlowController controller, long gameTime) {
+                if (performer == null || identifier == null) {
+                    return false;
+                }
+                var handleOpt = GuzhenrenResourceBridge.open(performer);
+                if (handleOpt.isEmpty()) {
+                    return false;
+                }
+                var valueOpt = handleOpt.get().read(identifier);
+                return valueOpt.isPresent() && valueOpt.getAsDouble() >= minimum;
+            }
+
+            @Override
+            public String describe() {
+                return "has_resource(" + identifier + ", " + minimum + ")";
+            }
+        };
+    }
+
+    public static FlowGuard cooldownReady(String key) {
+        return new FlowGuard() {
+            @Override
+            public boolean test(Player performer, LivingEntity target, FlowController controller, long gameTime) {
+                if (controller == null || key == null) {
+                    return false;
+                }
+                return controller.isCooldownReady(key, gameTime);
+            }
+
+            @Override
+            public String describe() {
+                return "cooldown_ready(" + key + ")";
+            }
+        };
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/sync/FlowSyncDispatcher.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/sync/FlowSyncDispatcher.java
@@ -1,0 +1,41 @@
+package net.tigereye.chestcavity.guscript.runtime.flow.sync;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.tigereye.chestcavity.guscript.network.packets.FlowSyncPayload;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowInstance;
+import net.tigereye.chestcavity.network.NetworkHandler;
+
+/**
+ * Sends flow state updates to clients.
+ */
+public final class FlowSyncDispatcher {
+
+    private FlowSyncDispatcher() {
+    }
+
+    public static void syncState(ServerPlayer player, FlowInstance instance) {
+        if (player == null || instance == null) {
+            return;
+        }
+        NetworkHandler.sendFlowSync(player, new FlowSyncPayload(
+                player.getId(),
+                instance.program().id(),
+                instance.state(),
+                instance.stateEnteredGameTime(),
+                instance.ticksInState()
+        ));
+    }
+
+    public static void syncStopped(ServerPlayer player, FlowInstance instance) {
+        if (player == null || instance == null) {
+            return;
+        }
+        NetworkHandler.sendFlowSync(player, new FlowSyncPayload(
+                player.getId(),
+                instance.program().id(),
+                instance.state(),
+                instance.stateEnteredGameTime(),
+                instance.ticksInState()
+        ));
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/network/NetworkHandler.java
+++ b/src/main/java/net/tigereye/chestcavity/network/NetworkHandler.java
@@ -17,6 +17,8 @@ import net.tigereye.chestcavity.network.packets.ChestCavityHotkeyPayload;
 import net.tigereye.chestcavity.network.packets.ChestCavityOrganSlotUpdatePayload;
 import net.tigereye.chestcavity.network.packets.ChestCavityUpdatePayload;
 import net.tigereye.chestcavity.network.packets.OrganDataPayload;
+import net.tigereye.chestcavity.guscript.network.packets.FlowInputPayload;
+import net.tigereye.chestcavity.guscript.network.packets.FlowSyncPayload;
 import net.tigereye.chestcavity.guscript.network.packets.GuScriptBindingTogglePayload;
 import net.tigereye.chestcavity.guscript.network.packets.GuScriptOpenPayload;
 import net.tigereye.chestcavity.guscript.network.packets.GuScriptPageChangePayload;
@@ -33,10 +35,12 @@ public final class NetworkHandler {
         registrar.playToServer(GuScriptBindingTogglePayload.TYPE, GuScriptBindingTogglePayload.STREAM_CODEC, GuScriptBindingTogglePayload::handle);
         registrar.playToServer(GuScriptPageChangePayload.TYPE, GuScriptPageChangePayload.STREAM_CODEC, GuScriptPageChangePayload::handle);
         registrar.playToServer(GuScriptTriggerPayload.TYPE, GuScriptTriggerPayload.STREAM_CODEC, GuScriptTriggerPayload::handle);
+        registrar.playToServer(FlowInputPayload.TYPE, FlowInputPayload.STREAM_CODEC, FlowInputPayload::handle);
         registrar.playToServer(KongqiaoDaoHenSeedPayload.TYPE, KongqiaoDaoHenSeedPayload.STREAM_CODEC, DaoHenSeedHandler::handleSeedPayload);
         registrar.playToClient(ChestCavityUpdatePayload.TYPE, ChestCavityUpdatePayload.STREAM_CODEC, ChestCavityUpdatePayload::handle);
         registrar.playToClient(OrganDataPayload.TYPE, OrganDataPayload.STREAM_CODEC, OrganDataPayload::handle);
         registrar.playToClient(ChestCavityOrganSlotUpdatePayload.TYPE, ChestCavityOrganSlotUpdatePayload.STREAM_CODEC, ChestCavityOrganSlotUpdatePayload::handle);
+        registrar.playToClient(FlowSyncPayload.TYPE, FlowSyncPayload.STREAM_CODEC, FlowSyncPayload::handle);
     }
 
 
@@ -53,6 +57,10 @@ public final class NetworkHandler {
     }
 
     public static void sendOrganSlotUpdate(ServerPlayer player, ChestCavityOrganSlotUpdatePayload payload) {
+        player.connection.send(payload);
+    }
+
+    public static void sendFlowSync(ServerPlayer player, FlowSyncPayload payload) {
         player.connection.send(payload);
     }
 }

--- a/src/main/resources/data/chestcavity/guscript/flows/demo_charge_release.json
+++ b/src/main/resources/data/chestcavity/guscript/flows/demo_charge_release.json
@@ -1,0 +1,61 @@
+{
+  "initial_state": "idle",
+  "states": {
+    "idle": {
+      "transitions": [
+        {
+          "trigger": "start",
+          "target": "charging",
+          "guards": [
+            {"type": "cooldown", "key": "chestcavity:demo_charge_release"},
+            {"type": "resource", "identifier": "zhenyuan", "minimum": 10.0}
+          ],
+          "actions": [
+            {"type": "consume_resource", "identifier": "zhenyuan", "amount": 10.0},
+            {"type": "set_cooldown", "key": "chestcavity:demo_charge_release", "ticks": 200}
+          ]
+        }
+      ]
+    },
+    "charging": {
+      "transitions": [
+        {"trigger": "auto", "target": "charged", "min_ticks": 40},
+        {"trigger": "cancel", "target": "cancel"}
+      ]
+    },
+    "charged": {
+      "transitions": [
+        {"trigger": "release", "target": "releasing"},
+        {"trigger": "auto", "target": "releasing", "min_ticks": 20},
+        {"trigger": "cancel", "target": "cancel"}
+      ]
+    },
+    "releasing": {
+      "transitions": [
+        {
+          "trigger": "auto",
+          "target": "cooldown",
+          "min_ticks": 20,
+          "actions": [
+            {
+              "type": "trigger_actions",
+              "actions": [
+                {"id": "emit_projectile", "projectileId": "minecraft:arrow", "damage": 2.0}
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "cooldown": {
+      "transitions": [
+        {"trigger": "auto", "target": "idle", "min_ticks": 40}
+      ]
+    },
+    "cancel": {
+      "transitions": [
+        {"trigger": "auto", "target": "cooldown", "min_ticks": 5}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add FlowProgram/FlowInstance/FlowController runtime with resource and cooldown guards plus transition actions
- load data-driven flow programs from `data/chestcavity/guscript/flows` and broadcast state via the new FlowSyncPayload
- hook the demo `demo_charge_release` flow into the GuScript trigger path and register supporting network events

## Testing
- `./gradlew compileJava --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68d8c64d688883268e5a3d24c71770df