### PR TITLE
Add furnace power FX linkage and tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,8 @@ dependencies {
     minecraft "net.minecraftforge:forge:${mc_version}-${forge_version}" //21
     compileOnly fg.deobf("curse.maven:clothconfig-348521:3782784")
     runtimeOnly fg.deobf("curse.maven:clothconfig-348521:3782784")
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"
     // compile "some.group:artifact:version"
@@ -114,6 +116,10 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 
+}
+
+test {
+    useJUnitPlatform()
 }
 
 sourceSets {

--- a/src/main/java/net/tigereye/chestcavity/mob_effect/FurnacePower.java
+++ b/src/main/java/net/tigereye/chestcavity/mob_effect/FurnacePower.java
@@ -10,6 +10,8 @@ import net.minecraft.util.FoodStats;
 import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
 import net.tigereye.chestcavity.interfaces.ChestCavityEntity;
 import net.tigereye.chestcavity.registration.CCItems;
+import net.tigereye.chestcavity.mob_effect.fx.FurnaceFlowState;
+import net.tigereye.chestcavity.mob_effect.fx.FurnacePowerFxHelper;
 
 import java.util.Optional;
 
@@ -31,6 +33,9 @@ public class FurnacePower extends CCStatusEffect{
                     ChestCavityEntity cce = optional.get();
                     ChestCavityInstance cc = cce.getChestCavityInstance();
                     cc.furnaceProgress++;
+                    if (cc.furnaceProgress % FurnacePowerFxHelper.CHARGE_SOUND_INTERVAL == 0) {
+                        FurnacePowerFxHelper.playFx(entity, FurnaceFlowState.CHARGING);
+                    }
                     if (cc.furnaceProgress >= 200) {
                         cc.furnaceProgress = 0;
                         FoodStats hungerManager = ((PlayerEntity) entity).getFoodData();
@@ -38,6 +43,7 @@ public class FurnacePower extends CCStatusEffect{
                         for (int i = 0; i <= amplifier; i++) {
                             hungerManager.eat(CCItems.FURNACE_POWER.get(), furnaceFuel);
                         }
+                        FurnacePowerFxHelper.playFx(entity, FurnaceFlowState.FEEDING);
                     }
                 }
             }

--- a/src/main/java/net/tigereye/chestcavity/mob_effect/fx/FurnaceFlowState.java
+++ b/src/main/java/net/tigereye/chestcavity/mob_effect/fx/FurnaceFlowState.java
@@ -1,0 +1,15 @@
+package net.tigereye.chestcavity.mob_effect.fx;
+
+/**
+ * Represents the coarse-grained lifecycle for the Furnace Power effect.
+ * The states are intentionally lightweight so they can be used by gameplay
+ * logic and tests without requiring a running Minecraft world.
+ */
+public enum FurnaceFlowState {
+    /** No furnace activity is happening. */
+    IDLE,
+    /** The effect is charging and preparing to feed the player. */
+    CHARGING,
+    /** The effect has just fed the player. */
+    FEEDING
+}

--- a/src/main/java/net/tigereye/chestcavity/mob_effect/fx/FurnacePowerFxHelper.java
+++ b/src/main/java/net/tigereye/chestcavity/mob_effect/fx/FurnacePowerFxHelper.java
@@ -1,0 +1,48 @@
+package net.tigereye.chestcavity.mob_effect.fx;
+
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.util.SoundEvent;
+import net.minecraft.util.SoundEvents;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Centralises the lightweight state-to-sound linkage for the Furnace Power
+ * effect. The helper keeps the gameplay code clean and makes the mapping
+ * easily testable.
+ */
+public final class FurnacePowerFxHelper {
+
+    public static final int CHARGE_SOUND_INTERVAL = 40;
+
+    private static final Map<FurnaceFlowState, SoundEvent> STATE_SOUNDS =
+            new EnumMap<>(FurnaceFlowState.class);
+
+    static {
+        STATE_SOUNDS.put(FurnaceFlowState.CHARGING, SoundEvents.FURNACE_FIRE_CRACKLE);
+        STATE_SOUNDS.put(FurnaceFlowState.FEEDING, SoundEvents.PLAYER_BURP);
+    }
+
+    private FurnacePowerFxHelper() {
+    }
+
+    /**
+     * Returns the sound effect tied to the supplied flow state.
+     */
+    public static Optional<SoundEvent> soundFor(FurnaceFlowState state) {
+        return Optional.ofNullable(STATE_SOUNDS.get(state));
+    }
+
+    /**
+     * Plays the sound effect that corresponds with the supplied flow state.
+     */
+    public static void playFx(LivingEntity entity, FurnaceFlowState state) {
+        if (entity == null) {
+            return;
+        }
+        soundFor(state).ifPresent(sound -> entity.playSound(sound, 0.75F, 1.0F));
+    }
+}

--- a/src/test/java/net/tigereye/chestcavity/mob_effect/fx/FurnacePowerFxHelperTest.java
+++ b/src/test/java/net/tigereye/chestcavity/mob_effect/fx/FurnacePowerFxHelperTest.java
@@ -1,0 +1,27 @@
+package net.tigereye.chestcavity.mob_effect.fx;
+
+
+import net.minecraft.util.SoundEvents;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FurnacePowerFxHelperTest {
+
+    @Test
+    void chargingStateReturnsCrackleSound() {
+        assertEquals(SoundEvents.FURNACE_FIRE_CRACKLE,
+                FurnacePowerFxHelper.soundFor(FurnaceFlowState.CHARGING).orElse(null));
+    }
+
+    @Test
+    void feedingStateReturnsBurpSound() {
+        assertEquals(SoundEvents.PLAYER_BURP,
+                FurnacePowerFxHelper.soundFor(FurnaceFlowState.FEEDING).orElse(null));
+    }
+
+    @Test
+    void idleStateReturnsNoSound() {
+        assertTrue(FurnacePowerFxHelper.soundFor(FurnaceFlowState.IDLE).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated furnace flow state enum and helper that maps states to sound effects
- trigger furnace power charge/feed sounds from the status effect using the helper
- wire up JUnit 5 and add tests covering the state-to-sound mapping

## Testing
- `./gradlew test` *(fails: missing Gradle wrapper classes in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e4d09aa88326b7b889673a82ba94