### PR TITLE
Add flow queue support with guard revalidation

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
+++ b/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
@@ -176,6 +176,14 @@ public class CCConfig implements ConfigData {
         public double maxCumulativeFlat = 20.0D;
         @ConfigEntry.Gui.Tooltip
         public boolean enableFlows = true; // toggle flow integration; when false, all roots execute immediately
+        @ConfigEntry.Gui.Tooltip
+        public boolean enableFlowQueue = false;
+        @ConfigEntry.Gui.Tooltip
+        public int maxFlowQueueLength = 4;
+        @ConfigEntry.Gui.Tooltip
+        public boolean revalidateQueuedGuards = true;
+        @ConfigEntry.Gui.Tooltip
+        public int queuedGuardRetryLimit = 0;
     }
 
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutor.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutor.java
@@ -306,17 +306,30 @@ public final class GuScriptExecutor {
                     } catch (Exception ignored) {}
 
                     double timeScale = parseTimeScale(adjustedParams);
-                    FlowControllerManager.get(performer)
-                            .start(program.get(), target, timeScale, adjustedParams, performer.level().getGameTime());
+                    String descriptor = source + ":" + root.name() + "#" + index;
+                    boolean accepted = FlowControllerManager.get(performer)
+                            .start(program.get(), target, timeScale, adjustedParams, performer.level().getGameTime(), descriptor);
                     ChestCavity.LOGGER.info(
-                            "[GuScript] Root {}#{} started flow {} (source={}, timeScale={}, params={})",
+                            "[GuScript] Root {}#{} requested flow {} (source={}, timeScale={}, params={}, accepted={})",
                             root.name(),
                             index,
                             flowToStart,
                             source,
                             formatDouble(timeScale),
-                            adjustedParams.isEmpty() ? "{}" : adjustedParams
+                            adjustedParams.isEmpty() ? "{}" : adjustedParams,
+                            accepted
                     );
+                    if (!accepted) {
+                        ChestCavity.LOGGER.info(
+                                "[GuScript] Root {}#{} flow {} was rejected (source={}, queueEnabled={}, params={})",
+                                root.name(),
+                                index,
+                                flowToStart,
+                                source,
+                                ChestCavity.config != null && ChestCavity.config.GUSCRIPT_EXECUTION.enableFlowQueue,
+                                adjustedParams.isEmpty() ? "{}" : adjustedParams
+                        );
+                    }
                     continue;
                 } else if (flowsEnabled) {
                     ChestCavity.LOGGER.warn(

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowControllerManager.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowControllerManager.java
@@ -32,7 +32,10 @@ public final class FlowControllerManager {
 
     public static void remove(ServerPlayer player) {
         if (player != null) {
-            CONTROLLERS.remove(player.getUUID());
+            FlowController controller = CONTROLLERS.remove(player.getUUID());
+            if (controller != null) {
+                controller.shutdown();
+            }
         }
     }
 }

--- a/src/test/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowRuntimeTest.java
+++ b/src/test/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowRuntimeTest.java
@@ -1,9 +1,12 @@
 package net.tigereye.chestcavity.guscript.runtime.flow;
 
 import net.minecraft.resources.ResourceLocation;
-import net.tigereye.chestcavity.guscript.runtime.flow.guards.FlowGuards;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.config.CCConfig;
 import net.tigereye.chestcavity.guscript.runtime.flow.FlowInput;
+import net.tigereye.chestcavity.guscript.runtime.flow.guards.FlowGuards;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
 
 import java.lang.reflect.Field;
 import java.util.EnumMap;
@@ -15,6 +18,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FlowRuntimeTest {
+
+    @AfterEach
+    void resetConfig() {
+        ChestCavity.config = null;
+    }
 
     @Test
     void cooldownGuardBlocksUntilReady() {
@@ -85,5 +93,109 @@ class FlowRuntimeTest {
         ticksField.setInt(instance, 2);
         instance.handleInput(FlowInput.RELEASE, 6L);
         assertEquals(FlowState.RELEASING, instance.state(), "Flow should advance after meeting min tick requirement");
+    }
+
+    @Test
+    void queueDisabledRejectsNewFlowWhileRunning() {
+        ChestCavity.config = new CCConfig();
+        FlowController controller = new FlowController();
+        FlowProgram program = simpleProgram(List.of());
+
+        assertTrue(controller.start(program, null, Map.of(), 0L));
+        assertFalse(controller.start(program, null, Map.of(), 1L));
+    }
+
+    @Test
+    void queueEnabledEnqueuesUpToCapacity() {
+        CCConfig config = new CCConfig();
+        config.GUSCRIPT_EXECUTION.enableFlowQueue = true;
+        config.GUSCRIPT_EXECUTION.maxFlowQueueLength = 1;
+        ChestCavity.config = config;
+
+        FlowController controller = new FlowController();
+        FlowProgram program = simpleProgram(List.of());
+
+        assertTrue(controller.start(program, null, Map.of(), 0L));
+        assertTrue(controller.start(program, null, Map.of("key", "value"), 1L));
+        assertTrue(controller.hasPending(), "Queue should contain enqueued flow");
+        assertEquals(1, controller.pendingSize(), "Exactly one entry should be queued");
+        assertFalse(controller.start(program, null, Map.of(), 2L), "Queue should reject when full");
+    }
+
+    @Test
+    void queuedEntryStartsAfterCurrentFinishes() throws Exception {
+        CCConfig config = new CCConfig();
+        config.GUSCRIPT_EXECUTION.enableFlowQueue = true;
+        ChestCavity.config = config;
+
+        FlowController controller = new FlowController();
+        FlowProgram program = simpleProgram(List.of());
+
+        assertTrue(controller.start(program, null, Map.of(), 0L));
+        assertTrue(controller.start(program, null, Map.of("chain", "1"), 1L));
+        assertEquals(1, controller.pendingSize());
+
+        Field instanceField = FlowController.class.getDeclaredField("instance");
+        instanceField.setAccessible(true);
+        FlowInstance active = (FlowInstance) instanceField.get(controller);
+        Field finishedField = FlowInstance.class.getDeclaredField("finished");
+        finishedField.setAccessible(true);
+        finishedField.setBoolean(active, true);
+
+        java.lang.reflect.Method clearRuntimeState = FlowController.class.getDeclaredMethod("clearRuntimeState");
+        clearRuntimeState.setAccessible(true);
+        clearRuntimeState.invoke(controller);
+        instanceField.set(controller, null);
+
+        controller.drainQueue(5L);
+
+        assertTrue(controller.isRunning(), "Queued flow should start once previous finishes");
+        assertFalse(controller.hasPending(), "Queue should be empty after starting next flow");
+    }
+
+    @Test
+    void queuedEntryDroppedWhenGuardFails() throws Exception {
+        CCConfig config = new CCConfig();
+        config.GUSCRIPT_EXECUTION.enableFlowQueue = true;
+        config.GUSCRIPT_EXECUTION.revalidateQueuedGuards = true;
+        config.GUSCRIPT_EXECUTION.queuedGuardRetryLimit = 0;
+        ChestCavity.config = config;
+
+        FlowController controller = new FlowController();
+        FlowProgram program = simpleProgram(List.of(FlowGuards.cooldownReady("demo")));
+
+        controller.setCooldown("demo", 0L);
+        assertTrue(controller.start(program, null, Map.of(), 0L));
+        assertTrue(controller.start(program, null, Map.of(), 1L));
+        assertEquals(1, controller.pendingSize());
+
+        controller.setCooldown("demo", 100L);
+        Field instanceField = FlowController.class.getDeclaredField("instance");
+        instanceField.setAccessible(true);
+        java.lang.reflect.Method clearRuntimeState = FlowController.class.getDeclaredMethod("clearRuntimeState");
+        clearRuntimeState.setAccessible(true);
+        clearRuntimeState.invoke(controller);
+        instanceField.set(controller, null);
+
+        controller.drainQueue(50L);
+
+        assertFalse(controller.isRunning(), "Guard failure should prevent queued flow from starting");
+        assertFalse(controller.hasPending(), "Queue should drop entry after guard failure");
+    }
+
+    private static FlowProgram simpleProgram(List<FlowGuard> guards) {
+        FlowTransition start = new FlowTransition(
+                FlowTrigger.START,
+                FlowState.CHARGING,
+                guards,
+                List.of(),
+                0
+        );
+
+        Map<FlowState, FlowStateDefinition> definitions = new EnumMap<>(FlowState.class);
+        definitions.put(FlowState.IDLE, new FlowStateDefinition(List.of(), List.of(), List.of(start)));
+        definitions.put(FlowState.CHARGING, new FlowStateDefinition(List.of(), List.of(), List.of()));
+
+        return new FlowProgram(ResourceLocation.fromNamespaceAndPath("test", "queue"), FlowState.IDLE, definitions);
     }
 }


### PR DESCRIPTION
## Summary
- enable queued flow execution with guard revalidation, logging, and cleanup hooks
- expose configuration switches for queue behaviour and update the executor to pass source descriptors
- cover queue acceptance, draining, and failure handling with FlowRuntimeTest cases

## Testing
- ./gradlew --no-daemon --console=plain compileJava
- ./gradlew --no-daemon --console=plain test

------
https://chatgpt.com/codex/tasks/task_e_68d9c736bf9c8326bc36c459f399ec33