### PR TITLE
Add steel bone combo integration and regen guard

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganEvents.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganEvents.java
@@ -1,5 +1,6 @@
 package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao;
 
+import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionHand;
@@ -11,18 +12,19 @@ import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.GuzhuguOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.SteelBoneComboHelper;
 import net.tigereye.chestcavity.interfaces.ChestCavityEntity;
+import net.tigereye.chestcavity.util.ChestCavityUtil;
 
 /**
  * Handles player interactions relevant to 骨道蛊 organs.
- * - 对着方块：保持 vanilla 骨粉逻辑
- * - 对着空气：模拟“吃骨粉”，触发 GuzhuguOrganBehavior
  */
 public final class GuDaoOrganEvents {
 
     private static boolean registered;
 
-    private GuDaoOrganEvents() {}
+    private GuDaoOrganEvents() {
+    }
 
     public static void register() {
         if (registered) {
@@ -33,67 +35,115 @@ public final class GuDaoOrganEvents {
     }
 
     private static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
-    if (event.isCanceled()) {
-        return;
-    }
-
-    Player player = event.getEntity();
-    ItemStack stack = event.getItemStack();
-
-    if (stack.isEmpty() || player == null) {
-        return;
-    }
-    if (!stack.is(Items.BONE_MEAL)) {
-        return;
-    }
-
-    // 提前检测方块命中：如果是方块，直接交给 vanilla
-    var hitResult = player.pick(5.0D, 0.0F, false);
-    if (hitResult.getType() == net.minecraft.world.phys.HitResult.Type.BLOCK) {
-        return; // 不拦截，走 vanilla 骨粉逻辑
-    }
-
-    // ---------- 对空气 ----------
-    handleBoneMeal(event, player, stack);
-}
-
-private static void handleBoneMeal(PlayerInteractEvent.RightClickItem event, Player player, ItemStack stack) {
-    Level level = event.getLevel();
-    InteractionHand hand = event.getHand();
-
-    if (level.isClientSide()) {
-        // 客户端：手动播动作/声音
-        player.swing(hand, true);
-        player.playSound(SoundEvents.GENERIC_EAT, 0.6f, 1.2f);
-        return;
-    }
-
-    // 服务端：应用骨道逻辑
-    ChestCavityEntity.of(player).map(ChestCavityEntity::getChestCavityInstance).ifPresent(cc -> {
-        boolean applied = GuzhuguOrganBehavior.INSTANCE.onBoneMealCatalyst(player, cc);
-        if (!applied) {
-            player.displayClientMessage(
-                net.minecraft.network.chat.Component.literal("[Guzhugu] ACTIVE blocked (cooldown or missing organ)"), 
-                true
-            );
+        if (event.isCanceled()) {
             return;
         }
 
-        ItemStack handStack = player.getItemInHand(hand);
-        if (!player.getAbilities().instabuild) {
-            handStack.shrink(1);
-            if (handStack.isEmpty()) {
-                player.setItemInHand(hand, ItemStack.EMPTY);
-            }
+        Player player = event.getEntity();
+        ItemStack stack = event.getItemStack();
+        if (player == null || stack.isEmpty()) {
+            return;
         }
 
-        level.playSound(null, player.getX(), player.getY(), player.getZ(),
-                SoundEvents.GENERIC_EAT, player.getSoundSource(), 0.6f, 1.2f);
+        if (stack.is(Items.BONE_MEAL)) {
+            if (player.pick(5.0D, 0.0F, false).getType() == net.minecraft.world.phys.HitResult.Type.BLOCK) {
+                return;
+            }
+            handleBoneMeal(event, player, stack);
+            return;
+        }
 
-        player.awardStat(Stats.ITEM_USED.get(Items.BONE_MEAL));
+        if (stack.is(Items.IRON_INGOT)) {
+            if (player.pick(5.0D, 0.0F, false).getType() == net.minecraft.world.phys.HitResult.Type.BLOCK) {
+                return;
+            }
+            handleIronIngot(event, player, stack);
+        }
+    }
 
-        event.setCancellationResult(InteractionResult.SUCCESS);
-        event.setCanceled(true);
-    });
+    private static void handleBoneMeal(PlayerInteractEvent.RightClickItem event, Player player, ItemStack stack) {
+        Level level = event.getLevel();
+        InteractionHand hand = event.getHand();
+
+        if (level.isClientSide()) {
+            player.swing(hand, true);
+            player.playSound(SoundEvents.GENERIC_EAT, 0.6f, 1.2f);
+            return;
+        }
+
+        ChestCavityEntity.of(player).map(ChestCavityEntity::getChestCavityInstance).ifPresent(cc -> {
+            boolean applied = GuzhuguOrganBehavior.INSTANCE.onBoneMealCatalyst(player, cc);
+            if (!applied) {
+                player.displayClientMessage(
+                        Component.literal("[Guzhugu] ACTIVE blocked (cooldown or missing organ)"),
+                        true
+                );
+                return;
+            }
+
+            ItemStack handStack = player.getItemInHand(hand);
+            if (!player.getAbilities().instabuild) {
+                handStack.shrink(1);
+                if (handStack.isEmpty()) {
+                    player.setItemInHand(hand, ItemStack.EMPTY);
+                }
+            }
+
+            level.playSound(null, player.getX(), player.getY(), player.getZ(),
+                    SoundEvents.GENERIC_EAT, player.getSoundSource(), 0.6f, 1.2f);
+            player.awardStat(Stats.ITEM_USED.get(Items.BONE_MEAL));
+
+            event.setCancellationResult(InteractionResult.SUCCESS);
+            event.setCanceled(true);
+        });
+    }
+
+    private static void handleIronIngot(PlayerInteractEvent.RightClickItem event, Player player, ItemStack stack) {
+        Level level = event.getLevel();
+        InteractionHand hand = event.getHand();
+
+        if (level.isClientSide()) {
+            player.swing(hand, true);
+            player.playSound(SoundEvents.ANVIL_PLACE, 0.6f, 1.2f);
+            return;
+        }
+
+        ChestCavityEntity.of(player).map(ChestCavityEntity::getChestCavityInstance).ifPresent(cc -> {
+            var comboState = SteelBoneComboHelper.analyse(cc);
+            if (!SteelBoneComboHelper.hasActiveCombo(comboState)) {
+                player.displayClientMessage(
+                        Component.literal("[Gangjingu] Iron repair requires steel + iron bone"),
+                        true
+                );
+                return;
+            }
+            if (player.getHealth() >= player.getMaxHealth() - 0.01f) {
+                return;
+            }
+
+            ItemStack handStack = player.getItemInHand(hand);
+            if (!player.getAbilities().instabuild) {
+                if (handStack.isEmpty()) {
+                    return;
+                }
+                handStack.shrink(1);
+                if (handStack.isEmpty()) {
+                    player.setItemInHand(hand, ItemStack.EMPTY);
+                }
+            }
+
+            float healAmount = player.getMaxHealth() * 0.10f;
+            ChestCavityUtil.runWithOrganHeal(() -> player.heal(healAmount));
+
+            player.getCooldowns().addCooldown(Items.IRON_INGOT, 20);
+            level.playSound(null, player.getX(), player.getY(), player.getZ(),
+                    SoundEvents.ANVIL_PLACE, player.getSoundSource(), 0.7f, 1.0f);
+            player.playSound(SoundEvents.GRINDSTONE_USE, 0.5f, 1.3f);
+            player.awardStat(Stats.ITEM_USED.get(Items.IRON_INGOT));
+
+            event.setCancellationResult(InteractionResult.SUCCESS);
+            event.setCanceled(true);
+        });
     }
 }
+

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganRegistry.java
@@ -1,12 +1,16 @@
 package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao;
 
 import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.GangjinguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.GuQiangguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.GuzhuguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.HuGuguOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.JingtieguguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.LuoXuanGuQiangguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.RouBaiguOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.TieGuGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.YuGuguOrganBehavior; // 你需要自己写对应行为
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.SteelBoneComboHealing;
 import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
 
 import java.util.List;
@@ -19,6 +23,9 @@ public final class GuDaoOrganRegistry {
 
     private static final String MOD_ID = "guzhenren";
     private static final ResourceLocation BONE_BAMBOO_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "gu_zhu_gu");
+    private static final ResourceLocation STEEL_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "ganjingu");
+    private static final ResourceLocation IRON_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "tie_gu_gu");
+    private static final ResourceLocation REFINED_IRON_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "jingtiegugu");
     private static final ResourceLocation BONE_SPEAR_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "gu_qiang_gu");
     private static final ResourceLocation SPIRAL_BONE_SPEAR_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "luo_xuan_gu_qiang_gu");
     private static final ResourceLocation TIGER_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "hugugu");
@@ -32,6 +39,25 @@ public final class GuDaoOrganRegistry {
                 OrganIntegrationSpec.builder(BONE_BAMBOO_ID)
                         .addSlowTickListener(GuzhuguOrganBehavior.INSTANCE)
                         .ensureAttached(GuzhuguOrganBehavior.INSTANCE::ensureAttached)
+                        .build(),
+                OrganIntegrationSpec.builder(STEEL_BONE_ID)
+                        .addSlowTickListener(GangjinguOrganBehavior.INSTANCE)
+                        .addOnHitListener(GangjinguOrganBehavior.INSTANCE)
+                        .addHealListener(SteelBoneComboHealing.INSTANCE)
+                        .ensureAttached(GangjinguOrganBehavior.INSTANCE::ensureAttached)
+                        .build(),
+                OrganIntegrationSpec.builder(IRON_BONE_ID)
+                        .addSlowTickListener(TieGuGuOrganBehavior.INSTANCE)
+                        .addRemovalListener(TieGuGuOrganBehavior.INSTANCE)
+                        .ensureAttached(TieGuGuOrganBehavior.INSTANCE::ensureAttached)
+                        .onEquip(TieGuGuOrganBehavior.INSTANCE::onEquip)
+                        .build(),
+                OrganIntegrationSpec.builder(REFINED_IRON_BONE_ID)
+                        .addSlowTickListener(JingtieguguOrganBehavior.INSTANCE)
+                        .addRemovalListener(JingtieguguOrganBehavior.INSTANCE)
+                        .addHealListener(SteelBoneComboHealing.INSTANCE)
+                        .ensureAttached(JingtieguguOrganBehavior.INSTANCE::ensureAttached)
+                        .onEquip(JingtieguguOrganBehavior.INSTANCE::onEquip)
                         .build(),
                 OrganIntegrationSpec.builder(BONE_SPEAR_ID)
                         .addSlowTickListener(GuQiangguOrganBehavior.INSTANCE)

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/SteelBoneComboHealing.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/SteelBoneComboHealing.java
@@ -1,0 +1,34 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.listeners.OrganHealListener;
+
+/**
+ * Provides the passive regeneration granted by the steel + refined iron bone combo.
+ */
+public enum SteelBoneComboHealing implements OrganHealListener {
+    INSTANCE;
+
+    private static final float HEAL_PER_TICK = 0.5f;
+
+    @Override
+    public float getHealingPerTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (entity == null || cc == null || organ == null || organ.isEmpty()) {
+            return 0.0f;
+        }
+        SteelBoneComboHelper.ComboState state = SteelBoneComboHelper.analyse(cc);
+        if (!SteelBoneComboHelper.hasRefinedCombo(state)) {
+            return 0.0f;
+        }
+        if (!SteelBoneComboHelper.isPrimaryRefinedOrgan(cc, organ)) {
+            return 0.0f;
+        }
+        if (entity.getHealth() >= entity.getMaxHealth()) {
+            return 0.0f;
+        }
+        return HEAL_PER_TICK;
+    }
+}
+

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/SteelBoneComboHelper.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/SteelBoneComboHelper.java
@@ -1,0 +1,236 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao;
+
+import net.minecraft.core.particles.DustParticleOptions;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.food.FoodData;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.GameRules;
+import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.linkage.LinkageChannel;
+import net.tigereye.chestcavity.linkage.LinkageManager;
+import net.tigereye.chestcavity.linkage.policy.ClampPolicy;
+
+import java.util.Objects;
+
+/**
+ * Shared utilities for the Steel Bone + Iron Bone combo logic.
+ */
+public final class SteelBoneComboHelper {
+
+    private static final String MOD_ID = "guzhenren";
+
+    private static final ResourceLocation STEEL_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "ganjingu");
+    private static final ResourceLocation IRON_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "tie_gu_gu");
+    private static final ResourceLocation REFINED_IRON_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "jingtiegugu");
+
+    private static final ResourceLocation GU_DAO_INCREASE_CHANNEL =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/gu_dao_increase_effect");
+    private static final ResourceLocation JIN_DAO_INCREASE_CHANNEL =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/jin_dao_increase_effect");
+    private static final ResourceLocation BONE_GROWTH_CHANNEL =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/bone_growth");
+
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    private static final DustParticleOptions PRIMARY_SPARK =
+            new DustParticleOptions(new org.joml.Vector3f(1.0f, 0.94f, 0.70f), 1.25f);
+    private static final DustParticleOptions SECONDARY_SPARK =
+            new DustParticleOptions(new org.joml.Vector3f(0.86f, 0.42f, 0.20f), 1.1f);
+
+    private SteelBoneComboHelper() {
+    }
+
+    public static ComboState analyse(ChestCavityInstance cc) {
+        if (cc == null || cc.inventory == null) {
+            return ComboState.EMPTY;
+        }
+        int steel = 0;
+        int iron = 0;
+        int refined = 0;
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (stack == null || stack.isEmpty()) {
+                continue;
+            }
+            ResourceLocation id = BuiltInRegistries.ITEM.getKey(stack.getItem());
+            if (STEEL_BONE_ID.equals(id)) {
+                steel += Math.max(1, stack.getCount());
+            } else if (IRON_BONE_ID.equals(id)) {
+                iron += Math.max(1, stack.getCount());
+            } else if (REFINED_IRON_BONE_ID.equals(id)) {
+                refined += Math.max(1, stack.getCount());
+            }
+        }
+        return new ComboState(steel, iron, refined);
+    }
+
+    public static boolean hasSteel(ComboState state) {
+        return state != null && state.steel() > 0;
+    }
+
+    public static boolean hasActiveCombo(ComboState state) {
+        return state != null && state.steel() > 0 && (state.iron() > 0 || state.refined() > 0);
+    }
+
+    public static boolean hasRefinedCombo(ComboState state) {
+        return state != null && state.steel() > 0 && state.refined() > 0;
+    }
+
+    public static boolean isPrimarySteelOrgan(ChestCavityInstance cc, ItemStack organ) {
+        return isPrimaryMatch(cc, organ, STEEL_BONE_ID);
+    }
+
+    public static boolean isPrimaryRefinedOrgan(ChestCavityInstance cc, ItemStack organ) {
+        return isPrimaryMatch(cc, organ, REFINED_IRON_BONE_ID);
+    }
+
+    private static boolean isPrimaryMatch(ChestCavityInstance cc, ItemStack organ, ResourceLocation id) {
+        if (cc == null || cc.inventory == null || organ == null || organ.isEmpty()) {
+            return false;
+        }
+        Item expected = organ.getItem();
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (stack == null || stack.isEmpty()) {
+                continue;
+            }
+            if (stack == organ) {
+                return true;
+            }
+            ResourceLocation stackId = BuiltInRegistries.ITEM.getKey(stack.getItem());
+            if (Objects.equals(stackId, id) || stack.getItem() == expected) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    public static boolean consumeMaintenanceHunger(Player player) {
+        if (player == null || player.isCreative()) {
+            return true;
+        }
+        FoodData food = player.getFoodData();
+        if (food == null) {
+            return false;
+        }
+        float saturation = food.getSaturationLevel();
+        if (saturation > 0.0f) {
+            float updated = Math.max(0.0f, saturation - 1.0f);
+            food.setSaturation(Math.min(updated, food.getFoodLevel()));
+            return true;
+        }
+        int hunger = food.getFoodLevel();
+        if (hunger > 0) {
+            food.setFoodLevel(Math.max(0, hunger - 1));
+            return true;
+        }
+        return false;
+    }
+
+    public static void restoreJingli(Player player, double amount) {
+        if (player == null || amount <= 0.0) {
+            return;
+        }
+        GuzhenrenResourceBridge.open(player).ifPresent(handle -> handle.adjustJingli(amount, true));
+    }
+
+    public static double guDaoIncrease(ChestCavityInstance cc) {
+        return readIncrease(cc, GU_DAO_INCREASE_CHANNEL);
+    }
+
+    public static double jinDaoIncrease(ChestCavityInstance cc) {
+        return readIncrease(cc, JIN_DAO_INCREASE_CHANNEL);
+    }
+
+    private static double readIncrease(ChestCavityInstance cc, ResourceLocation channelId) {
+        if (cc == null) {
+            return 0.0;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        return context.lookupChannel(channelId).map(LinkageChannel::get).orElse(0.0);
+    }
+
+    public static boolean tryConsumeBoneEnergy(ChestCavityInstance cc, double amount) {
+        if (cc == null || amount <= 0.0) {
+            return true;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        LinkageChannel channel = context.getOrCreateChannel(BONE_GROWTH_CHANNEL).addPolicy(NON_NEGATIVE);
+        double available = channel.get();
+        if (available + 1.0E-4 < amount) {
+            return false;
+        }
+        channel.adjust(-amount);
+        return true;
+    }
+
+    public static void spawnImpactFx(ServerLevel level, LivingEntity target, Vec3 hintPosition) {
+        if (level == null || target == null) {
+            return;
+        }
+        RandomSource random = level.getRandom();
+        Vec3 centre = hintPosition == null ? target.getBoundingBox().getCenter() : hintPosition;
+        for (int i = 0; i < 10; i++) {
+            double angle = random.nextDouble() * Math.PI * 2.0;
+            double speed = 0.15 + random.nextDouble() * 0.25;
+            double vx = Math.cos(angle) * speed;
+            double vz = Math.sin(angle) * speed;
+            double vy = 0.18 + random.nextDouble() * 0.12;
+            DustParticleOptions particle = (i % 2 == 0) ? PRIMARY_SPARK : SECONDARY_SPARK;
+            level.sendParticles(particle, centre.x(), centre.y(), centre.z(), 1, vx, vy, vz, 0.0);
+        }
+        level.sendParticles(ParticleTypes.ELECTRIC_SPARK, centre.x(), centre.y(), centre.z(), 6, 0.15, 0.15, 0.15, 0.02);
+        level.playSound(null, centre.x(), centre.y(), centre.z(), SoundEvents.ANVIL_LAND, SoundSource.PLAYERS, 0.7f,
+                1.05f + (random.nextFloat() - 0.5f) * 0.1f);
+        level.playSound(null, centre.x(), centre.y(), centre.z(), SoundEvents.GRINDSTONE_USE, SoundSource.PLAYERS, 0.4f,
+                1.3f + (random.nextFloat() - 0.5f) * 0.2f);
+    }
+
+    public static boolean shouldBlockNaturalRegen(Player player, ChestCavityInstance cc, ComboState state) {
+        if (player == null || cc == null) {
+            return false;
+        }
+        if (!player.level().getGameRules().getBoolean(GameRules.RULE_NATURAL_REGENERATION)) {
+            return false;
+        }
+        return hasActiveCombo(state);
+    }
+
+    private static boolean isOrganMatch(ItemStack stack, ResourceLocation id) {
+        if (stack == null || stack.isEmpty()) {
+            return false;
+        }
+        return Objects.equals(BuiltInRegistries.ITEM.getKey(stack.getItem()), id);
+    }
+
+    public static boolean isSteelOrgan(ItemStack stack) {
+        return isOrganMatch(stack, STEEL_BONE_ID);
+    }
+
+    public static boolean isRefinedOrgan(ItemStack stack) {
+        return isOrganMatch(stack, REFINED_IRON_BONE_ID);
+    }
+
+    public static boolean isIronOrgan(ItemStack stack) {
+        return isOrganMatch(stack, IRON_BONE_ID);
+    }
+
+    public record ComboState(int steel, int iron, int refined) {
+        private static final ComboState EMPTY = new ComboState(0, 0, 0);
+    }
+}
+

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/AbstractMetalBoneSupportBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/AbstractMetalBoneSupportBehavior.java
@@ -1,0 +1,178 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.AbstractGuzhenrenOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.OrganState;
+import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.linkage.IncreaseEffectLedger;
+import net.tigereye.chestcavity.linkage.LinkageChannel;
+import net.tigereye.chestcavity.linkage.LinkageManager;
+import net.tigereye.chestcavity.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.listeners.OrganRemovalContext;
+import net.tigereye.chestcavity.listeners.OrganRemovalListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+
+import java.util.List;
+
+/**
+ * Base behaviour for metallic bone platings that contribute to linkage channels and grant periodic absorption.
+ */
+abstract class AbstractMetalBoneSupportBehavior extends AbstractGuzhenrenOrganBehavior
+        implements OrganSlowTickListener, OrganRemovalListener, IncreaseEffectContributor {
+
+    private static final String ABSORPTION_KEY = "LastAbsorptionTick";
+
+    private static final ResourceLocation GU_DAO_CHANNEL =
+            ResourceLocation.fromNamespaceAndPath("guzhenren", "linkage/gu_dao_increase_effect");
+    private static final ResourceLocation JIN_DAO_CHANNEL =
+            ResourceLocation.fromNamespaceAndPath("guzhenren", "linkage/jin_dao_increase_effect");
+    private static final ResourceLocation BONE_GROWTH_CHANNEL =
+            ResourceLocation.fromNamespaceAndPath("guzhenren", "linkage/bone_growth");
+
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    AbstractMetalBoneSupportBehavior() {
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (entity == null || cc == null || organ == null || organ.isEmpty() || entity.level().isClientSide()) {
+            return;
+        }
+        refreshIncreaseContribution(cc, organ);
+
+        long gameTime = entity.level().getGameTime();
+        OrganState state = organState(organ, stateRootKey());
+        long lastApplied = state.getLong(ABSORPTION_KEY, Long.MIN_VALUE);
+        if (gameTime - lastApplied < absorptionIntervalTicks()) {
+            return;
+        }
+
+        int stackCount = Math.max(1, organ.getCount());
+        double energyCost = Math.max(0.0, boneEnergyCostPerStack()) * stackCount;
+        if (!net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.SteelBoneComboHelper.tryConsumeBoneEnergy(cc, energyCost)) {
+            return;
+        }
+
+        float requiredAbsorption = Math.max(0.0f, absorptionPerStack() * stackCount);
+        if (requiredAbsorption <= 0.0f) {
+            state.setLong(ABSORPTION_KEY, gameTime);
+            return;
+        }
+
+        if (entity.getAbsorptionAmount() + 1.0E-3f < requiredAbsorption) {
+            entity.setAbsorptionAmount(Math.max(entity.getAbsorptionAmount(), requiredAbsorption));
+            ChestCavity.LOGGER.debug(
+                    "[compat/guzhenren] Applied metal bone absorption {} -> {} for {}",
+                    String.format(java.util.Locale.ROOT, "%.1f", entity.getAbsorptionAmount()),
+                    String.format(java.util.Locale.ROOT, "%.1f", requiredAbsorption),
+                    describeStack(organ)
+            );
+        }
+        state.setLong(ABSORPTION_KEY, gameTime);
+    }
+
+    public void onEquip(ChestCavityInstance cc, ItemStack organ, List<OrganRemovalContext> staleRemovalContexts) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        RemovalRegistration registration = registerRemovalHook(cc, organ, this, staleRemovalContexts);
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        ledger.registerContributor(organ, this, GU_DAO_CHANNEL, JIN_DAO_CHANNEL);
+        refreshIncreaseContribution(cc, organ);
+        if (!registration.alreadyRegistered()) {
+            ChestCavity.LOGGER.debug("[compat/guzhenren] Registered metal bone contributor for {}", describeStack(organ));
+        }
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        if (cc == null) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        ensureChannel(context, GU_DAO_CHANNEL).addPolicy(NON_NEGATIVE);
+        ensureChannel(context, JIN_DAO_CHANNEL).addPolicy(NON_NEGATIVE);
+        ensureChannel(context, BONE_GROWTH_CHANNEL).addPolicy(NON_NEGATIVE);
+    }
+
+    @Override
+    public void onRemoved(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        double guRemoved = ledger.remove(organ, GU_DAO_CHANNEL);
+        double jinRemoved = ledger.remove(organ, JIN_DAO_CHANNEL);
+        ledger.unregisterContributor(organ);
+        if (guRemoved != 0.0) {
+            ensureChannel(context, GU_DAO_CHANNEL).addPolicy(NON_NEGATIVE).adjust(-guRemoved);
+        }
+        if (jinRemoved != 0.0) {
+            ensureChannel(context, JIN_DAO_CHANNEL).addPolicy(NON_NEGATIVE).adjust(-jinRemoved);
+        }
+        ledger.verifyAndRebuildIfNeeded();
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        int stackCount = Math.max(1, organ.getCount());
+        double guEffect = stackCount * guDaoEffectPerStack();
+        double jinEffect = stackCount * jinDaoEffectPerStack();
+        registrar.record(GU_DAO_CHANNEL, stackCount, guEffect);
+        registrar.record(JIN_DAO_CHANNEL, stackCount, jinEffect);
+    }
+
+    private void refreshIncreaseContribution(ChestCavityInstance cc, ItemStack organ) {
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+
+        LinkageChannel guDao = ensureChannel(context, GU_DAO_CHANNEL).addPolicy(NON_NEGATIVE);
+        LinkageChannel jinDao = ensureChannel(context, JIN_DAO_CHANNEL).addPolicy(NON_NEGATIVE);
+
+        double guTarget = Math.max(1, organ.getCount()) * guDaoEffectPerStack();
+        double jinTarget = Math.max(1, organ.getCount()) * jinDaoEffectPerStack();
+
+        double guPrevious = ledger.adjust(organ, GU_DAO_CHANNEL, 0.0);
+        double jinPrevious = ledger.adjust(organ, JIN_DAO_CHANNEL, 0.0);
+
+        double guDelta = guTarget - guPrevious;
+        double jinDelta = jinTarget - jinPrevious;
+
+        if (guDelta != 0.0) {
+            guDao.adjust(guDelta);
+            ledger.adjust(organ, GU_DAO_CHANNEL, guDelta);
+        }
+        if (jinDelta != 0.0) {
+            jinDao.adjust(jinDelta);
+            ledger.adjust(organ, JIN_DAO_CHANNEL, jinDelta);
+        }
+    }
+
+    protected abstract float absorptionPerStack();
+
+    protected abstract double boneEnergyCostPerStack();
+
+    protected abstract int absorptionIntervalTicks();
+
+    protected abstract double guDaoEffectPerStack();
+
+    protected abstract double jinDaoEffectPerStack();
+
+    protected abstract String stateRootKey();
+}
+

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/GangjinguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/GangjinguOrganBehavior.java
@@ -1,0 +1,168 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.AbstractGuzhenrenOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.OrganState;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.SteelBoneComboHelper;
+import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.linkage.LinkageManager;
+import net.tigereye.chestcavity.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.listeners.OrganOnHitListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+
+/**
+ * Behaviour for 钢筋蛊：hunger-gated absorption, jingli restoration and combo-driven buffs.
+ */
+public final class GangjinguOrganBehavior extends AbstractGuzhenrenOrganBehavior implements OrganSlowTickListener, OrganOnHitListener {
+
+    public static final GangjinguOrganBehavior INSTANCE = new GangjinguOrganBehavior();
+
+    private static final String STATE_ROOT = "Gangjingu";
+    private static final String ABSORPTION_KEY = "LastAbsorptionTick";
+    private static final int ABSORPTION_INTERVAL_TICKS = 20 * 120; // 2 minutes
+    private static final float ABSORPTION_PER_STACK = 60.0f;
+    private static final double JINGLI_PER_SECOND = 1.0;
+    private static final double BONUS_DAMAGE_CHANCE = 0.15;
+    private static final double BONUS_DAMAGE_RATIO = 0.08;
+    private static final int EFFECT_DURATION_TICKS = 60;
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    private static final ResourceLocation GU_DAO_CHANNEL =
+            ResourceLocation.fromNamespaceAndPath("guzhenren", "linkage/gu_dao_increase_effect");
+    private static final ResourceLocation JIN_DAO_CHANNEL =
+            ResourceLocation.fromNamespaceAndPath("guzhenren", "linkage/jin_dao_increase_effect");
+    private static final ResourceLocation BONE_GROWTH_CHANNEL =
+            ResourceLocation.fromNamespaceAndPath("guzhenren", "linkage/bone_growth");
+
+    private GangjinguOrganBehavior() {
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (!(entity instanceof Player player) || entity.level().isClientSide()) {
+            return;
+        }
+        if (!SteelBoneComboHelper.isPrimarySteelOrgan(cc, organ)) {
+            return;
+        }
+
+        SteelBoneComboHelper.ComboState comboState = SteelBoneComboHelper.analyse(cc);
+        if (!SteelBoneComboHelper.hasSteel(comboState)) {
+            return;
+        }
+
+        if (!SteelBoneComboHelper.consumeMaintenanceHunger(player)) {
+            ChestCavity.LOGGER.debug("[compat/guzhenren] Gangjingu skipped: insufficient hunger for {}", describeStack(organ));
+            return;
+        }
+
+        int steelStacks = Math.max(1, comboState.steel());
+        applyAbsorption(player, organ, steelStacks);
+
+        SteelBoneComboHelper.restoreJingli(player, JINGLI_PER_SECOND * steelStacks);
+
+        if (SteelBoneComboHelper.hasActiveCombo(comboState)) {
+            applyResistance(player, cc);
+        }
+        if (SteelBoneComboHelper.hasRefinedCombo(comboState)) {
+            applyHaste(player, cc);
+        }
+    }
+
+    private void applyAbsorption(Player player, ItemStack organ, int steelStacks) {
+        OrganState state = organState(organ, STATE_ROOT);
+        long gameTime = player.level().getGameTime();
+        long lastTick = state.getLong(ABSORPTION_KEY, Long.MIN_VALUE);
+        if (gameTime - lastTick < ABSORPTION_INTERVAL_TICKS) {
+            return;
+        }
+        float required = Math.max(0.0f, ABSORPTION_PER_STACK * steelStacks);
+        if (required <= 0.0f) {
+            state.setLong(ABSORPTION_KEY, gameTime);
+            return;
+        }
+        if (player.getAbsorptionAmount() + 1.0E-3f < required) {
+            player.setAbsorptionAmount(Math.max(player.getAbsorptionAmount(), required));
+            ChestCavity.LOGGER.debug(
+                    "[compat/guzhenren] Gangjingu applied absorption {} (stacks={})",
+                    String.format(java.util.Locale.ROOT, "%.1f", required),
+                    steelStacks
+            );
+        }
+        state.setLong(ABSORPTION_KEY, gameTime);
+    }
+
+    private void applyResistance(Player player, ChestCavityInstance cc) {
+        double increase = Math.max(0.0, SteelBoneComboHelper.guDaoIncrease(cc));
+        int amplifier = Math.max(0, (int) Math.round(increase));
+        player.addEffect(new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, EFFECT_DURATION_TICKS, amplifier, true, true));
+    }
+
+    private void applyHaste(Player player, ChestCavityInstance cc) {
+        double jinIncrease = Math.max(0.0, SteelBoneComboHelper.jinDaoIncrease(cc));
+        int amplifier = Math.max(0, (int) Math.round(jinIncrease));
+        player.addEffect(new MobEffectInstance(MobEffects.DIG_SPEED, EFFECT_DURATION_TICKS, amplifier, true, true));
+    }
+
+    @Override
+    public float onHit(DamageSource source, LivingEntity attacker, LivingEntity target, ChestCavityInstance cc, ItemStack organ, float damage) {
+        if (!(attacker instanceof Player player) || attacker.level().isClientSide()) {
+            return damage;
+        }
+        if (!SteelBoneComboHelper.isPrimarySteelOrgan(cc, organ)) {
+            return damage;
+        }
+        if (target == null || source.getDirectEntity() != attacker) {
+            return damage;
+        }
+        if (attacker.distanceToSqr(target) > 100.0) {
+            return damage;
+        }
+
+        RandomSource random = attacker.getRandom();
+        if (random.nextDouble() >= BONUS_DAMAGE_CHANCE) {
+            return damage;
+        }
+
+        double jinIncrease = Math.max(0.0, SteelBoneComboHelper.jinDaoIncrease(cc));
+        double bonus = damage * BONUS_DAMAGE_RATIO * (1.0 + jinIncrease);
+        if (bonus <= 0.0) {
+            return damage;
+        }
+
+        float result = (float) (damage + bonus);
+        ChestCavity.LOGGER.debug(
+                "[compat/guzhenren] Gangjingu bonus damage +{}/{} (jinIncrease={})",
+                String.format(java.util.Locale.ROOT, "%.2f", bonus),
+                String.format(java.util.Locale.ROOT, "%.2f", result),
+                String.format(java.util.Locale.ROOT, "%.3f", jinIncrease)
+        );
+        if (attacker.level() instanceof ServerLevel server) {
+            Vec3 impact = target.position().add(0.0, target.getBbHeight() * 0.4, 0.0);
+            SteelBoneComboHelper.spawnImpactFx(server, target, impact);
+        }
+        return result;
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        if (cc == null) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        ensureChannel(context, GU_DAO_CHANNEL).addPolicy(NON_NEGATIVE);
+        ensureChannel(context, JIN_DAO_CHANNEL).addPolicy(NON_NEGATIVE);
+        ensureChannel(context, BONE_GROWTH_CHANNEL).addPolicy(NON_NEGATIVE);
+    }
+}
+

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/JingtieguguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/JingtieguguOrganBehavior.java
@@ -1,0 +1,49 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior;
+
+/**
+ * Behaviour for 精铁骨蛊 – enhanced absorption and efficiency compared to the base iron bone.
+ */
+public final class JingtieguguOrganBehavior extends AbstractMetalBoneSupportBehavior {
+
+    public static final JingtieguguOrganBehavior INSTANCE = new JingtieguguOrganBehavior();
+
+    private static final float ABSORPTION_PER_STACK = 40.0f;
+    private static final double ENERGY_COST_PER_STACK = 40.0;
+    private static final int ABSORPTION_INTERVAL_TICKS = 20 * 60; // 1 minute
+    private static final double GU_DAO_EFFECT = 0.10;
+    private static final double JIN_DAO_EFFECT = 0.10;
+
+    private JingtieguguOrganBehavior() {
+    }
+
+    @Override
+    protected float absorptionPerStack() {
+        return ABSORPTION_PER_STACK;
+    }
+
+    @Override
+    protected double boneEnergyCostPerStack() {
+        return ENERGY_COST_PER_STACK;
+    }
+
+    @Override
+    protected int absorptionIntervalTicks() {
+        return ABSORPTION_INTERVAL_TICKS;
+    }
+
+    @Override
+    protected double guDaoEffectPerStack() {
+        return GU_DAO_EFFECT;
+    }
+
+    @Override
+    protected double jinDaoEffectPerStack() {
+        return JIN_DAO_EFFECT;
+    }
+
+    @Override
+    protected String stateRootKey() {
+        return "Jingtiegugu";
+    }
+}
+

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/TieGuGuOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/TieGuGuOrganBehavior.java
@@ -1,0 +1,49 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior;
+
+/**
+ * Behaviour for 铁骨蛊 – provides modest absorption and boosts Gu/Jin Dao efficiency.
+ */
+public final class TieGuGuOrganBehavior extends AbstractMetalBoneSupportBehavior {
+
+    public static final TieGuGuOrganBehavior INSTANCE = new TieGuGuOrganBehavior();
+
+    private static final float ABSORPTION_PER_STACK = 20.0f;
+    private static final double ENERGY_COST_PER_STACK = 20.0;
+    private static final int ABSORPTION_INTERVAL_TICKS = 20 * 60; // 1 minute
+    private static final double GU_DAO_EFFECT = 0.05;
+    private static final double JIN_DAO_EFFECT = 0.05;
+
+    private TieGuGuOrganBehavior() {
+    }
+
+    @Override
+    protected float absorptionPerStack() {
+        return ABSORPTION_PER_STACK;
+    }
+
+    @Override
+    protected double boneEnergyCostPerStack() {
+        return ENERGY_COST_PER_STACK;
+    }
+
+    @Override
+    protected int absorptionIntervalTicks() {
+        return ABSORPTION_INTERVAL_TICKS;
+    }
+
+    @Override
+    protected double guDaoEffectPerStack() {
+        return GU_DAO_EFFECT;
+    }
+
+    @Override
+    protected double jinDaoEffectPerStack() {
+        return JIN_DAO_EFFECT;
+    }
+
+    @Override
+    protected String stateRootKey() {
+        return "TieGuGu";
+    }
+}
+

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/GuNodeOrdering.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/GuNodeOrdering.java
@@ -45,7 +45,8 @@ public final class GuNodeOrdering {
 
     public static int primarySlotIndex(GuNode node) {
         if (node instanceof LeafGuNode leaf) {
-            return leaf.slotIndex().orElse(DEFAULT_INDEX);
+            int slot = leaf.slotIndex();
+            return slot >= 0 ? slot : DEFAULT_INDEX;
         }
         if (node instanceof OperatorGuNode operator) {
             return operator.primarySlotIndex().orElse(DEFAULT_INDEX);
@@ -69,7 +70,8 @@ public final class GuNodeOrdering {
 
     public static int pageIndex(GuNode node) {
         if (node instanceof LeafGuNode leaf) {
-            return leaf.pageIndex().orElse(DEFAULT_PAGE_INDEX);
+            int page = leaf.pageIndex();
+            return page >= 0 ? page : DEFAULT_PAGE_INDEX;
         }
         if (node instanceof OperatorGuNode operator) {
             return operator.pageIndexHint().orElse(DEFAULT_PAGE_INDEX);

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptCompiler.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptCompiler.java
@@ -59,7 +59,6 @@ public final class GuScriptCompiler {
             }
             int slotIndex = i;
             ResourceLocation itemId = stack.getItem().builtInRegistryHolder().key().location();
-            int slotIndex = i;
             GuScriptRegistry.leaf(itemId).ifPresentOrElse(def -> {
                 leaves.add(toScaledLeaf(def, stack.getCount(), pageIndex, slotIndex));
             }, () -> ChestCavity.LOGGER.warn("[GuScript] No leaf definition for item {}", itemId));

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/reduce/GuScriptReducer.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/reduce/GuScriptReducer.java
@@ -207,12 +207,13 @@ public final class GuScriptReducer {
     }
 
     private static Integer normalizeMetadata(int value) {
-        return value == UNKNOWN_SLOT_INDEX ? null : value;
+        return (value == UNKNOWN_SLOT_INDEX || value == UNKNOWN_PAGE_INDEX) ? null : value;
     }
 
     private static int resolvePrimarySlotIndex(GuNode node) {
         if (node instanceof LeafGuNode leaf) {
-            return leaf.slotIndex().orElse(UNKNOWN_SLOT_INDEX);
+            int slot = leaf.slotIndex();
+            return slot >= 0 ? slot : UNKNOWN_SLOT_INDEX;
         }
         if (node instanceof OperatorGuNode operator) {
             return operator.primarySlotIndex().orElse(UNKNOWN_SLOT_INDEX);
@@ -222,7 +223,8 @@ public final class GuScriptReducer {
 
     private static int resolvePageIndex(GuNode node) {
         if (node instanceof LeafGuNode leaf) {
-            return leaf.pageIndex().orElse(UNKNOWN_PAGE_INDEX);
+            int page = leaf.pageIndex();
+            return page >= 0 ? page : UNKNOWN_PAGE_INDEX;
         }
         if (node instanceof OperatorGuNode operator) {
             return operator.pageIndexHint().orElse(UNKNOWN_PAGE_INDEX);

--- a/src/main/java/net/tigereye/chestcavity/listeners/OrganHealingEvents.java
+++ b/src/main/java/net/tigereye/chestcavity/listeners/OrganHealingEvents.java
@@ -1,0 +1,79 @@
+package net.tigereye.chestcavity.listeners;
+
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.food.FoodData;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.living.LivingHealEvent;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.SteelBoneComboHelper;
+import net.tigereye.chestcavity.interfaces.ChestCavityEntity;
+import net.tigereye.chestcavity.util.ChestCavityUtil;
+
+import java.util.Optional;
+
+/**
+ * Guards natural regeneration so combination effects can suspend vanilla healing.
+ */
+@EventBusSubscriber(modid = ChestCavity.MODID)
+public final class OrganHealingEvents {
+
+    private OrganHealingEvents() {
+    }
+
+    @SubscribeEvent
+    public static void onLivingHeal(LivingHealEvent event) {
+        LivingEntity entity = event.getEntity();
+        if (entity == null || entity.level().isClientSide()) {
+            return;
+        }
+        if (ChestCavityUtil.isOrganHealGuardActive()) {
+            return;
+        }
+
+        Optional<ChestCavityEntity> optional = ChestCavityEntity.of(entity);
+        if (optional.isEmpty()) {
+            return;
+        }
+
+        ChestCavityInstance cc = optional.get().getChestCavityInstance();
+        if (entity instanceof Player player) {
+            if (shouldCancelPlayerHeal(player, cc, event.getAmount())) {
+                event.setCanceled(true);
+            }
+        }
+    }
+
+    private static boolean shouldCancelPlayerHeal(Player player, ChestCavityInstance cc, float amount) {
+        if (player == null || cc == null) {
+            return false;
+        }
+        if (!player.level().getGameRules().getBoolean(net.minecraft.world.level.GameRules.RULE_NATURAL_REGENERATION)) {
+            return false;
+        }
+        if (amount > 1.01f) {
+            return false;
+        }
+        if (player.hasEffect(MobEffects.REGENERATION) || player.hasEffect(MobEffects.HEAL)) {
+            return false;
+        }
+        FoodData foodData = player.getFoodData();
+        if (foodData == null || foodData.getFoodLevel() < 18) {
+            return false;
+        }
+        SteelBoneComboHelper.ComboState state = SteelBoneComboHelper.analyse(cc);
+        if (!SteelBoneComboHelper.shouldBlockNaturalRegen(player, cc, state)) {
+            return false;
+        }
+        ChestCavity.LOGGER.debug(
+                "[compat/guzhenren] Blocking natural regeneration for {} (amount={})",
+                player.getScoreboardName(),
+                amount
+        );
+        return true;
+    }
+}
+

--- a/src/main/java/net/tigereye/chestcavity/registration/CCItems.java
+++ b/src/main/java/net/tigereye/chestcavity/registration/CCItems.java
@@ -38,8 +38,11 @@ public class CCItems {
 	// -- 剑道
 	public static final Item GUZHENREN_JIAN_YING_GU = resolveExternalItem("guzhenren", "jian_ying_gu");
 
-	// -- 骨道
-	public static final Item GUZHENREN_GU_QIANG_GU = resolveExternalItem("guzhenren", "gu_qiang_gu");
+        // -- 骨道
+        public static final Item GUZHENREN_GU_QIANG_GU = resolveExternalItem("guzhenren", "gu_qiang_gu");
+        public static final Item GUZHENREN_GAN_JIN_GU = resolveExternalItem("guzhenren", "ganjingu");
+        public static final Item GUZHENREN_TIE_GU_GU = resolveExternalItem("guzhenren", "tie_gu_gu");
+        public static final Item GUZHENREN_JING_TIE_GU_GU = resolveExternalItem("guzhenren", "jingtiegugu");
 
 	// -- 模型类 item
 	public static final Item GUZHENREN_GU_QIANG = resolveExternalItem("guzhenren", "gu_qiang");

--- a/src/main/resources/data/chestcavity/organs/guzhenren/human/ganjingu.json
+++ b/src/main/resources/data/chestcavity/organs/guzhenren/human/ganjingu.json
@@ -1,0 +1,8 @@
+{
+  "itemID": "guzhenren:ganjingu",
+  "organScores": [
+    { "id": "chestcavity:strength", "value": "24" },
+    { "id": "chestcavity:speed", "value": "24" }
+  ]
+}
+

--- a/src/main/resources/data/chestcavity/organs/guzhenren/human/jingtiegugu.json
+++ b/src/main/resources/data/chestcavity/organs/guzhenren/human/jingtiegugu.json
@@ -1,0 +1,8 @@
+{
+  "itemID": "guzhenren:jingtiegugu",
+  "organScores": [
+    { "id": "chestcavity:defense", "value": "4" },
+    { "id": "chestcavity:nerves", "value": "1" }
+  ]
+}
+

--- a/src/main/resources/data/chestcavity/organs/guzhenren/human/tie_gu_gu.json
+++ b/src/main/resources/data/chestcavity/organs/guzhenren/human/tie_gu_gu.json
@@ -1,0 +1,8 @@
+{
+  "itemID": "guzhenren:tie_gu_gu",
+  "organScores": [
+    { "id": "chestcavity:defense", "value": "2" },
+    { "id": "chestcavity:nerves", "value": "1" }
+  ]
+}
+


### PR DESCRIPTION
## Summary
- add shared steel bone combo helper/healing logic and implement Gangjingu, TieGuGu, and Jingtiegugu organ behaviours
- extend Gu Dao organ registry/events for iron ingot repairs, hunger upkeep, and natural regeneration suppression tied to steel bone combos
- update GuScript compiler metadata handling and add organ heal guard utilities plus new organ datapack entries

## Testing
- ./gradlew --console=plain compileJava

------
https://chatgpt.com/codex/tasks/task_e_68da64878c0083268927121bb721726d