### PR TITLE
Fix flow resource consumption and add tests

### DIFF
--- a/docs/design/guscript-module.md
+++ b/docs/design/guscript-module.md
@@ -133,6 +133,12 @@ Tweaking these values automatically updates button placement the next time the U
    - 打通 UI 模拟预览（模拟上下文）并校验其与正式执行共享验证逻辑；
    - 编写示例脚本与集成测试，覆盖 reactive 更新、资源/链接差分与 UI 持久化。
 
+### Flow runtime resource scaling
+
+- `FlowActions.consume_resource` now normalises per-tick deductions against the effective `time.accelerate` parameter exported by the executor. Every invocation divides the configured amount by the resolved time scale so that a 10 HP/20 真元/10 精力 “per second” cost remains stable even when the flow accelerates or slows down.
+- When consuming Guzhenren resources the action routes to dedicated helpers: `jingli` uses `ResourceHandle.adjustJingli`, `zhenyuan` honours cultivation scaling via `ResourceHandle.consumeScaledZhenyuan`, and other identifiers fall back to the generic `adjustDouble` path.
+- Failures (missing attachment, unknown identifier, insufficient pool, or write errors) emit a DEBUG trace with the requested amount, resolved time scale, and before/after snapshots, then immediately raise a WARN and request `FlowTrigger.CANCEL`. That pushes the runtime into the flow’s cancel branch so punishment FX/fireballs trigger reliably instead of silently skipping the cost.
+
 ## Open Questions / Follow-ups
 
 - Determine whether script layouts should be per-player configurable via data packs or fixed presets shipped with the mod.

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowController.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowController.java
@@ -137,6 +137,24 @@ public final class FlowController {
         instance.handleInput(input, gameTime);
     }
 
+    public boolean requestCancel(String reason, long gameTime) {
+        if (instance == null) {
+            ChestCavity.LOGGER.debug("[Flow] Cancel request ignored because no instance is running (reason={})", reason);
+            return false;
+        }
+        String sanitized = (reason == null || reason.isBlank()) ? "unspecified" : reason;
+        ChestCavity.LOGGER.debug(
+                "[Flow] {} received cancel request (program={}, state={}, ticks={}, reason={})",
+                performerName(),
+                instance.program().id(),
+                instance.state(),
+                instance.ticksInState(),
+                sanitized
+        );
+        instance.handleInput(FlowInput.CANCEL, gameTime);
+        return true;
+    }
+
     public void handleStateChanged(FlowInstance flowInstance) {
         FlowSyncDispatcher.syncState(performer, flowInstance);
     }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/FlowActions.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/FlowActions.java
@@ -26,6 +26,9 @@ import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import java.util.List;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.function.Function;
 
 /**
  * Built-in flow actions used by the MVP implementation.
@@ -35,27 +38,135 @@ public final class FlowActions {
     private FlowActions() {
     }
 
+    private static Function<Player, Optional<GuzhenrenResourceBridge.ResourceHandle>> RESOURCE_OPENER = GuzhenrenResourceBridge::open;
+
+    public static void overrideResourceOpenerForTests(Function<Player, Optional<GuzhenrenResourceBridge.ResourceHandle>> opener) {
+        RESOURCE_OPENER = opener == null ? GuzhenrenResourceBridge::open : opener;
+    }
+
+    public static void resetResourceOpenerForTests() {
+        RESOURCE_OPENER = GuzhenrenResourceBridge::open;
+    }
+
     public static FlowEdgeAction consumeResource(String identifier, double amount) {
-        if (amount <= 0) {
+        if (identifier == null || identifier.isBlank()) {
             return describe(() -> "consume_resource(nop)");
         }
+        double sanitizedAmount = Math.max(0.0D, amount);
+        if (sanitizedAmount <= 0.0D) {
+            return describe(() -> "consume_resource(nop)");
+        }
+        String canonicalId = identifier.trim();
         return new FlowEdgeAction() {
             @Override
             public void apply(Player performer, LivingEntity target, FlowController controller, long gameTime) {
-                if (performer == null || identifier == null) {
+                double timeScale = 1.0D;
+                if (controller != null) {
+                    double resolved = controller.resolveFlowParamAsDouble("time.accelerate", 1.0D);
+                    if (Double.isFinite(resolved) && resolved > 0.0D) {
+                        timeScale = resolved;
+                    }
+                }
+                double scaledAmount = sanitizedAmount / timeScale;
+                if (!Double.isFinite(scaledAmount) || scaledAmount <= 0.0D) {
                     return;
                 }
-                GuzhenrenResourceBridge.open(performer).ifPresent(handle -> {
-                    double delta = -Math.abs(amount);
-                    handle.adjustDouble(identifier, delta, true);
-                });
+
+                Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = RESOURCE_OPENER.apply(performer);
+                if (handleOpt.isEmpty()) {
+                    logFailureAndCancel(performer, controller, gameTime, canonicalId, scaledAmount, sanitizedAmount, timeScale,
+                            OptionalDouble.empty(), OptionalDouble.empty(), "missing_attachment");
+                    return;
+                }
+
+                GuzhenrenResourceBridge.ResourceHandle handle = handleOpt.get();
+                String normalized = canonicalId.toLowerCase(java.util.Locale.ROOT);
+                OptionalDouble before = readResourceSnapshot(handle, normalized, canonicalId);
+                OptionalDouble result;
+                switch (normalized) {
+                    case "jingli" -> result = handle.adjustJingli(-scaledAmount, true);
+                    case "zhenyuan" -> result = handle.consumeScaledZhenyuan(scaledAmount);
+                    default -> result = handle.adjustDouble(canonicalId, -scaledAmount, true);
+                }
+
+                if (result.isEmpty()) {
+                    OptionalDouble after = readResourceSnapshot(handle, normalized, canonicalId);
+                    logFailureAndCancel(
+                            performer,
+                            controller,
+                            gameTime,
+                            canonicalId,
+                            scaledAmount,
+                            sanitizedAmount,
+                            timeScale,
+                            before,
+                            after,
+                            "write_failed"
+                    );
+                }
             }
 
             @Override
             public String describe() {
-                return "consume_resource(" + identifier + ", " + amount + ")";
+                return "consume_resource(" + canonicalId + ", " + sanitizedAmount + ")";
             }
         };
+    }
+
+    private static void logFailureAndCancel(
+            Player performer,
+            FlowController controller,
+            long gameTime,
+            String identifier,
+            double scaledAmount,
+            double originalAmount,
+            double timeScale,
+            OptionalDouble before,
+            OptionalDouble after,
+            String reason
+    ) {
+        String name = performer != null ? performer.getScoreboardName() : "<null>";
+        double available = before.isPresent() ? before.getAsDouble() : Double.NaN;
+        double remaining = after.isPresent() ? after.getAsDouble() : available;
+        ChestCavity.LOGGER.debug(
+                "[Flow] consume_resource failure for {} (identifier={}, scaledAmount={}, originalAmount={}, timeScale={}, reason={}, available={}, remaining={})",
+                name,
+                identifier,
+                formatDouble(scaledAmount),
+                formatDouble(originalAmount),
+                formatDouble(timeScale),
+                reason,
+                formatDouble(available),
+                formatDouble(remaining)
+        );
+        if (controller != null) {
+            ChestCavity.LOGGER.warn(
+                    "[Flow] {} cancelling due to resource failure (identifier={}, required={}, available={}, remaining={}, timeScale={}, reason={})",
+                    name,
+                    identifier,
+                    formatDouble(scaledAmount),
+                    formatDouble(available),
+                    formatDouble(remaining),
+                    formatDouble(timeScale),
+                    reason
+            );
+            controller.requestCancel("resource_failure:" + identifier, gameTime);
+        }
+    }
+
+    private static OptionalDouble readResourceSnapshot(GuzhenrenResourceBridge.ResourceHandle handle, String normalized, String identifier) {
+        return switch (normalized) {
+            case "jingli" -> handle.getJingli();
+            case "zhenyuan" -> handle.getZhenyuan();
+            default -> handle.read(identifier);
+        };
+    }
+
+    private static String formatDouble(double value) {
+        if (!Double.isFinite(value)) {
+            return "NaN";
+        }
+        return String.format(java.util.Locale.ROOT, "%.3f", value);
     }
 
     public static FlowEdgeAction setCooldown(String key, long durationTicks) {

--- a/src/test/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowRuntimeTest.java
+++ b/src/test/java/net/tigereye/chestcavity/guscript/runtime/flow/FlowRuntimeTest.java
@@ -4,14 +4,20 @@ import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.config.CCConfig;
 import net.tigereye.chestcavity.guscript.runtime.flow.FlowInput;
+import net.tigereye.chestcavity.guscript.runtime.flow.actions.FlowActions;
 import net.tigereye.chestcavity.guscript.runtime.flow.guards.FlowGuards;
+import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
+import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalDouble;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -186,6 +192,84 @@ class FlowRuntimeTest {
         assertFalse(controller.hasPending(), "Queue should drop entry after guard failure");
     }
 
+    @Test
+    void consumeResourceDeductsJingli() {
+        FlowEdgeAction consume = FlowActions.consumeResource("jingli", 10.0D);
+        FlowController controller = Mockito.mock(FlowController.class);
+        Mockito.when(controller.resolveFlowParamAsDouble(Mockito.eq("time.accelerate"), Mockito.eq(1.0D))).thenReturn(1.0D);
+
+        GuzhenrenResourceBridge.ResourceHandle handle = Mockito.mock(GuzhenrenResourceBridge.ResourceHandle.class);
+        AtomicReference<Double> jingli = new AtomicReference<>(200.0D);
+        Mockito.when(handle.getJingli()).thenAnswer(inv -> OptionalDouble.of(jingli.get()));
+        Mockito.when(handle.adjustJingli(Mockito.anyDouble(), Mockito.eq(true))).thenAnswer(inv -> {
+            double delta = inv.getArgument(0);
+            double next = Math.max(0.0D, jingli.get() + delta);
+            jingli.set(next);
+            return OptionalDouble.of(next);
+        });
+
+        FlowActions.overrideResourceOpenerForTests(player -> Optional.of(handle));
+        try {
+            consume.apply(null, null, controller, 0L);
+        } finally {
+            FlowActions.resetResourceOpenerForTests();
+        }
+
+        Mockito.verify(handle).adjustJingli(-10.0D, true);
+        Mockito.verify(controller, Mockito.never()).requestCancel(Mockito.anyString(), Mockito.anyLong());
+        assertEquals(190.0D, jingli.get(), 1.0E-6);
+    }
+
+    @Test
+    void consumeResourceRespectsTimeScale() {
+        FlowEdgeAction consume = FlowActions.consumeResource("jingli", 10.0D);
+        FlowController controller = Mockito.mock(FlowController.class);
+        Mockito.when(controller.resolveFlowParamAsDouble(Mockito.eq("time.accelerate"), Mockito.eq(1.0D))).thenReturn(2.0D);
+
+        GuzhenrenResourceBridge.ResourceHandle handle = Mockito.mock(GuzhenrenResourceBridge.ResourceHandle.class);
+        AtomicReference<Double> jingli = new AtomicReference<>(200.0D);
+        Mockito.when(handle.getJingli()).thenAnswer(inv -> OptionalDouble.of(jingli.get()));
+        Mockito.when(handle.adjustJingli(Mockito.anyDouble(), Mockito.eq(true))).thenAnswer(inv -> {
+            double delta = inv.getArgument(0);
+            double next = Math.max(0.0D, jingli.get() + delta);
+            jingli.set(next);
+            return OptionalDouble.of(next);
+        });
+
+        FlowActions.overrideResourceOpenerForTests(player -> Optional.of(handle));
+        try {
+            consume.apply(null, null, controller, 0L);
+        } finally {
+            FlowActions.resetResourceOpenerForTests();
+        }
+
+        Mockito.verify(handle).adjustJingli(-5.0D, true);
+        assertEquals(195.0D, jingli.get(), 1.0E-6);
+    }
+
+    @Test
+    void consumeResourceCancelTriggersOnFailure() {
+        FlowEdgeAction consume = FlowActions.consumeResource("jingli", 10.0D);
+        FlowController controller = Mockito.mock(FlowController.class);
+        Mockito.when(controller.resolveFlowParamAsDouble(Mockito.eq("time.accelerate"), Mockito.eq(1.0D))).thenReturn(1.0D);
+        Mockito.when(controller.requestCancel(Mockito.anyString(), Mockito.anyLong())).thenReturn(true);
+
+        GuzhenrenResourceBridge.ResourceHandle handle = Mockito.mock(GuzhenrenResourceBridge.ResourceHandle.class);
+        AtomicReference<Double> jingli = new AtomicReference<>(5.0D);
+        Mockito.when(handle.getJingli()).thenAnswer(inv -> OptionalDouble.of(jingli.get()));
+        Mockito.when(handle.adjustJingli(Mockito.anyDouble(), Mockito.eq(true))).thenAnswer(inv -> OptionalDouble.empty());
+
+        FlowActions.overrideResourceOpenerForTests(player -> Optional.of(handle));
+        try {
+            consume.apply(null, null, controller, 42L);
+        } finally {
+            FlowActions.resetResourceOpenerForTests();
+        }
+
+        Mockito.verify(controller).requestCancel(Mockito.eq("resource_failure:jingli"), Mockito.eq(42L));
+        assertEquals(5.0D, jingli.get(), 1.0E-6);
+    }
+
     private static FlowProgram simpleProgram(List<FlowGuard> guards) {
         FlowTransition start = new FlowTransition(
                 FlowTrigger.START,
@@ -201,4 +285,5 @@ class FlowRuntimeTest {
 
         return new FlowProgram(ResourceLocation.fromNamespaceAndPath("test", "queue"), FlowState.IDLE, definitions);
     }
+
 }


### PR DESCRIPTION
## Summary
- add a requestCancel helper on `FlowController` so actions can trigger CANCEL transitions directly
- harden `FlowActions.consume_resource` with time-scale aware deductions, resource-specific bridges, detailed logging, and a test hook
- extend `FlowRuntimeTest` with focused consume-resource cases and document the new scaling behaviour in `docs/design/guscript-module.md`

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68da3bb532f48326bf1532426ee6fe15