### PR TITLE
Add Fan Dai Cao Gu organ hunger conversion behavior

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shi_dao/ShiDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shi_dao/ShiDaoOrganRegistry.java
@@ -1,6 +1,7 @@
 package net.tigereye.chestcavity.compat.guzhenren.item.shi_dao;
 
 import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.behavior.FanDaiCaoGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.behavior.JiuChongOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
 
@@ -13,8 +14,12 @@ public final class ShiDaoOrganRegistry {
 
     private static final String MOD_ID = "guzhenren";
     private static final ResourceLocation JIU_CHONG_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "jiu_chong");
+    private static final ResourceLocation FAN_DAI_CAO_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "fan_dai_cao_gu");
 
     private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(FAN_DAI_CAO_GU_ID)
+                    .addSlowTickListener(FanDaiCaoGuOrganBehavior.INSTANCE)
+                    .build(),
             OrganIntegrationSpec.builder(JIU_CHONG_ID)
                     .addSlowTickListener(JiuChongOrganBehavior.INSTANCE)
                     .addOnHitListener(JiuChongOrganBehavior.INSTANCE)

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shi_dao/behavior/FanDaiCaoGuOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shi_dao/behavior/FanDaiCaoGuOrganBehavior.java
@@ -1,0 +1,51 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.behavior;
+
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.guzhenren.util.GuzhenrenHungerHelper;
+import net.tigereye.chestcavity.guzhenren.util.GuzhenrenResourceCostHelper;
+import net.tigereye.chestcavity.guzhenren.util.GuzhenrenResourceCostHelper.ConsumptionResult;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+
+/**
+ * Behaviour for 饭袋草蛊：消耗真元以维持饱食度。
+ */
+public enum FanDaiCaoGuOrganBehavior implements OrganSlowTickListener {
+    INSTANCE;
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation ORGAN_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "fan_dai_cao_gu");
+    private static final double BASE_ZHENYUAN_COST = 200.0;
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (!(entity instanceof Player player) || entity.level().isClientSide()) {
+            return;
+        }
+        if (!matchesOrgan(organ)) {
+            return;
+        }
+        if (!GuzhenrenHungerHelper.needsFood(player)) {
+            return;
+        }
+        ConsumptionResult payment = GuzhenrenResourceCostHelper.consumeStrict(player, BASE_ZHENYUAN_COST, 0.0);
+        if (!payment.succeeded()) {
+            return;
+        }
+        if (!GuzhenrenHungerHelper.topUpToFull(player)) {
+            GuzhenrenResourceCostHelper.refund(player, payment);
+        }
+    }
+
+    private static boolean matchesOrgan(ItemStack organ) {
+        if (organ == null || organ.isEmpty()) {
+            return false;
+        }
+        ResourceLocation id = BuiltInRegistries.ITEM.getKey(organ.getItem());
+        return ORGAN_ID.equals(id);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guzhenren/util/GuzhenrenHungerHelper.java
+++ b/src/main/java/net/tigereye/chestcavity/guzhenren/util/GuzhenrenHungerHelper.java
@@ -1,0 +1,73 @@
+package net.tigereye.chestcavity.guzhenren.util;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.food.FoodData;
+
+/**
+ * Utility helpers for manipulating player hunger without relying on real food items.
+ */
+public final class GuzhenrenHungerHelper {
+
+    private static final int VANILLA_MAX_FOOD_LEVEL = 20;
+
+    private GuzhenrenHungerHelper() {
+    }
+
+    /**
+     * Returns whether the supplied player can benefit from additional food.
+     *
+     * @param player player to query
+     * @return {@code true} if the player exists and is not at full hunger, {@code false} otherwise
+     */
+    public static boolean needsFood(Player player) {
+        if (player == null) {
+            return false;
+        }
+        FoodData foodData = player.getFoodData();
+        return foodData != null && foodData.needsFood();
+    }
+
+    /**
+     * Restores the player's hunger bar to full using vanilla food rules for saturation.
+     *
+     * @param player the player to feed
+     * @return {@code true} if any hunger was restored, {@code false} otherwise
+     */
+    public static boolean topUpToFull(Player player) {
+        return topUpTo(player, VANILLA_MAX_FOOD_LEVEL, 1.0f);
+    }
+
+    /**
+     * Adds virtual nutrition up to the requested food level, applying saturation using the provided modifier.
+     *
+     * @param player             player receiving the virtual meal
+     * @param targetFoodLevel    target food level after the meal (clamped to vanilla limits)
+     * @param saturationModifier saturation modifier equivalent to {@link net.minecraft.world.food.FoodProperties#getSaturationModifier()}
+     * @return {@code true} if any hunger was restored, {@code false} otherwise
+     */
+    public static boolean topUpTo(Player player, int targetFoodLevel, float saturationModifier) {
+        if (player == null) {
+            return false;
+        }
+        FoodData foodData = player.getFoodData();
+        if (foodData == null) {
+            return false;
+        }
+        int clampedTarget = Math.max(0, Math.min(targetFoodLevel, VANILLA_MAX_FOOD_LEVEL));
+        int current = foodData.getFoodLevel();
+        int missing = clampedTarget - current;
+        if (missing <= 0) {
+            return false;
+        }
+        float clampedSaturation = Math.max(0.0f, saturationModifier);
+        foodData.eat(missing, clampedSaturation);
+        if (foodData.getFoodLevel() > clampedTarget) {
+            foodData.setFoodLevel(clampedTarget);
+        }
+        float saturation = foodData.getSaturationLevel();
+        if (saturation > foodData.getFoodLevel()) {
+            foodData.setSaturation(foodData.getFoodLevel());
+        }
+        return true;
+    }
+}

--- a/src/main/resources/data/chestcavity/organs/guzhenren/human/fan_dai_cao_gu.json
+++ b/src/main/resources/data/chestcavity/organs/guzhenren/human/fan_dai_cao_gu.json
@@ -1,0 +1,6 @@
+{
+  "itemID": "guzhenren:fan_dai_cao_gu",
+  "organScores": [
+    {"id":"chestcavity:digestion","value": "0.5"}
+  ]
+}


### PR DESCRIPTION
## Summary
- add a reusable Guzhenren hunger helper for virtual feeding logic
- implement Fan Dai Cao Gu to convert zhenyuan into hunger restoration on slow ticks
- register the new organ and datapack entry with its digestion score

## Testing
- ./gradlew -g .gradle-home compileJava --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68d8f8951d28832696d6b3f493dff077