### PR TITLE
Fix GuScriptRuntimeTest RecordingBridge to implement playFx

### DIFF
--- a/src/test/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptRuntimeTest.java
+++ b/src/test/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptRuntimeTest.java
@@ -276,6 +276,11 @@ class GuScriptRuntimeTest {
         public void emitProjectile(String projectileId, double damage) {
             projectiles.incrementAndGet();
         }
+
+        @Override
+        public void playFx(net.minecraft.resources.ResourceLocation fxId, net.tigereye.chestcavity.guscript.fx.FxEventParameters parameters) {
+            // no-op for tests
+        }
     }
 
     private static final class RecordingContext implements GuScriptContext {


### PR DESCRIPTION
## Summary
- add a no-op playFx implementation to the GuScriptRuntimeTest RecordingBridge to satisfy the updated GuScriptExecutionBridge interface

## Testing
- ./gradlew test --console=plain
- ./gradlew compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d8d6a655348326b6365530f636a0c9