### PR TITLE
Fix remote thought ability targeting

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/guscript/network/packets/GuScriptTriggerPayload.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/network/packets/GuScriptTriggerPayload.java
@@ -4,6 +4,7 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.LivingEntity;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.guscript.data.GuScriptAttachment;
@@ -13,13 +14,16 @@ import net.tigereye.chestcavity.registration.CCAttachments;
 /**
  * Client-to-server payload requesting GuScript execution via keybind.
  */
-public record GuScriptTriggerPayload(int pageIndex) implements CustomPacketPayload {
+public record GuScriptTriggerPayload(int pageIndex, int targetEntityId) implements CustomPacketPayload {
 
     public static final Type<GuScriptTriggerPayload> TYPE = new Type<>(ChestCavity.id("guscript_trigger"));
 
     public static final StreamCodec<FriendlyByteBuf, GuScriptTriggerPayload> STREAM_CODEC = StreamCodec.of(
-            (buf, payload) -> buf.writeVarInt(payload.pageIndex),
-            buf -> new GuScriptTriggerPayload(buf.readVarInt())
+            (buf, payload) -> {
+                buf.writeVarInt(payload.pageIndex);
+                buf.writeVarInt(payload.targetEntityId);
+            },
+            buf -> new GuScriptTriggerPayload(buf.readVarInt(), buf.readVarInt())
     );
 
     @Override
@@ -36,7 +40,14 @@ public record GuScriptTriggerPayload(int pageIndex) implements CustomPacketPaylo
             if (payload.pageIndex >= 0) {
                 attachment.setCurrentPage(payload.pageIndex);
             }
-            GuScriptExecutor.triggerKeybind(player, player, attachment);
+            LivingEntity target = null;
+            if (payload.targetEntityId >= 0) {
+                var entity = player.level().getEntity(payload.targetEntityId);
+                if (entity instanceof LivingEntity living && entity.isAlive()) {
+                    target = living;
+                }
+            }
+            GuScriptExecutor.triggerKeybind(player, target, attachment);
         });
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/listeners/KeybindingClientListeners.java
+++ b/src/main/java/net/tigereye/chestcavity/listeners/KeybindingClientListeners.java
@@ -6,8 +6,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.phys.EntityHitResult;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.tigereye.chestcavity.network.packets.ChestCavityHotkeyPayload;
 import net.tigereye.chestcavity.guscript.network.packets.GuScriptTriggerPayload;
@@ -172,7 +174,13 @@ public class KeybindingClientListeners {
         if (minecraft.screen instanceof GuScriptScreen screen) {
             pageIndex = screen.getMenu().getPageIndex();
         }
-        connection.send(new GuScriptTriggerPayload(pageIndex));
+        int targetId = -1;
+        if (minecraft.hitResult instanceof EntityHitResult entityHit) {
+            if (entityHit.getEntity() instanceof LivingEntity living) {
+                targetId = living.getId();
+            }
+        }
+        connection.send(new GuScriptTriggerPayload(pageIndex, targetId));
     }
 
     private static void sendHotkeyToServer(ChestCavityHotkeyPayload payload) {


### PR DESCRIPTION
## Summary
- include the looked-at living entity id in GuScriptTriggerPayload and resolve it server-side before executing keybind scripts
- capture the client crosshair entity when sending the execute keybind so remote mind attacks can act on their intended target

## Testing
- ./gradlew compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68daa64f85e48326b1caf75907d30903