### PR TITLE
Add flow diagnostics and update demo charge flow

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowInstance.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowInstance.java
@@ -165,6 +165,14 @@ public final class FlowInstance {
         this.state = nextState;
         this.stateEnteredGameTime = gameTime;
         this.ticksInState = 0;
+        // log state enter for diagnostics
+        ChestCavity.LOGGER.info(
+                "[Flow] {} entered {} (timeScale={}, params={})",
+                program.id(),
+                nextState,
+                String.format("%.3f", timeScale),
+                flowParams.isEmpty() ? "{}" : flowParams
+        );
         controller.handleStateChanged(this);
         Optional<FlowStateDefinition> definition = definition();
         if (definition.isPresent()) {

--- a/src/main/resources/data/chestcavity/guscript/flows/demo_charge_release.json
+++ b/src/main/resources/data/chestcavity/guscript/flows/demo_charge_release.json
@@ -7,44 +7,73 @@
           "trigger": "start",
           "target": "charging",
           "guards": [
-            {"type": "cooldown", "key": "chestcavity:demo_charge_release"},
-            {"type": "resource", "identifier": "zhenyuan", "minimum": 10.0}
+            { "type": "cooldown", "key": "chestcavity:demo_charge_release" },
+            { "type": "resource", "identifier": "zhenyuan", "minimum": 10.0 }
           ],
           "actions": [
-            {"type": "consume_resource", "identifier": "zhenyuan", "amount": 10.0},
-            {"type": "set_cooldown", "key": "chestcavity:demo_charge_release", "ticks": 200}
+            { "type": "consume_resource", "identifier": "zhenyuan", "amount": 10.0 },
+            { "type": "set_cooldown", "key": "chestcavity:demo_charge_release", "ticks": 200 }
           ]
         }
       ]
     },
     "charging": {
+      "enter_actions": [
+        { "type": "apply_attribute", "attribute": "minecraft:generic.movement_speed", "modifier": "chestcavity:charge_lock", "operation": "MULTIPLY_TOTAL", "amount": -1.0 }
+      ],
+      "update_period": 20,
+      "update_actions": [
+        { "type": "consume_health", "amount": 2.0 },
+        { "type": "consume_resource", "identifier": "zhenyuan", "amount": 20.0 },
+        { "type": "consume_resource", "identifier": "jingli", "amount": 10.0 },
+        { "type": "trigger_actions", "actions": [ { "id": "emit.fx", "fxId": "chestcavity:blood_bone_charge_heartbeat", "intensity": 1.0 } ] }
+      ],
       "transitions": [
-        {"trigger": "auto", "target": "charged", "min_ticks": 40},
-        {"trigger": "cancel", "target": "cancel"}
+        {
+          "trigger": "auto",
+          "target": "cancel",
+          "guards": [
+            { "type": "health_below", "maximum": 2.0 },
+            { "type": "resource_below", "identifier": "zhenyuan", "maximum": 20.0 },
+            { "type": "resource_below", "identifier": "jingli", "maximum": 10.0 }
+          ]
+        },
+        { "trigger": "auto", "target": "charged", "min_ticks": 40 },
+        { "trigger": "cancel", "target": "cancel" }
       ]
     },
     "charged": {
       "transitions": [
-        {"trigger": "auto", "target": "releasing", "min_ticks": 160},
-        {"trigger": "cancel", "target": "cancel"}
+        { "trigger": "auto", "target": "releasing", "min_ticks": 160 },
+        { "trigger": "cancel", "target": "cancel" }
       ]
     },
     "releasing": {
+      "enter_fx": [ "chestcavity:burst" ],
       "enter_actions": [
-        {"id": "emit.projectile", "projectileId": "chestcavity:bone_gun_projectile", "damage": 12.0}
+        { "id": "emit.projectile", "projectileId": "chestcavity:bone_gun_projectile", "damage": 12.0 }
       ],
       "transitions": [
-        {"trigger": "auto", "target": "cooldown", "min_ticks": 5}
+        { "trigger": "auto", "target": "cooldown", "min_ticks": 5 }
       ]
     },
     "cooldown": {
+      "enter_actions": [
+        { "type": "remove_attribute", "attribute": "minecraft:generic.movement_speed", "modifier": "chestcavity:charge_lock" }
+      ],
       "transitions": [
-        {"trigger": "auto", "target": "idle", "min_ticks": 40}
+        { "trigger": "auto", "target": "idle", "min_ticks": 40 }
       ]
     },
     "cancel": {
+      "enter_actions": [
+        { "type": "remove_attribute", "attribute": "minecraft:generic.movement_speed", "modifier": "chestcavity:charge_lock" },
+        { "type": "true_damage", "amount": 50.0 },
+        { "type": "explode", "power": 3.5 },
+        { "type": "trigger_actions", "actions": [ { "id": "emit.fx", "fxId": "chestcavity:blood_bone_charge_failure", "intensity": 1.0 } ] }
+      ],
       "transitions": [
-        {"trigger": "auto", "target": "cooldown", "min_ticks": 5}
+        { "trigger": "auto", "target": "cooldown", "min_ticks": 5 }
       ]
     }
   }

--- a/src/main/resources/data/chestcavity/guscript/flows/thoughts_cycle.json
+++ b/src/main/resources/data/chestcavity/guscript/flows/thoughts_cycle.json
@@ -20,6 +20,16 @@
         { "trigger": "cancel", "target": "cancel" }
       ]
     },
+    "charged": {
+      "transitions": [
+        { "trigger": "auto", "target": "cooldown", "min_ticks": 1 }
+      ]
+    },
+    "releasing": {
+      "transitions": [
+        { "trigger": "auto", "target": "cooldown", "min_ticks": 1 }
+      ]
+    },
     "cooldown": {
       "transitions": [
         { "trigger": "auto", "target": "idle", "min_ticks": 40 }


### PR DESCRIPTION
## Summary
- log every flow state entry with program id, state, time scale, and parameters
- support FlowActions in enter/update action arrays so JSON states can mix typed and scripted actions
- update demo_charge_release and thoughts_cycle flows with charging costs, failure handling, and stub states

## Testing
- `./gradlew --console=plain --no-configuration-cache compileJava test`


------
https://chatgpt.com/codex/tasks/task_e_68d9bd75b9008326ae59e06f5221678c