### PR TITLE
Add time acceleration and thoughts flows with supporting actions

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutor.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutor.java
@@ -280,7 +280,7 @@ public final class GuScriptExecutor {
                 if (program.isPresent()) {
                     double timeScale = parseTimeScale(flowParams);
                     FlowControllerManager.get(performer)
-                            .start(program.get(), target, timeScale, performer.level().getGameTime());
+                            .start(program.get(), target, timeScale, flowParams, performer.level().getGameTime());
                     ChestCavity.LOGGER.info(
                             "[GuScript] Root {}#{} started flow {} (source={}, timeScale={}, params={})",
                             root.name(),

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowController.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowController.java
@@ -17,6 +17,9 @@ public final class FlowController {
 
     private ServerPlayer performer;
     private final Map<String, Long> cooldowns = new java.util.HashMap<>();
+    private final Map<String, Long> longVariables = new java.util.HashMap<>();
+    private final Map<String, Double> doubleVariables = new java.util.HashMap<>();
+    private final java.util.PriorityQueue<ScheduledTask> scheduledTasks = new java.util.PriorityQueue<>();
     private FlowInstance instance;
 
     public FlowController(ServerPlayer performer) {
@@ -50,20 +53,22 @@ public final class FlowController {
         if (!(level instanceof ServerLevel serverLevel)) {
             return;
         }
+        runScheduledTasks(serverLevel);
         if (instance != null) {
             instance.tick(serverLevel);
             if (instance.isFinished()) {
                 FlowSyncDispatcher.syncStopped(performer, instance);
+                clearRuntimeState();
                 instance = null;
             }
         }
     }
 
-    public void start(FlowProgram program, LivingEntity target, long gameTime) {
-        start(program, target, 1.0, gameTime);
+    public void start(FlowProgram program, LivingEntity target, java.util.Map<String, String> flowParams, long gameTime) {
+        start(program, target, 1.0, flowParams, gameTime);
     }
 
-    public void start(FlowProgram program, LivingEntity target, double timeScale, long gameTime) {
+    public void start(FlowProgram program, LivingEntity target, double timeScale, java.util.Map<String, String> flowParams, long gameTime) {
         if (program == null) {
             return;
         }
@@ -71,7 +76,9 @@ public final class FlowController {
             ChestCavity.LOGGER.debug("[Flow] Ignoring start for {} because flow {} already running", performer.getGameProfile().getName(), instance.program().id());
             return;
         }
-        instance = new FlowInstance(program, performer, target, this, Math.max(0.0, timeScale), gameTime);
+        clearRuntimeState();
+        java.util.Map<String, String> safeParams = flowParams == null ? java.util.Map.of() : java.util.Map.copyOf(flowParams);
+        instance = new FlowInstance(program, performer, target, this, Math.max(0.0, timeScale), safeParams, gameTime);
         FlowSyncDispatcher.syncState(performer, instance);
         if (!instance.attemptStart(gameTime)) {
             ChestCavity.LOGGER.debug("[Flow] Flow {} stayed in {} after start trigger", program.id(), instance.state());
@@ -96,5 +103,128 @@ public final class FlowController {
 
     public void setCooldown(String key, long readyTick) {
         cooldowns.put(key, readyTick);
+    }
+
+    public void setLong(String key, long value) {
+        if (key != null) {
+            longVariables.put(key, value);
+        }
+    }
+
+    public long addLong(String key, long delta) {
+        if (key == null) {
+            return 0L;
+        }
+        long value = longVariables.getOrDefault(key, 0L) + delta;
+        longVariables.put(key, value);
+        return value;
+    }
+
+    public long getLong(String key, long defaultValue) {
+        if (key == null) {
+            return defaultValue;
+        }
+        return longVariables.getOrDefault(key, defaultValue);
+    }
+
+    public void setDouble(String key, double value) {
+        if (key != null && !Double.isNaN(value) && !Double.isInfinite(value)) {
+            doubleVariables.put(key, value);
+        }
+    }
+
+    public double addDouble(String key, double delta) {
+        if (key == null || Double.isNaN(delta) || Double.isInfinite(delta)) {
+            return 0.0D;
+        }
+        double value = doubleVariables.getOrDefault(key, 0.0D) + delta;
+        doubleVariables.put(key, value);
+        return value;
+    }
+
+    public double getDouble(String key, double defaultValue) {
+        if (key == null) {
+            return defaultValue;
+        }
+        return doubleVariables.getOrDefault(key, defaultValue);
+    }
+
+    public void clampDouble(String key, double min, double max) {
+        if (key == null) {
+            return;
+        }
+        double value = getDouble(key, 0.0D);
+        double clamped = net.minecraft.util.Mth.clamp(value, min, max);
+        doubleVariables.put(key, clamped);
+    }
+
+    public void clampLong(String key, long min, long max) {
+        if (key == null) {
+            return;
+        }
+        long value = getLong(key, 0L);
+        long clamped = java.lang.Math.max(min, java.lang.Math.min(max, value));
+        longVariables.put(key, clamped);
+    }
+
+    public String resolveFlowParam(String key) {
+        if (instance == null) {
+            return null;
+        }
+        return instance.resolveParam(key).orElse(null);
+    }
+
+    public double resolveFlowParamAsDouble(String key, double defaultValue) {
+        if (instance == null) {
+            return defaultValue;
+        }
+        return instance.resolveParamAsDouble(key, defaultValue);
+    }
+
+    public void schedule(long executeAtTick, Runnable runnable) {
+        if (runnable == null) {
+            return;
+        }
+        scheduledTasks.add(new ScheduledTask(Math.max(0L, executeAtTick), runnable));
+    }
+
+    FlowInstance currentInstance() {
+        return instance;
+    }
+
+    private void runScheduledTasks(ServerLevel level) {
+        long gameTime = level.getGameTime();
+        while (!scheduledTasks.isEmpty() && scheduledTasks.peek().executeAt <= gameTime) {
+            ScheduledTask task = scheduledTasks.poll();
+            if (task == null || task.runnable == null) {
+                continue;
+            }
+            try {
+                task.runnable.run();
+            } catch (Exception ex) {
+                ChestCavity.LOGGER.error("[Flow] Scheduled task failed", ex);
+            }
+        }
+    }
+
+    private void clearRuntimeState() {
+        longVariables.clear();
+        doubleVariables.clear();
+        scheduledTasks.clear();
+    }
+
+    private static final class ScheduledTask implements Comparable<ScheduledTask> {
+        private final long executeAt;
+        private final Runnable runnable;
+
+        private ScheduledTask(long executeAt, Runnable runnable) {
+            this.executeAt = executeAt;
+            this.runnable = runnable;
+        }
+
+        @Override
+        public int compareTo(ScheduledTask other) {
+            return Long.compare(this.executeAt, other.executeAt);
+        }
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/guards/FlowGuards.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/guards/FlowGuards.java
@@ -105,4 +105,44 @@ public final class FlowGuards {
             }
         };
     }
+
+    public static FlowGuard variableAtMost(String name, double maximumInclusive, boolean asDouble) {
+        return new FlowGuard() {
+            @Override
+            public boolean test(Player performer, LivingEntity target, FlowController controller, long gameTime) {
+                if (controller == null || name == null) {
+                    return false;
+                }
+                if (asDouble) {
+                    return controller.getDouble(name, Double.NEGATIVE_INFINITY) <= maximumInclusive;
+                }
+                return controller.getLong(name, Long.MIN_VALUE) <= (long) Math.floor(maximumInclusive);
+            }
+
+            @Override
+            public String describe() {
+                return "variable_at_most(" + name + ", " + maximumInclusive + ")";
+            }
+        };
+    }
+
+    public static FlowGuard variableAtLeast(String name, double minimumInclusive, boolean asDouble) {
+        return new FlowGuard() {
+            @Override
+            public boolean test(Player performer, LivingEntity target, FlowController controller, long gameTime) {
+                if (controller == null || name == null) {
+                    return false;
+                }
+                if (asDouble) {
+                    return controller.getDouble(name, Double.POSITIVE_INFINITY) >= minimumInclusive;
+                }
+                return controller.getLong(name, Long.MAX_VALUE) >= (long) Math.ceil(minimumInclusive);
+            }
+
+            @Override
+            public String describe() {
+                return "variable_at_least(" + name + ", " + minimumInclusive + ")";
+            }
+        };
+    }
 }

--- a/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_orbit.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_orbit.json
@@ -1,0 +1,27 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:block.amethyst_block.chime",
+      "volume": 0.55,
+      "pitch": 1.4
+    },
+    {
+      "type": "trail",
+      "particle": "minecraft:end_rod",
+      "offset": [0.0, 1.6, 0.0],
+      "segments": 20,
+      "spacing": 0.19,
+      "speed": 0.05,
+      "spread": [0.02, 0.02, 0.02]
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:glow",
+      "count": 10,
+      "offset": [0.0, 1.8, 0.0],
+      "spread": [0.15, 0.2, 0.15],
+      "speed": 0.0
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_pulse.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_pulse.json
@@ -1,0 +1,24 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:block.note_block.pling",
+      "volume": 0.65,
+      "pitch": 1.7
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:witch",
+      "count": 20,
+      "spread": [0.4, 0.2, 0.4],
+      "speed": 0.02
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:spell_instant",
+      "count": 16,
+      "spread": [0.35, 0.35, 0.35],
+      "speed": 0.0
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/time_accel_enter.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/time_accel_enter.json
@@ -1,0 +1,24 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:block.beacon.activate",
+      "volume": 0.9,
+      "pitch": 1.25
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:poof",
+      "count": 24,
+      "spread": [0.45, 0.6, 0.45],
+      "speed": 0.02
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:enchant",
+      "count": 36,
+      "spread": [0.3, 1.0, 0.3],
+      "speed": 0.0
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/time_accel_exit.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/time_accel_exit.json
@@ -1,0 +1,24 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:block.note_block.hat",
+      "volume": 0.7,
+      "pitch": 1.6
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:dragon_breath",
+      "count": 18,
+      "spread": [0.3, 0.4, 0.3],
+      "speed": 0.05
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:enchant",
+      "count": 24,
+      "spread": [0.25, 0.9, 0.25],
+      "speed": 0.0
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/time_accel_loop.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/time_accel_loop.json
@@ -1,0 +1,27 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:block.beacon.ambient",
+      "volume": 0.5,
+      "pitch": 1.35
+    },
+    {
+      "type": "trail",
+      "particle": "minecraft:portal",
+      "offset": [0.0, 1.3, 0.0],
+      "segments": 28,
+      "spacing": 0.18,
+      "speed": 0.08,
+      "spread": [0.05, 0.05, 0.05]
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:glow",
+      "count": 12,
+      "offset": [0.0, 1.4, 0.0],
+      "spread": [0.25, 0.25, 0.25],
+      "speed": 0.0
+    }
+  ]
+}

--- a/src/main/resources/data/chestcavity/guscript/flows/thoughts_cycle.json
+++ b/src/main/resources/data/chestcavity/guscript/flows/thoughts_cycle.json
@@ -1,0 +1,71 @@
+{
+  "initial_state": "idle",
+  "states": {
+    "idle": {
+      "transitions": [
+        {"trigger": "start", "target": "charging"}
+      ]
+    },
+    "charging": {
+      "enter_fx": ["chestcavity:mind_thoughts_orbit"],
+      "enter_actions": [
+        {"type": "set_variable_from_param", "param": "stack_gain", "name": "thoughts.gain", "default": 1.0},
+        {"type": "set_variable_from_param", "param": "max_count", "name": "thoughts.max", "default": 5.0},
+        {"type": "set_variable_from_param", "param": "decay_per_tick", "name": "thoughts.decay", "default": 0.2},
+        {"type": "set_variable_from_param", "param": "radius", "name": "thoughts.radius", "default": 10.0},
+        {"type": "add_variable_from_variable", "name": "thoughts.count", "source": "thoughts.gain", "scale": 1.0, "value_type": "double"},
+        {"type": "clamp_variable", "name": "thoughts.count", "min": 0.0, "max": 999.0},
+        {"type": "copy_variable", "from": "thoughts.count", "to": "thoughts.export", "scale": 0.1, "offset": 0.0, "value_type": "double"},
+        {"type": "emit_fx", "fx": "chestcavity:mind_thoughts_pulse", "base_intensity": 0.5, "scale_variable": "thoughts.count", "default_scale": 1.0}
+      ],
+      "transitions": [
+        {"trigger": "auto", "target": "charged", "min_ticks": 5},
+        {"trigger": "cancel", "target": "cancel"}
+      ]
+    },
+    "charged": {
+      "update_period": 20,
+      "update_actions": [
+        {"type": "add_variable_from_variable", "name": "thoughts.count", "source": "thoughts.decay", "scale": -1.0, "value_type": "double"},
+        {"type": "clamp_variable", "name": "thoughts.count", "min": 0.0, "max": 999.0},
+        {"type": "copy_variable", "from": "thoughts.count", "to": "thoughts.export", "scale": 0.1, "offset": 0.0, "value_type": "double"},
+        {"type": "emit_fx", "fx": "chestcavity:mind_thoughts_orbit", "base_intensity": 0.6, "scale_variable": "thoughts.count", "default_scale": 1.0},
+        {"type": "highlight_hostiles", "radius": 10.0, "radius_variable": "thoughts.radius", "duration": 20}
+      ],
+      "transitions": [
+        {
+          "trigger": "auto",
+          "target": "releasing",
+          "min_ticks": 20,
+          "guards": [
+            {"type": "variable_at_most", "name": "thoughts.count", "maximum": 0.0, "value_type": "double"}
+          ]
+        },
+        {"trigger": "cancel", "target": "cancel"}
+      ]
+    },
+    "releasing": {
+      "enter_actions": [
+        {"type": "set_variable", "name": "thoughts.count", "value": 0.0, "value_type": "double"},
+        {"type": "set_variable", "name": "thoughts.export", "value": 0.0, "value_type": "double"}
+      ],
+      "transitions": [
+        {"trigger": "auto", "target": "cooldown", "min_ticks": 10}
+      ]
+    },
+    "cooldown": {
+      "transitions": [
+        {"trigger": "auto", "target": "idle", "min_ticks": 20}
+      ]
+    },
+    "cancel": {
+      "enter_actions": [
+        {"type": "set_variable", "name": "thoughts.count", "value": 0.0, "value_type": "double"},
+        {"type": "set_variable", "name": "thoughts.export", "value": 0.0, "value_type": "double"}
+      ],
+      "transitions": [
+        {"trigger": "auto", "target": "cooldown", "min_ticks": 10}
+      ]
+    }
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/flows/time_acceleration.json
+++ b/src/main/resources/data/chestcavity/guscript/flows/time_acceleration.json
@@ -1,0 +1,78 @@
+{
+  "initial_state": "idle",
+  "states": {
+    "idle": {
+      "transitions": [
+        {
+          "trigger": "start",
+          "target": "charging"
+        }
+      ]
+    },
+    "charging": {
+      "enter_fx": ["chestcavity:time_accel_enter"],
+      "enter_actions": [
+        {"type": "apply_effect", "id": "minecraft:speed", "duration": 220, "amplifier": 4, "showParticles": false, "showIcon": true},
+        {"type": "apply_effect", "id": "minecraft:haste", "duration": 220, "amplifier": 4, "showParticles": false, "showIcon": true},
+        {"type": "apply_attribute", "attribute": "minecraft:generic.attack_speed", "modifier": "chestcavity:time_accel_attack", "operation": "add_value", "amount": 1.75},
+        {"type": "apply_attribute", "attribute": "minecraft:generic.movement_speed", "modifier": "chestcavity:time_accel_move", "operation": "add_value", "amount": 0.12},
+        {"type": "set_variable_from_param", "param": "intensity", "name": "time_accel.intensity", "default": 1.0},
+        {"type": "set_variable_from_param", "param": "radius", "name": "time_accel.radius", "default": 8.0},
+        {"type": "set_variable_from_param", "param": "duration_ticks", "name": "time_accel.duration", "default": 200.0}
+      ],
+      "transitions": [
+        {"trigger": "auto", "target": "charged", "min_ticks": 5},
+        {"trigger": "cancel", "target": "cancel"}
+      ]
+    },
+    "charged": {
+      "update_period": 20,
+      "update_actions": [
+        {"type": "apply_effect", "id": "minecraft:speed", "duration": 220, "amplifier": 4, "showParticles": false, "showIcon": true},
+        {"type": "apply_effect", "id": "minecraft:haste", "duration": 220, "amplifier": 4, "showParticles": false, "showIcon": true},
+        {"type": "area_effect", "id": "minecraft:slowness", "duration": 40, "amplifier": 2, "radius": 8.0, "radius_variable": "time_accel.radius", "hostiles_only": true, "show_particles": false, "show_icon": false},
+        {"type": "area_effect", "id": "minecraft:mining_fatigue", "duration": 40, "amplifier": 1, "radius": 8.0, "radius_variable": "time_accel.radius", "hostiles_only": true, "show_particles": false, "show_icon": false},
+        {"type": "dampen_projectiles", "radius": 8.0, "radius_variable": "time_accel.radius", "factor": 0.55, "cap": 24},
+        {"type": "emit_fx", "fx": "chestcavity:time_accel_loop", "base_intensity": 1.0, "scale_variable": "time_accel.intensity", "default_scale": 1.0},
+        {"type": "add_variable", "name": "time_accel.duration", "value": -20.0},
+        {"type": "clamp_variable", "name": "time_accel.duration", "min": 0.0, "max": 1200.0}
+      ],
+      "transitions": [
+        {
+          "trigger": "auto",
+          "target": "releasing",
+          "min_ticks": 20,
+          "guards": [
+            {"type": "variable_at_most", "name": "time_accel.duration", "maximum": 0.0, "value_type": "double"}
+          ]
+        },
+        {"trigger": "cancel", "target": "cancel"}
+      ]
+    },
+    "releasing": {
+      "enter_fx": ["chestcavity:time_accel_exit"],
+      "enter_actions": [
+        {"type": "remove_attribute", "attribute": "minecraft:generic.attack_speed", "modifier": "chestcavity:time_accel_attack"},
+        {"type": "remove_attribute", "attribute": "minecraft:generic.movement_speed", "modifier": "chestcavity:time_accel_move"}
+      ],
+      "transitions": [
+        {"trigger": "auto", "target": "cooldown", "min_ticks": 10}
+      ]
+    },
+    "cooldown": {
+      "transitions": [
+        {"trigger": "auto", "target": "idle", "min_ticks": 40}
+      ]
+    },
+    "cancel": {
+      "enter_fx": ["chestcavity:time_accel_exit"],
+      "enter_actions": [
+        {"type": "remove_attribute", "attribute": "minecraft:generic.attack_speed", "modifier": "chestcavity:time_accel_attack"},
+        {"type": "remove_attribute", "attribute": "minecraft:generic.movement_speed", "modifier": "chestcavity:time_accel_move"}
+      ],
+      "transitions": [
+        {"trigger": "auto", "target": "cooldown", "min_ticks": 10}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extend the flow runtime with variable storage, scheduled tasks, and flow parameter lookups so actions can react to flow configuration
- add a suite of flow actions and guards for attribute modifiers, area effects, projectile dampening, variable math, and FX emission, then wire up JSON loading support
- author new time_acceleration and thoughts_cycle flow programs plus client FX definitions for their enter/loop/exit and orbit/pulse visuals

## Testing
- ./gradlew -g .gradle-home compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d9305757748326b1349e1fa012969c