### PR TITLE
Align blood bone bomb flow with charge sequence

### DIFF
--- a/src/main/resources/data/chestcavity/guscript/flows/blood_bone_charge.json
+++ b/src/main/resources/data/chestcavity/guscript/flows/blood_bone_charge.json
@@ -7,68 +7,122 @@
           "trigger": "start",
           "target": "charging",
           "guards": [
-            {"type": "cooldown", "key": "chestcavity:blood_bone_charge"},
-            {"type": "resource", "identifier": "zhenyuan", "minimum": 10.0}
+            { "type": "cooldown", "key": "chestcavity:blood_bone_charge" },
+            { "type": "resource", "identifier": "zhenyuan", "minimum": 10.0 }
           ],
           "actions": [
-            {"type": "consume_resource", "identifier": "zhenyuan", "amount": 10.0},
-            {"type": "set_cooldown", "key": "chestcavity:blood_bone_charge", "ticks": 200}
+            { "type": "consume_resource", "identifier": "zhenyuan", "amount": 10.0 },
+            { "type": "set_cooldown", "key": "chestcavity:blood_bone_charge", "ticks": 200 }
           ]
         }
       ]
     },
     "charging": {
-      "enter_fx": ["chestcavity:blood_bone_charge_start"],
+      "enter_fx": [ "chestcavity:blood_bone_charge_start" ],
+      "enter_actions": [
+        {
+          "type": "apply_attribute",
+          "attribute": "minecraft:generic.movement_speed",
+          "modifier": "chestcavity:charge_lock",
+          "operation": "MULTIPLY_TOTAL",
+          "amount": -1.0
+        }
+      ],
       "update_period": 20,
       "update_actions": [
-        {"id": "consume.health", "amount": 2},
-        {"id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -20.0},
-        {"id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0},
-        {"id": "emit.fx", "fxId": "chestcavity:blood_bone_charge_heartbeat"},
-        {"id": "emit.fx", "fxId": "chestcavity:blood_bone_charge_tick"},
-        {"id": "emit.fx", "fxId": "chestcavity:blood_bone_charge_heartbeat"}
+        { "type": "consume_health", "amount": 2.0 },
+        { "type": "consume_resource", "identifier": "zhenyuan", "amount": 20.0 },
+        { "type": "consume_resource", "identifier": "jingli", "amount": 10.0 },
+        {
+          "type": "trigger_actions",
+          "actions": [
+            { "id": "emit.fx", "fxId": "chestcavity:blood_bone_charge_heartbeat", "intensity": 1.0 }
+          ]
+        },
+        {
+          "type": "trigger_actions",
+          "actions": [
+            { "id": "emit.fx", "fxId": "chestcavity:blood_bone_charge_tick", "intensity": 1.0 }
+          ]
+        }
       ],
       "transitions": [
-        {"trigger": "auto", "target": "releasing", "min_ticks": 200},
-        {"trigger": "auto", "target": "cancel", "min_ticks": 1, "guards": [ {"type": "resource_below", "identifier": "zhenyuan", "maximum": 20.0} ]},
-        {"trigger": "auto", "target": "cancel", "min_ticks": 1, "guards": [ {"type": "resource_below", "identifier": "jingli", "maximum": 10.0} ]},
-        {"trigger": "auto", "target": "cancel", "min_ticks": 1, "guards": [ {"type": "health_below", "maximum": 2.0} ]}
-      ]
-    },
-
-    "releasing": {
-      "enter_fx": ["chestcavity:burst"],
-      "transitions": [
         {
-          "trigger": "auto", "target": "cooldown", "min_ticks": 1,
-          "actions": [
-            {"type": "trigger_actions", "actions": [ {"id": "emit.blood_bone_bomb", "base": 80.0} ]}
+          "trigger": "auto",
+          "target": "cancel",
+          "guards": [
+            { "type": "health_below", "maximum": 2.0 }
           ]
-        }
+        },
+        {
+          "trigger": "auto",
+          "target": "cancel",
+          "guards": [
+            { "type": "resource_below", "identifier": "zhenyuan", "maximum": 20.0 }
+          ]
+        },
+        {
+          "trigger": "auto",
+          "target": "cancel",
+          "guards": [
+            { "type": "resource_below", "identifier": "jingli", "maximum": 10.0 }
+          ]
+        },
+        { "trigger": "auto", "target": "charged", "min_ticks": 40 },
+        { "trigger": "cancel", "target": "cancel" }
       ]
     },
-
     "charged": {
       "transitions": [
-        { "trigger": "auto", "target": "releasing", "min_ticks": 0 }
+        { "trigger": "auto", "target": "releasing", "min_ticks": 160 },
+        { "trigger": "cancel", "target": "cancel" }
       ]
     },
-
-    "cancel": {
-      "enter_fx": ["chestcavity:blood_bone_charge_failure"],
-      "transitions": [
+    "releasing": {
+      "enter_fx": [ "chestcavity:burst" ],
+      "enter_actions": [
         {
-          "trigger": "auto", "target": "cooldown", "min_ticks": 1,
+          "type": "trigger_actions",
           "actions": [
-            {"type": "explode", "power": 4.0},
-            {"type": "true_damage", "amount": 50.0}
+            { "id": "emit.blood_bone_bomb", "base": 80.0 }
           ]
         }
+      ],
+      "transitions": [
+        { "trigger": "auto", "target": "cooldown", "min_ticks": 5 }
       ]
     },
-
     "cooldown": {
-      "transitions": [ {"trigger": "auto", "target": "idle", "min_ticks": 40} ]
+      "enter_actions": [
+        {
+          "type": "remove_attribute",
+          "attribute": "minecraft:generic.movement_speed",
+          "modifier": "chestcavity:charge_lock"
+        }
+      ],
+      "transitions": [
+        { "trigger": "auto", "target": "idle", "min_ticks": 40 }
+      ]
+    },
+    "cancel": {
+      "enter_actions": [
+        {
+          "type": "remove_attribute",
+          "attribute": "minecraft:generic.movement_speed",
+          "modifier": "chestcavity:charge_lock"
+        },
+        { "type": "true_damage", "amount": 50.0 },
+        { "type": "explode", "power": 4.0 },
+        {
+          "type": "trigger_actions",
+          "actions": [
+            { "id": "emit.fx", "fxId": "chestcavity:blood_bone_charge_failure", "intensity": 1.0 }
+          ]
+        }
+      ],
+      "transitions": [
+        { "trigger": "auto", "target": "cooldown", "min_ticks": 5 }
+      ]
     }
   }
 }

--- a/src/main/resources/data/chestcavity/guscript/rules/xuerou_yuanchengbaoji_baodan.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/xuerou_yuanchengbaoji_baodan.json
@@ -7,6 +7,6 @@
     "operator_id": "chestcavity:blood_bone_bomb_final",
     "kind": "composite",
     "tags": ["杀招", "血骨爆弹"],
-    "flow_id": "chestcavity:demo_charge_release"
+    "flow_id": "chestcavity:blood_bone_charge"
   }
 }


### PR DESCRIPTION
## Summary
- point the blood-bone bomb rule to the dedicated `blood_bone_charge` flow
- fold the charge flow to include per-tick resource drains, movement lock, and failure cleanup
- move the projectile emission to releasing enter actions so the burst happens as soon as the state starts

## Testing
- `./gradlew --console=plain compileJava`


------
https://chatgpt.com/codex/tasks/task_e_68da35866e58832681c343eb6cff5d9d