### PR TITLE
Implement GuScript time scale exports and add invariance tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,8 @@ dependencies {
     testImplementation 'com.google.guava:guava:33.3.1-jre'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
+    testImplementation 'org.mockito:mockito-core:5.11.0'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
 
 
     annotationProcessor 'org.spongepowered:mixin:0.8.7:processor'

--- a/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
+++ b/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
@@ -184,6 +184,14 @@ public class CCConfig implements ConfigData {
         public boolean revalidateQueuedGuards = true;
         @ConfigEntry.Gui.Tooltip
         public int queuedGuardRetryLimit = 0;
+        @ConfigEntry.Gui.Tooltip
+        public TimeScaleCombineStrategy timeScaleCombine = TimeScaleCombineStrategy.MULTIPLY;
+    }
+
+    public enum TimeScaleCombineStrategy {
+        MULTIPLY,
+        MAX,
+        OVERRIDE
     }
 
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/actions/ExportTimeScaleFlatAction.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/actions/ExportTimeScaleFlatAction.java
@@ -1,0 +1,31 @@
+package net.tigereye.chestcavity.guscript.actions;
+
+import net.tigereye.chestcavity.guscript.ast.Action;
+import net.tigereye.chestcavity.guscript.runtime.exec.GuScriptContext;
+
+/**
+ * Exports a flat time-scale adjustment into the current execution session.
+ */
+public record ExportTimeScaleFlatAction(double amount) implements Action {
+
+    public static final String ID = "export.time_scale_flat";
+
+    @Override
+    public String id() {
+        return ID;
+    }
+
+    @Override
+    public String description() {
+        return "导出时间倍率加成 +" + amount;
+    }
+
+    @Override
+    public void execute(GuScriptContext context) {
+        if (context == null) {
+            return;
+        }
+        context.exportTimeScaleFlat(amount);
+    }
+}
+

--- a/src/main/java/net/tigereye/chestcavity/guscript/actions/ExportTimeScaleMultiplierAction.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/actions/ExportTimeScaleMultiplierAction.java
@@ -1,0 +1,31 @@
+package net.tigereye.chestcavity.guscript.actions;
+
+import net.tigereye.chestcavity.guscript.ast.Action;
+import net.tigereye.chestcavity.guscript.runtime.exec.GuScriptContext;
+
+/**
+ * Exports a multiplicative time-scale modifier into the current execution session.
+ */
+public record ExportTimeScaleMultiplierAction(double amount) implements Action {
+
+    public static final String ID = "export.time_scale_mult";
+
+    @Override
+    public String id() {
+        return ID;
+    }
+
+    @Override
+    public String description() {
+        return "导出时间倍率 ×" + amount;
+    }
+
+    @Override
+    public void execute(GuScriptContext context) {
+        if (context == null) {
+            return;
+        }
+        context.exportTimeScaleMultiplier(amount);
+    }
+}
+

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/action/ActionRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/action/ActionRegistry.java
@@ -11,6 +11,8 @@ import net.tigereye.chestcavity.guscript.actions.TriggerFxAction;
 import net.tigereye.chestcavity.guscript.ast.Action;
 import net.tigereye.chestcavity.guscript.actions.ExportFlatModifierAction;
 import net.tigereye.chestcavity.guscript.actions.ExportMultiplierModifierAction;
+import net.tigereye.chestcavity.guscript.actions.ExportTimeScaleFlatAction;
+import net.tigereye.chestcavity.guscript.actions.ExportTimeScaleMultiplierAction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.phys.Vec3;
 
@@ -44,6 +46,8 @@ public final class ActionRegistry {
         register(AddFlatDamageAction.ID, json -> new AddFlatDamageAction(json.get("amount").getAsDouble()));
         register(ExportMultiplierModifierAction.ID, json -> new ExportMultiplierModifierAction(json.get("amount").getAsDouble()));
         register(ExportFlatModifierAction.ID, json -> new ExportFlatModifierAction(json.get("amount").getAsDouble()));
+        register(ExportTimeScaleMultiplierAction.ID, json -> new ExportTimeScaleMultiplierAction(json.get("amount").getAsDouble()));
+        register(ExportTimeScaleFlatAction.ID, json -> new ExportTimeScaleFlatAction(json.get("amount").getAsDouble()));
         register(TriggerFxAction.ID, json -> TriggerFxAction.from(
                 ResourceLocation.parse(json.get("fxId").getAsString()),
                 readVec3(json, "originOffset"),

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/DefaultGuScriptContext.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/DefaultGuScriptContext.java
@@ -18,6 +18,9 @@ public final class DefaultGuScriptContext implements GuScriptContext {
     private double addedFlat;
     private double directMultiplierExports;
     private double directFlatExports;
+    private double directTimeScaleMultiplier = 1.0D;
+    private boolean hasDirectTimeScaleMultiplier;
+    private double directTimeScaleFlat;
     private boolean exportMultiplierDelta;
     private boolean exportFlatDelta;
 
@@ -99,6 +102,29 @@ public final class DefaultGuScriptContext implements GuScriptContext {
     }
 
     @Override
+    public void exportTimeScaleMultiplier(double multiplier) {
+        if (Double.isNaN(multiplier) || Double.isInfinite(multiplier) || multiplier <= 0.0D) {
+            return;
+        }
+        directTimeScaleMultiplier *= multiplier;
+        hasDirectTimeScaleMultiplier = true;
+        if (session != null) {
+            session.exportTimeScaleMultiplier(multiplier);
+        }
+    }
+
+    @Override
+    public void exportTimeScaleFlat(double amount) {
+        if (Double.isNaN(amount) || Double.isInfinite(amount) || amount == 0.0D) {
+            return;
+        }
+        directTimeScaleFlat += amount;
+        if (session != null) {
+            session.exportTimeScaleFlat(amount);
+        }
+    }
+
+    @Override
     public void enableModifierExports(boolean exportMultiplier, boolean exportFlat) {
         this.exportMultiplierDelta = exportMultiplier;
         this.exportFlatDelta = exportFlat;
@@ -122,5 +148,15 @@ public final class DefaultGuScriptContext implements GuScriptContext {
     @Override
     public double directExportedFlat() {
         return directFlatExports;
+    }
+
+    @Override
+    public double directExportedTimeScaleMultiplier() {
+        return hasDirectTimeScaleMultiplier ? directTimeScaleMultiplier : 1.0D;
+    }
+
+    @Override
+    public double directExportedTimeScaleFlat() {
+        return directTimeScaleFlat;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/ExecutionSession.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/ExecutionSession.java
@@ -11,6 +11,8 @@ public final class ExecutionSession {
     private final double flatCap;
     private double cumulativeMultiplier;
     private double cumulativeFlat;
+    private double currentTimeScaleMultiplier = 1.0D;
+    private double currentTimeScaleFlat = 0.0D;
 
     public ExecutionSession(double multiplierCap, double flatCap) {
         this.multiplierCap = sanitizeCap(multiplierCap);
@@ -62,6 +64,36 @@ public final class ExecutionSession {
                     flatCap == Double.POSITIVE_INFINITY ? "unlimited" : String.format("%.3f", flatCap)
             );
         }
+    }
+
+    public void exportTimeScaleMultiplier(double multiplier) {
+        if (Double.isNaN(multiplier) || Double.isInfinite(multiplier) || multiplier <= 0.0D) {
+            return;
+        }
+        currentTimeScaleMultiplier *= multiplier;
+    }
+
+    public void exportTimeScaleFlat(double amount) {
+        if (Double.isNaN(amount) || Double.isInfinite(amount) || amount == 0.0D) {
+            return;
+        }
+        currentTimeScaleFlat += amount;
+    }
+
+    public double currentTimeScaleMultiplier() {
+        return currentTimeScaleMultiplier;
+    }
+
+    public double currentTimeScaleFlat() {
+        return currentTimeScaleFlat;
+    }
+
+    public double currentTimeScale() {
+        double combined = currentTimeScaleMultiplier + currentTimeScaleFlat;
+        if (Double.isNaN(combined) || Double.isInfinite(combined)) {
+            return 1.0D;
+        }
+        return combined;
     }
 
     private static double clamp(double value, double cap) {

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptContext.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptContext.java
@@ -47,6 +47,20 @@ public interface GuScriptContext {
         return 0.0;
     }
 
+    default void exportTimeScaleMultiplier(double multiplier) {
+    }
+
+    default void exportTimeScaleFlat(double amount) {
+    }
+
+    default double directExportedTimeScaleMultiplier() {
+        return 1.0;
+    }
+
+    default double directExportedTimeScaleFlat() {
+        return 0.0;
+    }
+
     default double applyDamageModifiers(double baseDamage) {
         double scaled = baseDamage * (1.0 + damageMultiplier());
         return Math.max(0.0, scaled + flatDamageBonus());

--- a/src/main/resources/data/chestcavity/guscript/rules/zhou_zhi_accelerate_charge.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/zhou_zhi_accelerate_charge.json
@@ -12,13 +12,8 @@
     "tags": ["加速", "蓄力"],
     "order": 0,
     "export_modifiers": { "multiplier": true },
-    "flow_id": "chestcavity:time_acceleration",
-    "flow_params": {
-      "intensity": "1.0",
-      "duration_ticks": "200",
-      "time.accelerate": "2.0"
-    },
     "actions": [
+      { "id": "export.time_scale_mult", "amount": 2.0 },
       { "id": "export.modifier.multiplier", "amount": 0.5 }
     ]
   }

--- a/src/test/java/net/tigereye/chestcavity/guscript/runtime/exec/FlowTimeScaleCombineTest.java
+++ b/src/test/java/net/tigereye/chestcavity/guscript/runtime/exec/FlowTimeScaleCombineTest.java
@@ -1,0 +1,34 @@
+package net.tigereye.chestcavity.guscript.runtime.exec;
+
+import net.tigereye.chestcavity.config.CCConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FlowTimeScaleCombineTest {
+
+    @Test
+    void multiplyStrategyMultipliesAndClamps() {
+        double result = GuScriptExecutor.combineTimeScale(1.2D, 1.5D, CCConfig.TimeScaleCombineStrategy.MULTIPLY);
+        assertEquals(1.8D, result, 1.0E-6);
+
+        double clampedLow = GuScriptExecutor.combineTimeScale(0.01D, 0.2D, CCConfig.TimeScaleCombineStrategy.MULTIPLY);
+        assertEquals(0.1D, clampedLow, 1.0E-6);
+
+        double clampedHigh = GuScriptExecutor.combineTimeScale(150.0D, 2.0D, CCConfig.TimeScaleCombineStrategy.MULTIPLY);
+        assertEquals(100.0D, clampedHigh, 1.0E-6);
+    }
+
+    @Test
+    void maxStrategyChoosesLarger() {
+        double result = GuScriptExecutor.combineTimeScale(1.2D, 1.5D, CCConfig.TimeScaleCombineStrategy.MAX);
+        assertEquals(1.5D, result, 1.0E-6);
+    }
+
+    @Test
+    void overrideStrategyPrefersSession() {
+        double result = GuScriptExecutor.combineTimeScale(2.0D, 1.5D, CCConfig.TimeScaleCombineStrategy.OVERRIDE);
+        assertEquals(1.5D, result, 1.0E-6);
+    }
+}
+

--- a/src/test/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutorTimeScaleTest.java
+++ b/src/test/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutorTimeScaleTest.java
@@ -1,0 +1,179 @@
+package net.tigereye.chestcavity.guscript.runtime.exec;
+
+import com.google.common.collect.HashMultiset;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.config.CCConfig;
+import net.tigereye.chestcavity.guscript.actions.ExportTimeScaleMultiplierAction;
+import net.tigereye.chestcavity.guscript.ast.GuNode;
+import net.tigereye.chestcavity.guscript.ast.GuNodeKind;
+import net.tigereye.chestcavity.guscript.ast.OperatorGuNode;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowProgram;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowController;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowProgramRegistry;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowState;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowStateDefinition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+
+class GuScriptExecutorTimeScaleTest {
+
+    private Method executeMethod;
+    private FlowController controller;
+    private List<StartCall> startCalls;
+    private Constructor<FlowController> controllerConstructor;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        executeMethod = GuScriptExecutor.class.getDeclaredMethod(
+                "executeRootsWithSession",
+                List.class,
+                ServerPlayer.class,
+                net.minecraft.world.entity.LivingEntity.class,
+                ExecutionSession.class,
+                ResourceLocation.class,
+                Map.class
+        );
+        executeMethod.setAccessible(true);
+
+        ChestCavity.config = new CCConfig();
+
+        controllerConstructor = FlowController.class.getDeclaredConstructor();
+        controllerConstructor.setAccessible(true);
+        installRecordingController();
+
+        FlowProgram program = new FlowProgram(
+                ResourceLocation.fromNamespaceAndPath("test", "progress"),
+                FlowState.IDLE,
+                Map.of(FlowState.IDLE, new FlowStateDefinition(List.of(), List.of(), List.of()))
+        );
+        FlowProgramRegistry.update(Map.of(program.id(), program));
+    }
+
+    @AfterEach
+    void tearDown() {
+        GuScriptExecutor.resetFlowControllerAccessor();
+        FlowProgramRegistry.update(Map.of());
+        ChestCavity.config = null;
+    }
+
+    @Test
+    void flowStartUsesSessionScaleWhenParamMissing() throws Exception {
+        OperatorGuNode exporter = new OperatorGuNode(
+                "test:export",
+                "Export",
+                GuNodeKind.OPERATOR,
+                HashMultiset.create(),
+                List.of(new ExportTimeScaleMultiplierAction(1.5D)),
+                List.of(),
+                0,
+                false,
+                false
+        );
+        OperatorGuNode flowStarter = new OperatorGuNode(
+                "test:start",
+                "StartFlow",
+                GuNodeKind.OPERATOR,
+                HashMultiset.create(),
+                List.of(),
+                List.of(),
+                1,
+                false,
+                false,
+                ResourceLocation.fromNamespaceAndPath("test", "progress"),
+                Map.of()
+        );
+
+        List<GuNode> roots = GuScriptExecutor.sortRootsForSession(List.of(flowStarter, exporter));
+        ExecutionSession session = new ExecutionSession(5.0D, 5.0D);
+
+        executeMethod.invoke(null, roots, null, null, session, null, Map.of());
+
+        assertEquals(1, startCalls.size());
+        StartCall call = startCalls.getFirst();
+        assertEquals(1.5D, call.timeScale(), 1.0E-6);
+        assertEquals(1.5D, Double.parseDouble(call.flowParams().get("time.accelerate")), 1.0E-6);
+    }
+
+    @Test
+    void flowStartCombinesWithExistingParam() throws Exception {
+        OperatorGuNode exporter = new OperatorGuNode(
+                "test:export",
+                "Export",
+                GuNodeKind.OPERATOR,
+                HashMultiset.create(),
+                List.of(new ExportTimeScaleMultiplierAction(1.5D)),
+                List.of(),
+                0,
+                false,
+                false
+        );
+        OperatorGuNode flowStarter = new OperatorGuNode(
+                "test:start",
+                "StartFlow",
+                GuNodeKind.OPERATOR,
+                HashMultiset.create(),
+                List.of(),
+                List.of(),
+                1,
+                false,
+                false,
+                ResourceLocation.fromNamespaceAndPath("test", "progress"),
+                Map.of("time.accelerate", "1.2")
+        );
+
+        List<GuNode> roots = GuScriptExecutor.sortRootsForSession(List.of(flowStarter, exporter));
+        ExecutionSession session = new ExecutionSession(5.0D, 5.0D);
+
+        executeMethod.invoke(null, roots, null, null, session, null, Map.of());
+
+        assertEquals(1, startCalls.size());
+        StartCall call = startCalls.getFirst();
+        assertEquals(1.8D, call.timeScale(), 1.0E-6);
+        assertEquals(1.8D, Double.parseDouble(call.flowParams().get("time.accelerate")), 1.0E-6);
+    }
+
+    private void installRecordingController() throws Exception {
+        FlowController rawController = controllerConstructor.newInstance();
+        controller = Mockito.spy(rawController);
+        startCalls = new ArrayList<>();
+        Mockito.doAnswer(invocation -> {
+            FlowProgram program = invocation.getArgument(0);
+            net.minecraft.world.entity.LivingEntity target = invocation.getArgument(1);
+            double timeScale = invocation.getArgument(2);
+            Map<String, String> params = invocation.getArgument(3);
+            long gameTime = invocation.getArgument(4);
+            String descriptor = invocation.getArgument(5);
+            startCalls.add(new StartCall(program, target, timeScale,
+                    params == null ? Map.of() : Map.copyOf(params), gameTime, descriptor));
+            return true;
+        }).when(controller).start(any(FlowProgram.class), any(), anyDouble(), anyMap(), anyLong(), any());
+        GuScriptExecutor.setFlowControllerAccessor(player -> controller);
+    }
+
+    private record StartCall(
+            FlowProgram program,
+            net.minecraft.world.entity.LivingEntity target,
+            double timeScale,
+            Map<String, String> flowParams,
+            long gameTime,
+            String sourceDescriptor
+    ) {
+    }
+}
+

--- a/src/test/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowTimeScaleInvarianceTest.java
+++ b/src/test/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowTimeScaleInvarianceTest.java
@@ -1,0 +1,66 @@
+package net.tigereye.chestcavity.guscript.runtime.flow;
+
+import net.minecraft.resources.ResourceLocation;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FlowTimeScaleInvarianceTest {
+
+    @Test
+    void updateActionsFireSameCountRegardlessOfTimeScale() {
+        AtomicInteger counter = new AtomicInteger();
+        FlowEdgeAction countingAction = new FlowEdgeAction() {
+            @Override
+            public void apply(net.minecraft.world.entity.player.Player performer, net.minecraft.world.entity.LivingEntity target,
+                              FlowController controller, long gameTime) {
+                counter.incrementAndGet();
+            }
+
+            @Override
+            public String describe() {
+                return "count";
+            }
+        };
+
+        FlowTransition start = new FlowTransition(FlowTrigger.START, FlowState.CHARGING, List.of(), List.of(), 0);
+        FlowTransition chargingComplete = new FlowTransition(FlowTrigger.AUTO, FlowState.CHARGED, List.of(), List.of(), 200);
+        FlowTransition chargedComplete = new FlowTransition(FlowTrigger.AUTO, FlowState.COOLDOWN, List.of(), List.of(), 1);
+        FlowTransition cooldownComplete = new FlowTransition(FlowTrigger.AUTO, FlowState.IDLE, List.of(), List.of(), 40);
+
+        FlowProgram program = new FlowProgram(
+                ResourceLocation.fromNamespaceAndPath("test", "invariance"),
+                FlowState.IDLE,
+                Map.of(
+                        FlowState.IDLE, new FlowStateDefinition(List.of(), List.of(), List.of(start)),
+                        FlowState.CHARGING, new FlowStateDefinition(List.of(), List.of(), List.of(chargingComplete), List.of(countingAction), 20),
+                        FlowState.CHARGED, new FlowStateDefinition(List.of(), List.of(), List.of(chargedComplete)),
+                        FlowState.COOLDOWN, new FlowStateDefinition(List.of(), List.of(), List.of(cooldownComplete))
+                )
+        );
+
+        FlowController normalController = new FlowController();
+        FlowInstance normal = new FlowInstance(program, null, null, normalController, 1.0D, Map.of(), 0L);
+        normal.attemptStart(0L);
+        runUntilFinished(normal);
+        assertEquals(10, counter.get(), "timeScale=1 should run ten update ticks");
+
+        counter.set(0);
+        FlowController fastController = new FlowController();
+        FlowInstance accelerated = new FlowInstance(program, null, null, fastController, 2.0D, Map.of(), 0L);
+        accelerated.attemptStart(0L);
+        runUntilFinished(accelerated);
+        assertEquals(10, counter.get(), "timeScale=2 should still run ten update ticks");
+    }
+
+    private static void runUntilFinished(FlowInstance instance) {
+        for (int tick = 0; tick < 500 && !instance.isFinished(); tick++) {
+            instance.tick(tick);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add export actions and execution-session tracking for time-scale exports, wiring them through the GuScript executor and config merge strategy
- update GuScriptExecutor to collect exports before starting flows, support null performers in tests, and improve logging plus flow JSON usage
- introduce dedicated tests for time-scale combination and invariance while enabling Mockito support for final classes

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68da2a7090bc83268ae511b866dc69c8