### PR TITLE
Add Bing Ji Gu ice-path organ integration

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/bing_xue_dao/BingXueDaoClientAbilities.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/bing_xue_dao/BingXueDaoClientAbilities.java
@@ -1,0 +1,20 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.bing_xue_dao;
+
+import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import net.tigereye.chestcavity.compat.guzhenren.item.bing_xue_dao.behavior.BingJiGuOrganBehavior;
+import net.tigereye.chestcavity.registration.CCKeybindings;
+
+/**
+ * Client-side ability registration for 冰雪道 organs.
+ */
+public final class BingXueDaoClientAbilities {
+
+    private BingXueDaoClientAbilities() {
+    }
+
+    public static void onClientSetup(FMLClientSetupEvent event) {
+        if (!CCKeybindings.ATTACK_ABILITY_LIST.contains(BingJiGuOrganBehavior.ABILITY_ID)) {
+            CCKeybindings.ATTACK_ABILITY_LIST.add(BingJiGuOrganBehavior.ABILITY_ID);
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/bing_xue_dao/BingXueDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/bing_xue_dao/BingXueDaoOrganRegistry.java
@@ -1,0 +1,33 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.bing_xue_dao;
+
+import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.compat.guzhenren.item.bing_xue_dao.behavior.BingJiGuOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
+
+/**
+ * Registry wiring for 冰雪道（Bing Xue Dao） organs.
+ */
+public final class BingXueDaoOrganRegistry {
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation BING_JI_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "bing_ji_gu");
+
+    private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(BING_JI_GU_ID)
+                    .addSlowTickListener(BingJiGuOrganBehavior.INSTANCE)
+                    .addOnHitListener(BingJiGuOrganBehavior.INSTANCE)
+                    .addRemovalListener(BingJiGuOrganBehavior.INSTANCE)
+                    .ensureAttached(BingJiGuOrganBehavior.INSTANCE::ensureAttached)
+                    .onEquip(BingJiGuOrganBehavior.INSTANCE::onEquip)
+                    .build()
+    );
+
+    private BingXueDaoOrganRegistry() {
+    }
+
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/bing_xue_dao/behavior/BingJiGuOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/bing_xue_dao/behavior/BingJiGuOrganBehavior.java
@@ -1,0 +1,482 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.bing_xue_dao.behavior;
+
+import com.mojang.logging.LogUtils;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.SnowLayerBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraft.world.level.material.Fluids;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.AbstractGuzhenrenOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.OrganState;
+import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.linkage.LinkageChannel;
+import net.tigereye.chestcavity.linkage.LinkageManager;
+import net.tigereye.chestcavity.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.listeners.OrganActivationListeners;
+import net.tigereye.chestcavity.listeners.OrganOnHitListener;
+import net.tigereye.chestcavity.listeners.OrganRemovalContext;
+import net.tigereye.chestcavity.listeners.OrganRemovalListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.registration.CCItems;
+import net.tigereye.chestcavity.util.ChestCavityUtil;
+import net.tigereye.chestcavity.util.NetworkUtil;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Behaviour implementation for 冰肌蛊 (Bing Ji Gu).
+ */
+public final class BingJiGuOrganBehavior extends AbstractGuzhenrenOrganBehavior
+        implements OrganSlowTickListener, OrganOnHitListener, OrganRemovalListener {
+
+    public static final BingJiGuOrganBehavior INSTANCE = new BingJiGuOrganBehavior();
+
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation ORGAN_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "bing_ji_gu");
+    private static final ResourceLocation JADE_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "yu_gu_gu");
+    private static final ResourceLocation ICE_BURST_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "bing_bao_gu");
+    private static final ResourceLocation BING_XUE_INCREASE_EFFECT =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/bing_xue_dao_increase_effect");
+    private static final ResourceLocation BLEED_EFFECT_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "lliuxue");
+    private static final ResourceLocation ICE_COLD_EFFECT_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "hhanleng");
+
+    public static final ResourceLocation ABILITY_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "bing_ji_gu_iceburst");
+
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    private static final String STATE_ROOT = "BingJiGu";
+    private static final String ABSORPTION_TIMER_KEY = "AbsorptionTimer";
+    private static final String INVULN_COOLDOWN_KEY = "InvulnCooldown";
+
+    private static final double ZHENYUAN_BASE_COST = 200.0;
+    private static final double JINGLI_PER_TICK = 1.0;
+    private static final float HEAL_PER_TICK = 5.0f;
+    private static final int SLOW_TICK_INTERVALS_PER_MINUTE = 60;
+    private static final float ABSORPTION_PER_TRIGGER = 20.0f;
+    private static final double BONUS_DAMAGE_FRACTION = 0.05;
+    private static final double BONUS_TRIGGER_CHANCE = 0.10;
+    private static final int ICE_EFFECT_DURATION_TICKS = 30 * 20;
+    private static final double ICE_BURST_BASE_DAMAGE = 18.0;
+    private static final double ICE_BURST_RADIUS = 6.0;
+    private static final double ICE_BURST_RADIUS_PER_STACK = 0.5;
+    private static final double ICE_BURST_STACK_DAMAGE_SCALE = 0.65;
+    private static final double ICE_BURST_BING_BAO_MULTIPLIER = 0.35;
+    private static final float ICE_BURST_SLOW_AMPLIFIER = 1.0f;
+    private static final int ICE_BURST_SLOW_DURATION = 8 * 20;
+    private static final double MAX_BLOCK_HARDNESS = 4.0;
+    private static final int INVULN_DURATION_TICKS = 40;
+    private static final int INVULN_COOLDOWN_TICKS = 20 * 30;
+    private static final double LOW_HEALTH_THRESHOLD = 0.30;
+
+    static {
+        OrganActivationListeners.register(ABILITY_ID, BingJiGuOrganBehavior::activateAbility);
+    }
+
+    private BingJiGuOrganBehavior() {
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (!(entity instanceof Player player) || entity.level().isClientSide() || cc == null) {
+            return;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID) && !organ.is(CCItems.GUZHENREN_BING_JI_GU)) {
+            return;
+        }
+
+        int stackCount = Math.max(1, organ.getCount());
+        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+        if (handleOpt.isEmpty()) {
+            return;
+        }
+        GuzhenrenResourceBridge.ResourceHandle handle = handleOpt.get();
+
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        double efficiency = 1.0 + lookupIncreaseEffect(context);
+
+        boolean paid = handle.consumeScaledZhenyuan(ZHENYUAN_BASE_COST * stackCount).isPresent();
+        OrganState state = organState(organ, STATE_ROOT);
+        boolean stateChanged = false;
+
+        if (paid) {
+            handle.adjustJingli(JINGLI_PER_TICK * stackCount, true);
+            float healAmount = HEAL_PER_TICK * stackCount;
+            if (healAmount > 0.0f) {
+                ChestCavityUtil.runWithOrganHeal(() -> player.heal(healAmount));
+            }
+            stateChanged |= tickAbsorption(player, state, stackCount, efficiency);
+            if (hasJadeBone(cc)) {
+                clearBleed(player);
+            }
+        }
+
+        stateChanged |= tickInvulnerability(player, state, cc, organ);
+        if (stateChanged) {
+            NetworkUtil.sendOrganSlotUpdate(cc, organ);
+        }
+    }
+
+    @Override
+    public float onHit(
+            DamageSource source,
+            LivingEntity attacker,
+            LivingEntity target,
+            ChestCavityInstance cc,
+            ItemStack organ,
+            float damage
+    ) {
+        if (attacker == null || target == null || attacker.level().isClientSide()) {
+            return damage;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID) && !organ.is(CCItems.GUZHENREN_BING_JI_GU)) {
+            return damage;
+        }
+        if (damage <= 0.0f || attacker.getRandom().nextDouble() >= BONUS_TRIGGER_CHANCE) {
+            return damage;
+        }
+
+        double efficiency = 1.0 + lookupIncreaseEffect(LinkageManager.getContext(cc));
+        float bonus = (float) (damage * BONUS_DAMAGE_FRACTION * Math.max(0.0, efficiency));
+        if (bonus > 0.0f) {
+            applyColdEffect(target);
+            return damage + bonus;
+        }
+        applyColdEffect(target);
+        return damage;
+    }
+
+    @Override
+    public void onRemoved(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (!matchesOrgan(organ, ORGAN_ID) && !organ.is(CCItems.GUZHENREN_BING_JI_GU)) {
+            return;
+        }
+    }
+
+    public void onEquip(ChestCavityInstance cc, ItemStack organ, List<OrganRemovalContext> staleRemovalContexts) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID) && !organ.is(CCItems.GUZHENREN_BING_JI_GU)) {
+            return;
+        }
+        RemovalRegistration registration = registerRemovalHook(cc, organ, this, staleRemovalContexts);
+        if (!registration.alreadyRegistered()) {
+            OrganState state = organState(organ, STATE_ROOT);
+            state.setInt(ABSORPTION_TIMER_KEY, 0);
+            state.setInt(INVULN_COOLDOWN_KEY, 0);
+            NetworkUtil.sendOrganSlotUpdate(cc, organ);
+        }
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        if (cc == null) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        if (context == null) {
+            return;
+        }
+        ensureIncreaseChannel(context, BING_XUE_INCREASE_EFFECT);
+    }
+
+    private static void ensureIncreaseChannel(ActiveLinkageContext context, ResourceLocation id) {
+        if (context == null || id == null) {
+            return;
+        }
+        context.getOrCreateChannel(id).addPolicy(NON_NEGATIVE);
+    }
+
+    private static double lookupIncreaseEffect(ActiveLinkageContext context) {
+        if (context == null) {
+            return 0.0;
+        }
+        return context.lookupChannel(BING_XUE_INCREASE_EFFECT).map(LinkageChannel::get).orElse(0.0);
+    }
+
+    private static boolean tickAbsorption(Player player, OrganState state, int stacks, double efficiency) {
+        if (player == null || state == null) {
+            return false;
+        }
+        int timer = state.getInt(ABSORPTION_TIMER_KEY, 0) + 1;
+        boolean changed = false;
+        if (timer >= SLOW_TICK_INTERVALS_PER_MINUTE) {
+            timer = 0;
+            float gain = (float) (ABSORPTION_PER_TRIGGER * Math.max(1, stacks) * Math.max(0.0, efficiency));
+            float updated = player.getAbsorptionAmount() + gain;
+            player.setAbsorptionAmount(updated);
+            changed = true;
+        }
+        if (changed) {
+            state.setInt(ABSORPTION_TIMER_KEY, timer);
+            return true;
+        }
+        if (state.getInt(ABSORPTION_TIMER_KEY, 0) != timer) {
+            state.setInt(ABSORPTION_TIMER_KEY, timer);
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean tickInvulnerability(Player player, OrganState state, ChestCavityInstance cc, ItemStack organ) {
+        if (player == null || state == null) {
+            return false;
+        }
+        int cooldown = Math.max(0, state.getInt(INVULN_COOLDOWN_KEY, 0));
+        boolean changed = false;
+        if (cooldown > 0) {
+            cooldown--;
+            state.setInt(INVULN_COOLDOWN_KEY, cooldown);
+            changed = true;
+        }
+        if (cooldown <= 0 && hasJadeBone(cc) && isBeimingConstitution(player)
+                && player.getHealth() <= player.getMaxHealth() * LOW_HEALTH_THRESHOLD) {
+            player.invulnerableTime = Math.max(player.invulnerableTime, INVULN_DURATION_TICKS);
+            player.addEffect(new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, INVULN_DURATION_TICKS, 4, false, true, true));
+            state.setInt(INVULN_COOLDOWN_KEY, INVULN_COOLDOWN_TICKS);
+            changed = true;
+        }
+        return changed;
+    }
+
+    private static void clearBleed(LivingEntity entity) {
+        if (entity == null || entity.level().isClientSide()) {
+            return;
+        }
+        Optional<Holder.Reference<MobEffect>> holder = BuiltInRegistries.MOB_EFFECT.getHolder(BLEED_EFFECT_ID);
+        holder.ifPresent(entity::removeEffect);
+    }
+
+    private static void applyColdEffect(LivingEntity target) {
+        if (target == null || target.level().isClientSide()) {
+            return;
+        }
+        Optional<Holder.Reference<MobEffect>> holder = BuiltInRegistries.MOB_EFFECT.getHolder(ICE_COLD_EFFECT_ID);
+        holder.ifPresent(effect -> target.addEffect(new MobEffectInstance(effect, ICE_EFFECT_DURATION_TICKS, 0, false, true, true)));
+        target.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, ICE_EFFECT_DURATION_TICKS, 0, false, true, true));
+        target.addEffect(new MobEffectInstance(MobEffects.DIG_SLOWDOWN, ICE_EFFECT_DURATION_TICKS, 0, false, true, true));
+    }
+
+    private static boolean hasJadeBone(ChestCavityInstance cc) {
+        return hasOrgan(cc, JADE_BONE_ID);
+    }
+
+    private static boolean hasBingBao(ChestCavityInstance cc) {
+        return hasOrgan(cc, ICE_BURST_ID);
+    }
+
+    private static boolean hasOrgan(ChestCavityInstance cc, ResourceLocation id) {
+        if (cc == null || id == null || cc.inventory == null) {
+            return false;
+        }
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (stack == null || stack.isEmpty()) {
+                continue;
+            }
+            ResourceLocation stackId = BuiltInRegistries.ITEM.getKey(stack.getItem());
+            if (Objects.equals(stackId, id)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static ItemStack findOrgan(ChestCavityInstance cc) {
+        if (cc == null || cc.inventory == null) {
+            return ItemStack.EMPTY;
+        }
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (stack == null || stack.isEmpty()) {
+                continue;
+            }
+            if (stack.is(CCItems.GUZHENREN_BING_JI_GU)) {
+                return stack;
+            }
+            ResourceLocation id = BuiltInRegistries.ITEM.getKey(stack.getItem());
+            if (Objects.equals(id, ORGAN_ID)) {
+                return stack;
+            }
+        }
+        return ItemStack.EMPTY;
+    }
+
+    private static boolean consumeMuscle(ChestCavityInstance cc) {
+        if (cc == null || cc.inventory == null) {
+            return false;
+        }
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (stack == null || stack.isEmpty()) {
+                continue;
+            }
+            ResourceLocation id = BuiltInRegistries.ITEM.getKey(stack.getItem());
+            if (id != null && "chestcavity".equals(id.getNamespace()) && id.getPath().endsWith("_muscle")) {
+                cc.inventory.removeItem(i, 1);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void activateAbility(LivingEntity entity, ChestCavityInstance cc) {
+        if (entity == null || cc == null || entity.level().isClientSide()) {
+            return;
+        }
+        ItemStack organ = findOrgan(cc);
+        if (organ.isEmpty() || !hasJadeBone(cc)) {
+            return;
+        }
+        if (!consumeMuscle(cc)) {
+            return;
+        }
+        Level level = entity.level();
+        if (!(level instanceof ServerLevel server)) {
+            return;
+        }
+        int stacks = Math.max(1, organ.getCount());
+        double efficiency = 1.0 + lookupIncreaseEffect(LinkageManager.getContext(cc));
+        double baseDamage = ICE_BURST_BASE_DAMAGE * Math.pow(ICE_BURST_STACK_DAMAGE_SCALE, stacks - 1);
+        baseDamage *= Math.max(0.0, efficiency);
+        if (hasBingBao(cc)) {
+            baseDamage *= 1.0 + ICE_BURST_BING_BAO_MULTIPLIER;
+        }
+        double radius = ICE_BURST_RADIUS + Math.max(0, stacks - 1) * ICE_BURST_RADIUS_PER_STACK;
+
+        Vec3 origin = entity.position();
+        List<LivingEntity> victims = gatherTargets(entity, server, radius);
+        for (LivingEntity target : victims) {
+            double distance = Math.sqrt(target.distanceToSqr(origin));
+            double falloff = Math.max(0.0, 1.0 - (distance / radius));
+            float damage = (float) (baseDamage * falloff);
+            if (damage > 0.0f) {
+                DamageSource source = entity instanceof Player player
+                        ? player.damageSources().playerAttack(player)
+                        : server.damageSources().mobAttack(entity);
+                target.hurt(source, damage);
+                target.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, ICE_BURST_SLOW_DURATION, (int) ICE_BURST_SLOW_AMPLIFIER, false, true, true));
+                target.addEffect(new MobEffectInstance(MobEffects.DIG_SLOWDOWN, ICE_BURST_SLOW_DURATION, (int) ICE_BURST_SLOW_AMPLIFIER, false, true, true));
+                applyColdEffect(target);
+            }
+        }
+
+        playExplosionCues(server, entity, radius, victims.size());
+        transformEnvironment(server, entity.blockPosition(), radius);
+    }
+
+    private static List<LivingEntity> gatherTargets(LivingEntity user, ServerLevel level, double radius) {
+        AABB area = user.getBoundingBox().inflate(radius);
+        return level.getEntitiesOfClass(LivingEntity.class, area, target ->
+                target != user && target.isAlive() && !target.isAlliedTo(user));
+    }
+
+    private static void playExplosionCues(ServerLevel server, LivingEntity user, double radius, int victims) {
+        RandomSource random = user.getRandom();
+        double x = user.getX();
+        double y = user.getY() + user.getBbHeight() * 0.5;
+        double z = user.getZ();
+        server.playSound(null, x, y, z, SoundEvents.GLASS_BREAK, SoundSource.PLAYERS, 1.2f, 0.6f + random.nextFloat() * 0.2f);
+        server.playSound(null, x, y, z, SoundEvents.SNOW_BREAK, SoundSource.PLAYERS, 0.8f, 0.8f + random.nextFloat() * 0.2f);
+        int particleCount = 80 + victims * 10;
+        server.sendParticles(ParticleTypes.ITEM_SNOWBALL, x, y, z, particleCount, radius * 0.25, radius * 0.25, radius * 0.25, 0.1);
+        server.sendParticles(ParticleTypes.SNOWFLAKE, x, y, z, particleCount, radius * 0.3, radius * 0.3, radius * 0.3, 0.05);
+    }
+
+    private static void transformEnvironment(ServerLevel server, BlockPos origin, double radius) {
+        int bound = Mth.ceil(radius);
+        RandomSource random = server.getRandom();
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        for (int dx = -bound; dx <= bound; dx++) {
+            for (int dy = -bound; dy <= bound; dy++) {
+                for (int dz = -bound; dz <= bound; dz++) {
+                    double distSq = dx * dx + dy * dy + dz * dz;
+                    if (distSq > radius * radius) {
+                        continue;
+                    }
+                    cursor.set(origin.getX() + dx, origin.getY() + dy, origin.getZ() + dz);
+                    BlockState state = server.getBlockState(cursor);
+                    if (state == null || state.isAir() || state.getFluidState().getType() != Fluids.EMPTY) {
+                        continue;
+                    }
+                    float destroySpeed = state.getDestroySpeed(server, cursor);
+                    if (destroySpeed < 0.0f || destroySpeed > MAX_BLOCK_HARDNESS) {
+                        continue;
+                    }
+                    Block block = state.getBlock();
+                    if (block == Blocks.BEDROCK || block == Blocks.OBSIDIAN) {
+                        continue;
+                    }
+                    if (!server.removeBlock(cursor, false)) {
+                        continue;
+                    }
+                    BlockState replacement = chooseReplacement(random);
+                    if (replacement != null) {
+                        server.setBlock(cursor, replacement, Block.UPDATE_ALL);
+                    }
+                    maybePlaceSnowLayer(server, cursor.above(), random);
+                }
+            }
+        }
+    }
+
+    private static BlockState chooseReplacement(RandomSource random) {
+        List<BlockState> options = new ArrayList<>();
+        options.add(Blocks.PACKED_ICE.defaultBlockState());
+        options.add(Blocks.SNOW_BLOCK.defaultBlockState());
+        options.add(Blocks.POWDER_SNOW.defaultBlockState());
+        return options.get(random.nextInt(options.size()));
+    }
+
+    private static void maybePlaceSnowLayer(ServerLevel server, BlockPos pos, RandomSource random) {
+        BlockState state = server.getBlockState(pos);
+        if (!state.isAir()) {
+            return;
+        }
+        BlockState layer = Blocks.SNOW.defaultBlockState();
+        IntegerProperty height = SnowLayerBlock.LAYERS;
+        int layers = Mth.clamp(1 + random.nextInt(3), 1, height.getPossibleValues().stream().max(Comparator.naturalOrder()).orElse(1));
+        server.setBlock(pos, layer.setValue(height, layers), Block.UPDATE_ALL);
+    }
+
+    private static boolean isBeimingConstitution(Player player) {
+        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+        if (handleOpt.isEmpty()) {
+            return false;
+        }
+        return handleOpt.get().hasConstitution("北冥冰魄体");
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/GuzhenrenIntegrationModule.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/GuzhenrenIntegrationModule.java
@@ -2,6 +2,7 @@ package net.tigereye.chestcavity.compat.guzhenren.module;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.compat.guzhenren.item.bing_xue_dao.BingXueDaoOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.du_dao.DuDaoOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_cai.GuCaiOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoOrganRegistry;
@@ -30,6 +31,7 @@ public final class GuzhenrenIntegrationModule {
 
     private static final List<Supplier<List<OrganIntegrationSpec>>> SPEC_SUPPLIERS = List.of(
             GuCaiOrganRegistry::specs,
+            BingXueDaoOrganRegistry::specs,
             DuDaoOrganRegistry::specs,
             GuDaoOrganRegistry::specs,
             LeiDaoOrganRegistry::specs,

--- a/src/main/java/net/tigereye/chestcavity/guzhenren/GuzhenrenModule.java
+++ b/src/main/java/net/tigereye/chestcavity/guzhenren/GuzhenrenModule.java
@@ -5,6 +5,7 @@ import net.neoforged.fml.ModList;
 import net.neoforged.fml.loading.FMLEnvironment;
 import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.guscript.ability.guzhenren.Abilities;
+import net.tigereye.chestcavity.compat.guzhenren.item.bing_xue_dao.BingXueDaoClientAbilities;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoClientAbilities;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoClientRenderLayers;
 import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoClientAbilities;
@@ -86,6 +87,7 @@ public final class GuzhenrenModule {
         if (FMLEnvironment.dist.isClient()) {
             modBus.addListener(Abilities::onClientSetup);
             modBus.addListener(GuDaoClientAbilities::onClientSetup);
+            modBus.addListener(BingXueDaoClientAbilities::onClientSetup);
             modBus.addListener(MuDaoClientAbilities::onClientSetup);
             modBus.addListener(ShiDaoClientAbilities::onClientSetup);
             modBus.addListener(JiandaoClientAbilities::onClientSetup);

--- a/src/main/java/net/tigereye/chestcavity/registration/CCItems.java
+++ b/src/main/java/net/tigereye/chestcavity/registration/CCItems.java
@@ -29,8 +29,9 @@ public class CCItems {
 	// -- 血道
 	public static final Item GUZHENREN_TIE_XUE_GU = resolveExternalItem("guzhenren", "tiexuegu");
 	public static final Item GUZHENREN_XUE_FEI_GU = resolveExternalItem("guzhenren", "xie_fei_gu");
-	public static final Item GUZHENREN_XIE_DI_GU = resolveExternalItem("guzhenren", "xie_di_gu");
-	public static final Item GUZHENREN_XIE_YAN_GU = resolveExternalItem("guzhenren", "xie_yan_gu");
+        public static final Item GUZHENREN_XIE_DI_GU = resolveExternalItem("guzhenren", "xie_di_gu");
+        public static final Item GUZHENREN_XIE_YAN_GU = resolveExternalItem("guzhenren", "xie_yan_gu");
+        public static final Item GUZHENREN_BING_JI_GU = resolveExternalItem("guzhenren", "bing_ji_gu");
 
 	// -- 水道
 	public static final Item GUZHENREN_LING_XIAN_GU = resolveExternalItem("guzhenren", "ling_xian_gu");

--- a/src/main/resources/data/chestcavity/guscript/flows/bing_xue_burst.json
+++ b/src/main/resources/data/chestcavity/guscript/flows/bing_xue_burst.json
@@ -1,0 +1,64 @@
+{
+  "initial_state": "idle",
+  "states": {
+    "idle": {
+      "transitions": [
+        { "trigger": "start", "target": "releasing" }
+      ]
+    },
+    "charging": {
+      "transitions": [
+        { "trigger": "auto", "target": "idle", "min_ticks": 1 }
+      ]
+    },
+    "charged": {
+      "transitions": [
+        { "trigger": "auto", "target": "releasing", "min_ticks": 1 }
+      ]
+    },
+    "releasing": {
+      "enter_actions": [
+        { "type": "set_variable_from_param", "param": "burst.scale", "name": "burst.scale", "default": 1.0 },
+        {
+          "type": "emit_fx",
+          "fx": "chestcavity:bing_xue_burst",
+          "base_intensity": 1.0,
+          "scale_variable": "burst.scale",
+          "default_scale": 1.0
+        },
+        {
+          "type": "replace_blocks_sphere",
+          "radius": 6.0,
+          "radius_param": "burst.radius",
+          "max_hardness": 4.0,
+          "forbidden_blocks": [
+            "minecraft:bedrock",
+            "minecraft:obsidian"
+          ],
+          "replacements": [
+            { "block": "minecraft:packed_ice", "weight": 3 },
+            { "block": "minecraft:snow_block", "weight": 2 },
+            { "block": "minecraft:powder_snow", "weight": 1 }
+          ],
+          "place_snow_layers": true,
+          "snow_layers_min": 1,
+          "snow_layers_max": 3,
+          "origin": "performer"
+        }
+      ],
+      "transitions": [
+        { "trigger": "auto", "target": "cooldown", "min_ticks": 1 }
+      ]
+    },
+    "cooldown": {
+      "transitions": [
+        { "trigger": "auto", "target": "idle", "min_ticks": 20 }
+      ]
+    },
+    "cancel": {
+      "transitions": [
+        { "trigger": "auto", "target": "cooldown", "min_ticks": 1 }
+      ]
+    }
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/fx/bing_xue_burst.json
+++ b/src/main/resources/data/chestcavity/guscript/fx/bing_xue_burst.json
@@ -1,0 +1,20 @@
+{
+  "modules": [
+    { "type": "sound", "sound": "minecraft:block.glass.break", "volume": 1.1, "pitch": 0.8 },
+    { "type": "sound", "sound": "minecraft:block.snow.break", "volume": 0.9, "pitch": 1.05 },
+    {
+      "type": "particle",
+      "particle": "minecraft:item_snowball",
+      "count": 90,
+      "speed": 0.08,
+      "spread": [0.6, 0.6, 0.6]
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:snowflake",
+      "count": 70,
+      "speed": 0.035,
+      "spread": [0.55, 0.55, 0.55]
+    }
+  ]
+}

--- a/src/main/resources/data/chestcavity/organs/guzhenren/human/bing_ji_gu.json
+++ b/src/main/resources/data/chestcavity/organs/guzhenren/human/bing_ji_gu.json
@@ -1,0 +1,7 @@
+{
+  "itemID": "guzhenren:bing_ji_gu",
+  "organScores": [
+    {"id": "chestcavity:strength", "value": "8"},
+    {"id": "chestcavity:speed", "value": "8"}
+  ]
+}


### PR DESCRIPTION
## Summary
- implement the Bing Ji Gu ice-path organ with per-tick sustain, bleed immunity when paired with Jade Bone, and an ice burst attack ability that consumes spare muscles
- register the new organ in the integration module/client ability list and add its organ score metadata
- extend the Guzhenren resource bridge to expose constitution strings so Bing Ji Gu can detect Beiming Bingpo bodies

## Testing
- ./gradlew compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68db30676ec0832680c33592686849b6