### PR TITLE
Add flow state FX linkage and tests

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/guscript/fx/client/FxClientDispatcher.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/fx/client/FxClientDispatcher.java
@@ -39,7 +39,7 @@ public final class FxClientDispatcher {
         play(payload.effectId(), context);
     }
 
-    private static void play(ResourceLocation id, FxRegistry.FxContext context) {
+    public static void play(ResourceLocation id, FxRegistry.FxContext context) {
         if (id == null || context == null) {
             return;
         }

--- a/src/main/java/net/tigereye/chestcavity/guscript/registry/GuScriptFlowLoader.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/registry/GuScriptFlowLoader.java
@@ -77,7 +77,20 @@ public final class GuScriptFlowLoader extends SimpleJsonResourceReloadListener {
                 enterActions.add(ActionRegistry.fromJson(element.getAsJsonObject()));
             }
         }
-        return new FlowStateDefinition(enterActions.isEmpty() ? List.of() : List.of(FlowActions.runActions(enterActions)), transitions);
+        List<ResourceLocation> enterFx = new ArrayList<>();
+        if (json.has("enter_fx")) {
+            for (JsonElement element : json.getAsJsonArray("enter_fx")) {
+                if (!element.isJsonPrimitive()) {
+                    throw new IllegalArgumentException("Flow state enter_fx entries must be strings");
+                }
+                enterFx.add(ResourceLocation.parse(element.getAsString()));
+            }
+        }
+        return new FlowStateDefinition(
+                enterActions.isEmpty() ? List.of() : List.of(FlowActions.runActions(enterActions)),
+                enterFx,
+                transitions
+        );
     }
 
     private static FlowTransition parseTransition(JsonObject json) {

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowController.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowController.java
@@ -23,6 +23,10 @@ public final class FlowController {
         this.performer = Objects.requireNonNull(performer, "performer");
     }
 
+    FlowController() {
+        this.performer = null;
+    }
+
     public ServerPlayer performer() {
         return performer;
     }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowInstance.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowInstance.java
@@ -1,5 +1,6 @@
 package net.tigereye.chestcavity.guscript.runtime.flow;
 
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
@@ -143,6 +144,10 @@ public final class FlowInstance {
 
     private Optional<FlowStateDefinition> definition() {
         return program.definition(state);
+    }
+
+    public List<ResourceLocation> enterFx() {
+        return definition().map(FlowStateDefinition::enterFx).orElse(List.of());
     }
     void rebindPerformer(Player performer) {
         if (performer != null) {

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowStateDefinition.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowStateDefinition.java
@@ -1,5 +1,7 @@
 package net.tigereye.chestcavity.guscript.runtime.flow;
 
+import net.minecraft.resources.ResourceLocation;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,15 +11,21 @@ import java.util.List;
 public final class FlowStateDefinition {
 
     private final List<FlowEdgeAction> enterActions;
+    private final List<ResourceLocation> enterFx;
     private final List<FlowTransition> transitions;
 
-    public FlowStateDefinition(List<FlowEdgeAction> enterActions, List<FlowTransition> transitions) {
+    public FlowStateDefinition(List<FlowEdgeAction> enterActions, List<ResourceLocation> enterFx, List<FlowTransition> transitions) {
         this.enterActions = enterActions == null ? List.of() : List.copyOf(enterActions);
+        this.enterFx = enterFx == null ? List.of() : List.copyOf(enterFx);
         this.transitions = transitions == null ? List.of() : List.copyOf(transitions);
     }
 
     public List<FlowEdgeAction> enterActions() {
         return enterActions;
+    }
+
+    public List<ResourceLocation> enterFx() {
+        return enterFx;
     }
 
     public List<FlowTransition> transitions() {

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/client/GuScriptClientFlows.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/client/GuScriptClientFlows.java
@@ -2,9 +2,16 @@ package net.tigereye.chestcavity.guscript.runtime.flow.client;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minecraft.client.Minecraft;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.phys.Vec3;
 import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.guscript.fx.FxRegistry;
+import net.tigereye.chestcavity.guscript.fx.client.FxClientDispatcher;
 import net.tigereye.chestcavity.guscript.network.packets.FlowSyncPayload;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -31,10 +38,34 @@ public final class GuScriptClientFlows {
         }
 
         void update(FlowSyncPayload payload) {
+            FlowSyncPayload previous = this.lastPayload;
             this.lastPayload = payload;
             ChestCavity.LOGGER.debug("[Flow][Client] Entity {} program {} -> {} (t={} start={})", entityId, payload.programId(), payload.state(), payload.ticksInState(), payload.stateGameTime());
             if (Minecraft.getInstance().player != null && Minecraft.getInstance().player.getId() == entityId) {
-                // Future: drive client-side FX. For now only log.
+                if (previous == null || previous.state() != payload.state()) {
+                    playEnterFx(payload);
+                }
+            }
+        }
+
+        private void playEnterFx(FlowSyncPayload payload) {
+            if (payload.enterFx().isEmpty()) {
+                return;
+            }
+            Minecraft minecraft = Minecraft.getInstance();
+            if (minecraft.level == null) {
+                return;
+            }
+            Entity entity = minecraft.level.getEntity(entityId);
+            if (!(entity instanceof LivingEntity living)) {
+                return;
+            }
+            Vec3 origin = new Vec3(living.getX(), living.getY() + living.getBbHeight() * 0.5D, living.getZ());
+            Vec3 look = living.getLookAngle();
+            FxRegistry.FxContext context = new FxRegistry.FxContext(origin, look, look, null, 1.0F, living.getId(), -1);
+            List<ResourceLocation> fxIds = payload.enterFx();
+            for (ResourceLocation fxId : fxIds) {
+                FxClientDispatcher.play(fxId, context);
             }
         }
     }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/sync/FlowSyncDispatcher.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/sync/FlowSyncDispatcher.java
@@ -22,7 +22,8 @@ public final class FlowSyncDispatcher {
                 instance.program().id(),
                 instance.state(),
                 instance.stateEnteredGameTime(),
-                instance.ticksInState()
+                instance.ticksInState(),
+                instance.enterFx()
         ));
     }
 
@@ -35,7 +36,8 @@ public final class FlowSyncDispatcher {
                 instance.program().id(),
                 instance.state(),
                 instance.stateEnteredGameTime(),
-                instance.ticksInState()
+                instance.ticksInState(),
+                instance.enterFx()
         ));
     }
 }

--- a/src/test/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowRuntimeTest.java
+++ b/src/test/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowRuntimeTest.java
@@ -1,0 +1,89 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.guscript.runtime.flow.guards.FlowGuards;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowInput;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FlowRuntimeTest {
+
+    @Test
+    void cooldownGuardBlocksUntilReady() {
+        FlowController controller = new FlowController();
+
+        FlowTransition start = new FlowTransition(
+                FlowTrigger.START,
+                FlowState.CHARGING,
+                List.of(FlowGuards.cooldownReady("demo")),
+                List.of(),
+                0
+        );
+
+        Map<FlowState, FlowStateDefinition> definitions = new EnumMap<>(FlowState.class);
+        definitions.put(FlowState.IDLE, new FlowStateDefinition(List.of(), List.of(), List.of(start)));
+        definitions.put(FlowState.CHARGING, new FlowStateDefinition(List.of(), List.of(), List.of()));
+
+        FlowProgram program = new FlowProgram(ResourceLocation.fromNamespaceAndPath("test", "cooldown"), FlowState.IDLE, definitions);
+
+        FlowInstance instance = new FlowInstance(program, null, null, controller, 0L);
+
+        controller.setCooldown("demo", 5L);
+        assertFalse(instance.attemptStart(0L), "Start should fail while cooldown is active");
+        assertEquals(FlowState.IDLE, instance.state(), "State should remain idle");
+
+        assertTrue(instance.attemptStart(10L), "Cooldown should expire once game time passes threshold");
+        assertEquals(FlowState.CHARGING, instance.state(), "State should advance to charging");
+        assertEquals(0, instance.ticksInState(), "Entering a state should reset tick counter");
+    }
+
+    @Test
+    void tickTransitionsRespectMinTicks() throws Exception {
+        FlowController controller = new FlowController();
+
+        FlowTransition start = new FlowTransition(
+                FlowTrigger.START,
+                FlowState.CHARGING,
+                List.of(),
+                List.of(),
+                0
+        );
+        FlowTransition chargingComplete = new FlowTransition(
+                FlowTrigger.RELEASE,
+                FlowState.RELEASING,
+                List.of(),
+                List.of(),
+                2
+        );
+
+        Map<FlowState, FlowStateDefinition> definitions = new EnumMap<>(FlowState.class);
+        definitions.put(FlowState.IDLE, new FlowStateDefinition(List.of(), List.of(), List.of(start)));
+        definitions.put(FlowState.CHARGING, new FlowStateDefinition(List.of(), List.of(), List.of(chargingComplete)));
+        definitions.put(FlowState.RELEASING, new FlowStateDefinition(List.of(), List.of(), List.of()));
+
+        FlowProgram program = new FlowProgram(ResourceLocation.fromNamespaceAndPath("test", "progress"), FlowState.IDLE, definitions);
+
+        FlowInstance instance = new FlowInstance(program, null, null, controller, 0L);
+        assertTrue(instance.attemptStart(0L), "Start transition should succeed without guards");
+        assertEquals(FlowState.CHARGING, instance.state(), "Flow should enter charging state");
+
+        Field ticksField = FlowInstance.class.getDeclaredField("ticksInState");
+        ticksField.setAccessible(true);
+
+        ticksField.setInt(instance, 1);
+        instance.handleInput(FlowInput.RELEASE, 5L);
+        assertEquals(FlowState.CHARGING, instance.state(), "Flow should remain charging until min ticks reached");
+
+        ticksField.setInt(instance, 2);
+        instance.handleInput(FlowInput.RELEASE, 6L);
+        assertEquals(FlowState.RELEASING, instance.state(), "Flow should advance after meeting min tick requirement");
+    }
+}


### PR DESCRIPTION
## Summary
- parse optional `enter_fx` bundles while loading flow states and include them in flow sync payloads
- trigger client FX playback when a player's mirrored flow state changes and expose `FxClientDispatcher.play`
- add `FlowRuntimeTest` to cover cooldown guard behavior and release-driven state progression

## Testing
- ./gradlew compileJava --no-daemon --console=plain
- ./gradlew test --no-daemon --console=plain


------
https://chatgpt.com/codex/tasks/task_e_68d8e6f588808326b8ecf2df127fe0d9