### PR TITLE
Support dust_color_transition FX particles

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/guscript/fx/FxDefinition.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/fx/FxDefinition.java
@@ -48,8 +48,8 @@ public record FxDefinition(List<FxModule> modules) {
         }
     }
 
-    public record ParticleSettings(ResourceLocation particleId, double speed, Vec3 spread, Integer color, float size) {
-        static final ParticleSettings DEFAULT = new ParticleSettings(ResourceLocation.fromNamespaceAndPath("minecraft", "crit"), 0.0D, Vec3.ZERO, null, 1.0F);
+    public record ParticleSettings(ResourceLocation particleId, double speed, Vec3 spread, Integer primaryColor, Integer secondaryColor, float size) {
+        static final ParticleSettings DEFAULT = new ParticleSettings(ResourceLocation.fromNamespaceAndPath("minecraft", "crit"), 0.0D, Vec3.ZERO, null, null, 1.0F);
 
         public ParticleSettings {
             speed = Math.max(0.0D, speed);

--- a/src/main/java/net/tigereye/chestcavity/guscript/fx/client/FxClientDispatcher.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/fx/client/FxClientDispatcher.java
@@ -2,6 +2,7 @@ package net.tigereye.chestcavity.guscript.fx.client;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.particles.DustColorTransitionOptions;
 import net.minecraft.core.particles.DustParticleOptions;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.particles.ParticleType;
@@ -126,15 +127,28 @@ public final class FxClientDispatcher {
         if (type instanceof SimpleParticleType simple) {
             return simple;
         }
-        if ("minecraft:dust".equals(settings.particleId().toString()) && settings.color() != null) {
-            float r = ((settings.color() >> 16) & 0xFF) / 255.0F;
-            float g = ((settings.color() >> 8) & 0xFF) / 255.0F;
-            float b = (settings.color() & 0xFF) / 255.0F;
+        String particleKey = settings.particleId().toString();
+        if ("minecraft:dust".equals(particleKey) && settings.primaryColor() != null) {
             float size = settings.size() <= 0.0F ? 1.0F : settings.size();
-            return new DustParticleOptions(new Vector3f(r, g, b), size);
+            return new DustParticleOptions(colorToVector(settings.primaryColor()), size);
+        }
+        if ("minecraft:dust_color_transition".equals(particleKey)) {
+            if (settings.primaryColor() == null || settings.secondaryColor() == null) {
+                ChestCavity.LOGGER.warn("[GuScript] dust_color_transition requires from_color and to_color in FX definition");
+                return null;
+            }
+            float size = settings.size() <= 0.0F ? 1.0F : settings.size();
+            return new DustColorTransitionOptions(colorToVector(settings.primaryColor()), colorToVector(settings.secondaryColor()), size);
         }
         ChestCavity.LOGGER.warn("[GuScript] Unsupported particle type {} for FX", settings.particleId());
         return null;
 
+    }
+
+    private static Vector3f colorToVector(int color) {
+        float r = ((color >> 16) & 0xFF) / 255.0F;
+        float g = ((color >> 8) & 0xFF) / 255.0F;
+        float b = (color & 0xFF) / 255.0F;
+        return new Vector3f(r, g, b);
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/registry/FxDefinitionLoader.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/registry/FxDefinitionLoader.java
@@ -98,9 +98,19 @@ public final class FxDefinitionLoader extends SimpleJsonResourceReloadListener {
         ResourceLocation particleId = ResourceLocation.parse(GsonHelper.getAsString(json, "particle", "minecraft:crit"));
         double speed = GsonHelper.getAsDouble(json, "speed", 0.05D);
         Vec3 spread = readVec3(json, "spread", 0.15D);
-        Integer color = json.has("color") ? parseColor(json.get("color")) : null;
+        Integer primaryColor = null;
+        if (json.has("color")) {
+            primaryColor = parseColor(json.get("color"));
+        }
+        if (json.has("from_color")) {
+            Integer fromColor = parseColor(json.get("from_color"));
+            if (fromColor != null) {
+                primaryColor = fromColor;
+            }
+        }
+        Integer secondaryColor = json.has("to_color") ? parseColor(json.get("to_color")) : null;
         float size = GsonHelper.getAsFloat(json, "size", 1.0F);
-        return new ParticleSettings(particleId, speed, spread, color, size);
+        return new ParticleSettings(particleId, speed, spread, primaryColor, secondaryColor, size);
     }
 
     private static Vec3 readVec3(JsonObject json, String key) {


### PR DESCRIPTION
## Summary
- allow FX particle settings to capture both primary and secondary colors from JSON
- render `minecraft:dust_color_transition` FX definitions with the proper DustColorTransitionOptions on the client

## Testing
- ./gradlew --console=plain compileJava

------
https://chatgpt.com/codex/tasks/task_e_68db13c755748326a6c7565ce49e2940