### PR TITLE
Add waste energy rules for all dao marks

### DIFF
--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_an.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_an.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "暗道": 1 },
+  "result": {
+    "name": "废能·暗",
+    "operator_id": "chestcavity:waste_an",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_bianhua.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_bianhua.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "变化道": 1 },
+  "result": {
+    "name": "废能·变化",
+    "operator_id": "chestcavity:waste_bianhua",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_bing.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_bing.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "兵道": 1 },
+  "result": {
+    "name": "废能·兵",
+    "operator_id": "chestcavity:waste_bing",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_bingxue.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_bingxue.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "冰雪道": 1 },
+  "result": {
+    "name": "废能·冰雪",
+    "operator_id": "chestcavity:waste_bingxue",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_dan.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_dan.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "丹道": 1 },
+  "result": {
+    "name": "废能·丹",
+    "operator_id": "chestcavity:waste_dan",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_dao.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_dao.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "刀道": 1 },
+  "result": {
+    "name": "废能·刀",
+    "operator_id": "chestcavity:waste_dao",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_du.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_du.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "毒道": 1 },
+  "result": {
+    "name": "废能·毒",
+    "operator_id": "chestcavity:waste_du",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_feng.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_feng.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "风道": 1 },
+  "result": {
+    "name": "废能·风",
+    "operator_id": "chestcavity:waste_feng",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_gu.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_gu.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "骨道": 1 },
+  "result": {
+    "name": "废能·骨",
+    "operator_id": "chestcavity:waste_gu",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_guang.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_guang.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "光道": 1 },
+  "result": {
+    "name": "废能·光",
+    "operator_id": "chestcavity:waste_guang",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_hua.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_hua.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "画道": 1 },
+  "result": {
+    "name": "废能·画",
+    "operator_id": "chestcavity:waste_hua",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_huan.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_huan.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "幻道": 1 },
+  "result": {
+    "name": "废能·幻",
+    "operator_id": "chestcavity:waste_huan",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_hun.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_hun.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "魂道": 1 },
+  "result": {
+    "name": "废能·魂",
+    "operator_id": "chestcavity:waste_hun",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_jian.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_jian.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "剑道": 1 },
+  "result": {
+    "name": "废能·剑",
+    "operator_id": "chestcavity:waste_jian",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_jin_forbidden.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_jin_forbidden.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "禁道": 1 },
+  "result": {
+    "name": "废能·禁",
+    "operator_id": "chestcavity:waste_jin_forbidden",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_lei.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_lei.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "雷道": 1 },
+  "result": {
+    "name": "废能·雷",
+    "operator_id": "chestcavity:waste_lei",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_li.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_li.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "力道": 1 },
+  "result": {
+    "name": "废能·力",
+    "operator_id": "chestcavity:waste_li",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_lian.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_lian.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "炼道": 1 },
+  "result": {
+    "name": "废能·炼",
+    "operator_id": "chestcavity:waste_lian",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_lv.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_lv.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "律道": 1 },
+  "result": {
+    "name": "废能·律",
+    "operator_id": "chestcavity:waste_lv",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_meng.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_meng.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "梦道": 1 },
+  "result": {
+    "name": "废能·梦",
+    "operator_id": "chestcavity:waste_meng",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_mu.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_mu.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "木道": 1 },
+  "result": {
+    "name": "废能·木",
+    "operator_id": "chestcavity:waste_mu",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_nu.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_nu.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "奴道": 1 },
+  "result": {
+    "name": "废能·奴",
+    "operator_id": "chestcavity:waste_nu",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_qi.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_qi.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "气道": 1 },
+  "result": {
+    "name": "废能·气",
+    "operator_id": "chestcavity:waste_qi",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_ren.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_ren.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "人道": 1 },
+  "result": {
+    "name": "废能·人",
+    "operator_id": "chestcavity:waste_ren",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_shi.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_shi.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "食道": 1 },
+  "result": {
+    "name": "废能·食",
+    "operator_id": "chestcavity:waste_shi",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_shui.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_shui.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "水道": 1 },
+  "result": {
+    "name": "废能·水",
+    "operator_id": "chestcavity:waste_shui",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_tian.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_tian.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "天道": 1 },
+  "result": {
+    "name": "废能·天",
+    "operator_id": "chestcavity:waste_tian",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_tou.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_tou.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "偷道": 1 },
+  "result": {
+    "name": "废能·偷",
+    "operator_id": "chestcavity:waste_tou",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_tu.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_tu.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "土道": 1 },
+  "result": {
+    "name": "废能·土",
+    "operator_id": "chestcavity:waste_tu",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_xin.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_xin.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "信道": 1 },
+  "result": {
+    "name": "废能·信",
+    "operator_id": "chestcavity:waste_xin",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_xing.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_xing.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "星道": 1 },
+  "result": {
+    "name": "废能·星",
+    "operator_id": "chestcavity:waste_xing",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_xu.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_xu.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "虚道": 1 },
+  "result": {
+    "name": "废能·虚",
+    "operator_id": "chestcavity:waste_xu",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_yan.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_yan.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "炎道": 1 },
+  "result": {
+    "name": "废能·炎",
+    "operator_id": "chestcavity:waste_yan",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_yin.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_yin.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "音道": 1 },
+  "result": {
+    "name": "废能·音",
+    "operator_id": "chestcavity:waste_yin",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_ying.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_ying.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "影道": 1 },
+  "result": {
+    "name": "废能·影",
+    "operator_id": "chestcavity:waste_ying",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_yu.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_yu.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "宇道": 1 },
+  "result": {
+    "name": "废能·宇",
+    "operator_id": "chestcavity:waste_yu",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_yue.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_yue.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "月道": 1 },
+  "result": {
+    "name": "废能·月",
+    "operator_id": "chestcavity:waste_yue",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_yun.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_yun.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "运道": 1 },
+  "result": {
+    "name": "废能·运",
+    "operator_id": "chestcavity:waste_yun",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_yun_cloud.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_yun_cloud.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "云道": 1 },
+  "result": {
+    "name": "废能·云",
+    "operator_id": "chestcavity:waste_yun_cloud",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_zhen.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_zhen.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "阵道": 1 },
+  "result": {
+    "name": "废能·阵",
+    "operator_id": "chestcavity:waste_zhen",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_zhi.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_zhi.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "智道": 1 },
+  "result": {
+    "name": "废能·智",
+    "operator_id": "chestcavity:waste_zhi",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/waste/waste_zhou.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/waste/waste_zhou.json
@@ -1,0 +1,15 @@
+{
+  "arity": 1,
+  "priority": -100,
+  "required": { "宙道": 1 },
+  "result": {
+    "name": "废能·宙",
+    "operator_id": "chestcavity:waste_zhou",
+    "kind": "composite",
+    "tags": ["废能"],
+    "actions": [
+      { "id": "guzhenren.adjust", "identifier": "zhenyuan", "amount": -10.0 },
+      { "id": "guzhenren.adjust", "identifier": "jingli", "amount": -10.0 }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add GuScript waste rule definitions for each dao mark so every path can convert to waste energy consistently

## Testing
- ./gradlew compileJava *(fails: existing int dereference errors in GuNodeOrdering/GuScriptReducer/GuScriptCompiler)*

------
https://chatgpt.com/codex/tasks/task_e_68da6968475c83269c7b085b8a89020a