### PR TITLE
Scale GuScript tag contributions by stack count

### DIFF
--- a/docs/design/guscript-module.md
+++ b/docs/design/guscript-module.md
@@ -55,7 +55,7 @@ The top-level package highlights the AST and UI folders explicitly while still a
   - actions (`EmitProjectileNode`, `ConsumeResourceNode`, `ApplyEffectNode`),
   - queries (`ReadResourceNode`, `CheckOrganNode`, `LinkageValueNode`).
 - `GuScriptParser` produces ASTs from JSON/NBT resources placed under `data/chestcavity/guscript/scripts/`. Manual editing in the UI will emit the same format to attachment storage.
-- `GuScriptCompiler` folds the AST into executable `GuScriptProgram` objects with validated resource requirements and pre-bound references to `GuScriptBridge`. Compilation happens server-side; client uses lightweight summaries for UI preview.
+- `GuScriptCompiler` folds the AST into executable `GuScriptProgram` objects with validated resource requirements and pre-bound references to `GuScriptBridge`. Compilation happens server-side; client uses lightweight summaries for UI preview. When a page slot holds an `ItemStack` with a count > 1, the compiler multiplies the leaf's tag multiset by that count so reaction rules requiring repeated tags can match a single stacked item.
 - Validation errors feed back to the UI via dedicated sync packets so players know why a script fails to arm.
 - Reactive nodes subscribe to context updates (linkage/resource deltas, target changes) via a lightweight observer API. When those values change, dependent nodes mark cached results dirty so only affected branches re-evaluate.
 - Compilation caches structural metadata (listener graphs, node indices) so repeated triggers reuse existing node instances while swapping in fresh execution context.

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptCompiler.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptCompiler.java
@@ -1,5 +1,6 @@
 package net.tigereye.chestcavity.guscript.runtime.exec;
 
+import com.google.common.collect.HashMultiset;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.tigereye.chestcavity.ChestCavity;
@@ -58,7 +59,7 @@ public final class GuScriptCompiler {
             }
             ResourceLocation itemId = stack.getItem().builtInRegistryHolder().key().location();
             GuScriptRegistry.leaf(itemId).ifPresentOrElse(def -> {
-                leaves.add(def.toNode());
+                leaves.add(toScaledLeaf(def, stack.getCount()));
             }, () -> ChestCavity.LOGGER.debug("[GuScript] No leaf definition for item {}", itemId));
         }
 
@@ -91,6 +92,13 @@ public final class GuScriptCompiler {
         page.setInventorySignature(signature);
         page.consumeDirtyFlag();
         return program;
+    }
+
+    static LeafGuNode toScaledLeaf(GuScriptRegistry.LeafDefinition definition, int count) {
+        int scaledCount = Math.max(1, count);
+        HashMultiset<String> scaledTags = HashMultiset.create();
+        definition.tags().forEachEntry((tag, tagCount) -> scaledTags.add(tag, tagCount * scaledCount));
+        return new LeafGuNode(definition.name(), scaledTags, definition.actions());
     }
 
     private static int computeSignature(GuScriptPageState page) {

--- a/src/test/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptCompilerTest.java
+++ b/src/test/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptCompilerTest.java
@@ -1,0 +1,80 @@
+package net.tigereye.chestcavity.guscript.runtime.exec;
+
+import com.google.common.collect.ImmutableMultiset;
+import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.guscript.ast.GuNode;
+import net.tigereye.chestcavity.guscript.ast.GuNodeKind;
+import net.tigereye.chestcavity.guscript.ast.LeafGuNode;
+import net.tigereye.chestcavity.guscript.ast.OperatorGuNode;
+import net.tigereye.chestcavity.guscript.registry.GuScriptRegistry;
+import net.tigereye.chestcavity.guscript.runtime.reduce.GuScriptReducer;
+import net.tigereye.chestcavity.guscript.runtime.reduce.ReactionRule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GuScriptCompilerTest {
+
+    private static final ResourceLocation TEST_ITEM_ID = ResourceLocation.fromNamespaceAndPath("chestcavity", "test_leaf");
+
+    @BeforeEach
+    void setUpRegistry() {
+        GuScriptRegistry.updateLeaves(Map.of(
+                TEST_ITEM_ID,
+                new GuScriptRegistry.LeafDefinition(
+                        "骨道叶",
+                        ImmutableMultiset.of("骨道"),
+                        List.of()
+                )
+        ));
+
+        ReactionRule doubleBone = ReactionRule.builder("chestcavity:test_double_bone")
+                .arity(1)
+                .requiredTags(ImmutableMultiset.of("骨道", "骨道"))
+                .priority(10)
+                .operator((ruleId, inputs) -> new OperatorGuNode(
+                        ruleId,
+                        "骨道合鸣",
+                        GuNodeKind.OPERATOR,
+                        ImmutableMultiset.of("测试"),
+                        List.of(),
+                        inputs
+                ))
+                .build();
+
+        GuScriptRegistry.updateReactionRules(List.of(doubleBone));
+    }
+
+    @AfterEach
+    void tearDownRegistry() {
+        GuScriptRegistry.updateLeaves(Map.of());
+        GuScriptRegistry.updateReactionRules(List.of());
+    }
+
+    @Test
+    void toScaledLeaf_multipliesTagsByCount() {
+        GuScriptRegistry.LeafDefinition definition = GuScriptRegistry.leaf(TEST_ITEM_ID).orElseThrow();
+        LeafGuNode scaled = GuScriptCompiler.toScaledLeaf(definition, 3);
+        assertEquals(3, scaled.tags().count("骨道"));
+
+        GuScriptReducer reducer = new GuScriptReducer();
+        GuScriptReducer.ReductionResult result = reducer.reduce(List.of(scaled), GuScriptRegistry.reactionRules());
+
+        List<GuNode> roots = result.roots();
+        assertEquals(1, roots.size(), "Expected scaled leaf to satisfy double tag requirement");
+        assertEquals("骨道合鸣", roots.getFirst().name());
+    }
+
+    @Test
+    void toScaledLeaf_requiresEnoughCountToMatch() {
+        GuScriptRegistry.LeafDefinition definition = GuScriptRegistry.leaf(TEST_ITEM_ID).orElseThrow();
+        LeafGuNode scaled = GuScriptCompiler.toScaledLeaf(definition, 1);
+        assertEquals(1, scaled.tags().count("骨道"));
+
+    }
+}


### PR DESCRIPTION
## Summary
- scale GuScript leaf nodes by the item stack count so reaction rules see repeated tags
- document the stack-count scaling behaviour in the GuScript design notes
- add a regression test covering tag scaling and matching via the reducer

## Testing
- `./gradlew -g .gradle-home test --console=plain --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68d9277e15808326bfb59d5ef33b8159