### PR TITLE
Add missing GuScript FX for mind thought abilities

### DIFF
--- a/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_charge_ready.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_charge_ready.json
@@ -1,0 +1,33 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:block.enchantment_table.use",
+      "volume": 0.85,
+      "pitch": 1.35
+    },
+    {
+      "type": "sound",
+      "sound": "minecraft:block.note_block.harp",
+      "volume": 0.6,
+      "pitch": 1.9
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:end_rod",
+      "count": 16,
+      "spread": [0.25, 0.5, 0.25],
+      "speed": 0.01
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:dust_color_transition",
+      "from_color": "#7458ff",
+      "to_color": "#f5f2ff",
+      "size": 0.85,
+      "count": 26,
+      "spread": [0.35, 0.45, 0.35],
+      "speed": 0.02
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_pulse.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_pulse.json
@@ -15,7 +15,7 @@
     },
     {
       "type": "particle",
-      "particle": "minecraft:spell_instant",
+      "particle": "minecraft:instant_effect",
       "count": 16,
       "spread": [0.35, 0.35, 0.35],
       "speed": 0.0

--- a/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_recover.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_recover.json
@@ -1,0 +1,33 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:block.amethyst_block.chime",
+      "volume": 0.6,
+      "pitch": 1.8
+    },
+    {
+      "type": "sound",
+      "sound": "minecraft:block.amethyst_cluster.place",
+      "volume": 0.55,
+      "pitch": 1.5
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:dust_color_transition",
+      "from_color": "#d7c8ff",
+      "to_color": "#ffffff",
+      "size": 0.6,
+      "count": 24,
+      "spread": [0.35, 0.25, 0.35],
+      "speed": 0.01
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:glow",
+      "count": 10,
+      "spread": [0.2, 0.2, 0.2],
+      "speed": 0.0
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_release.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_release.json
@@ -1,0 +1,32 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:entity.evoker.cast_spell",
+      "volume": 0.9,
+      "pitch": 1.1
+    },
+    {
+      "type": "sound",
+      "sound": "minecraft:entity.illusioner.prepare_mirror",
+      "volume": 0.6,
+      "pitch": 1.45
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:dragon_breath",
+      "count": 20,
+      "spread": [0.25, 0.35, 0.25],
+      "speed": 0.12
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:dust",
+      "color": "#ede1ff",
+      "size": 1.05,
+      "count": 18,
+      "spread": [0.3, 0.3, 0.3],
+      "speed": 0.18
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_remote_hit.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_remote_hit.json
@@ -1,0 +1,26 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:entity.generic.explode",
+      "volume": 0.5,
+      "pitch": 1.6
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:poof",
+      "count": 14,
+      "spread": [0.25, 0.25, 0.25],
+      "speed": 0.18
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:dust",
+      "color": "#d2bfff",
+      "size": 0.65,
+      "count": 20,
+      "spread": [0.3, 0.3, 0.3],
+      "speed": 0.05
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_remote_release.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/mind_thoughts_remote_release.json
@@ -1,0 +1,34 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:entity.warden.sonic_boom",
+      "volume": 0.7,
+      "pitch": 1.25
+    },
+    {
+      "type": "sound",
+      "sound": "minecraft:entity.shulker.shoot",
+      "volume": 0.6,
+      "pitch": 1.6
+    },
+    {
+      "type": "trail",
+      "particle": "minecraft:dust_color_transition",
+      "from_color": "#a280ff",
+      "to_color": "#ffffff",
+      "size": 0.75,
+      "segments": 14,
+      "spacing": 0.22,
+      "speed": 0.2,
+      "spread": [0.05, 0.05, 0.05]
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:small_flame",
+      "count": 20,
+      "spread": [0.4, 0.25, 0.4],
+      "speed": 0.08
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace the removed `minecraft:spell_instant` particle in the mind thoughts pulse FX with `minecraft:instant_effect`
- add FX definitions for the mind thoughts charge, release, remote release, remote hit, and recover events so the flows can play client feedback without warnings

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68da9e0f6b048326908935cc69d31063