### PR TITLE
Implement GuScript flow selection per root

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/guscript/ast/OperatorGuNode.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/ast/OperatorGuNode.java
@@ -2,9 +2,14 @@ package net.tigereye.chestcavity.guscript.ast;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
+import net.minecraft.resources.ResourceLocation;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 
 /**
@@ -20,15 +25,24 @@ public final class OperatorGuNode implements GuNode {
     private final Integer executionOrder;
     private final boolean exportMultiplier;
     private final boolean exportFlat;
+    private final ResourceLocation flowId;
+    private final Map<String, String> flowParams;
 
     public OperatorGuNode(String operatorId, String name, GuNodeKind kind,
                           Multiset<String> tags, List<Action> actions, List<GuNode> children) {
-        this(operatorId, name, kind, tags, actions, children, null, false, false);
+        this(operatorId, name, kind, tags, actions, children, null, false, false, null, Map.of());
     }
 
     public OperatorGuNode(String operatorId, String name, GuNodeKind kind,
                           Multiset<String> tags, List<Action> actions, List<GuNode> children,
                           Integer executionOrder, boolean exportMultiplier, boolean exportFlat) {
+        this(operatorId, name, kind, tags, actions, children, executionOrder, exportMultiplier, exportFlat, null, Map.of());
+    }
+
+    public OperatorGuNode(String operatorId, String name, GuNodeKind kind,
+                          Multiset<String> tags, List<Action> actions, List<GuNode> children,
+                          Integer executionOrder, boolean exportMultiplier, boolean exportFlat,
+                          ResourceLocation flowId, Map<String, String> flowParams) {
         if (operatorId == null || operatorId.isBlank()) {
             throw new IllegalArgumentException("Operator requires an id");
         }
@@ -44,6 +58,12 @@ public final class OperatorGuNode implements GuNode {
         this.executionOrder = executionOrder;
         this.exportMultiplier = exportMultiplier;
         this.exportFlat = exportFlat;
+        this.flowId = flowId;
+        if (flowParams == null || flowParams.isEmpty()) {
+            this.flowParams = Map.of();
+        } else {
+            this.flowParams = Collections.unmodifiableMap(new LinkedHashMap<>(flowParams));
+        }
     }
 
     public String operatorId() {
@@ -87,6 +107,14 @@ public final class OperatorGuNode implements GuNode {
         return exportFlat;
     }
 
+    public Optional<ResourceLocation> flowId() {
+        return Optional.ofNullable(flowId);
+    }
+
+    public Map<String, String> flowParams() {
+        return flowParams;
+    }
+
     @Override
     public String toString() {
         return "OperatorGuNode{" +
@@ -99,6 +127,8 @@ public final class OperatorGuNode implements GuNode {
                 ", order=" + executionOrder +
                 ", exportMultiplier=" + exportMultiplier +
                 ", exportFlat=" + exportFlat +
+                ", flowId=" + flowId +
+                ", flowParams=" + flowParams +
                 '}';
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/network/packets/GuScriptTriggerPayload.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/network/packets/GuScriptTriggerPayload.java
@@ -8,8 +8,6 @@ import net.neoforged.neoforge.network.handling.IPayloadContext;
 import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.guscript.data.GuScriptAttachment;
 import net.tigereye.chestcavity.guscript.runtime.exec.GuScriptExecutor;
-import net.tigereye.chestcavity.guscript.runtime.flow.FlowControllerManager;
-import net.tigereye.chestcavity.guscript.runtime.flow.FlowProgramRegistry;
 import net.tigereye.chestcavity.registration.CCAttachments;
 
 /**
@@ -38,9 +36,6 @@ public record GuScriptTriggerPayload(int pageIndex) implements CustomPacketPaylo
             if (payload.pageIndex >= 0) {
                 attachment.setCurrentPage(payload.pageIndex);
             }
-            FlowProgramRegistry.get(ChestCavity.id("demo_charge_release"))
-                    .ifPresent(program -> FlowControllerManager.get(player)
-                            .start(program, player, player.level().getGameTime()));
             GuScriptExecutor.triggerKeybind(player, player, attachment);
         });
     }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptCompiler.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptCompiler.java
@@ -17,6 +17,7 @@ import net.tigereye.chestcavity.guscript.runtime.reduce.ReactionRule;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -106,6 +107,13 @@ public final class GuScriptCompiler {
         }
         hash = 31 * hash + page.bindingTarget().ordinal();
         hash = 31 * hash + page.listenerType().ordinal();
+        hash = 31 * hash + page.flowId().map(Object::hashCode).orElse(0);
+        Map<String, String> params = page.flowParams();
+        if (!params.isEmpty()) {
+            for (Map.Entry<String, String> entry : params.entrySet()) {
+                hash = 31 * hash + Objects.hash(entry.getKey(), entry.getValue());
+            }
+        }
         return hash;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/reduce/GuScriptReducer.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/reduce/GuScriptReducer.java
@@ -173,8 +173,20 @@ public final class GuScriptReducer {
     private static GuNode adjustCompositeKind(GuNode node) {
         if (node instanceof OperatorGuNode operator) {
             if (operator.kind() == GuNodeKind.OPERATOR && operator.children().stream().noneMatch(GuNode::isLeaf)) {
-                return new OperatorGuNode(operator.operatorId(), operator.name(), GuNodeKind.COMPOSITE,
-                        operator.tags(), operator.actions(), operator.children());
+                Integer order = operator.executionOrder().isPresent() ? operator.executionOrder().getAsInt() : null;
+                return new OperatorGuNode(
+                        operator.operatorId(),
+                        operator.name(),
+                        GuNodeKind.COMPOSITE,
+                        operator.tags(),
+                        operator.actions(),
+                        operator.children(),
+                        order,
+                        operator.exportMultiplier(),
+                        operator.exportFlat(),
+                        operator.flowId().orElse(null),
+                        operator.flowParams()
+                );
             }
         }
         return node;

--- a/src/main/resources/data/chestcavity/guscript/rules/blood_bone_explosion.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/blood_bone_explosion.json
@@ -12,6 +12,7 @@
     "tags": ["杀招"],
     "actions": [
       { "id": "emit.projectile", "projectileId": "minecraft:arrow", "damage": 6.0 }
-    ]
+    ],
+    "flow_id": "chestcavity:demo_charge_release"
   }
 }


### PR DESCRIPTION
## Summary
- add optional flow metadata to operator nodes and GuScript pages, plus loader support for flow identifiers and parameters
- start flows during execution based on root or page defaults and remove the hardcoded demo flow trigger
- include flow metadata in compiler caching and tag the sample explosion rule with its flow id

## Testing
- ./gradlew compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d8e021aec483268621437b42d00acc