### PR TITLE
Fix salvage recipe serializer compatibility

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/recipes/SalvageRecipe.java
+++ b/src/main/java/net/tigereye/chestcavity/recipes/SalvageRecipe.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.CraftingBookCategory;
 import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.CraftingRecipe;
@@ -39,6 +39,14 @@ public class SalvageRecipe implements CraftingRecipe {
 
     public ItemStack getOutputPrototype() {
         return outputStack.copy();
+    }
+
+    public Item getOutputItem() {
+        return outputStack.getItem();
+    }
+
+    public int getOutputCount() {
+        return outputStack.getCount();
     }
 
     @Override

--- a/src/main/java/net/tigereye/chestcavity/recipes/json/SalvageRecipeSerializer.java
+++ b/src/main/java/net/tigereye/chestcavity/recipes/json/SalvageRecipeSerializer.java
@@ -3,10 +3,10 @@ package net.tigereye.chestcavity.recipes.json;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingBookCategory;
 import net.minecraft.world.item.crafting.Ingredient;
@@ -19,8 +19,11 @@ public class SalvageRecipeSerializer implements RecipeSerializer<SalvageRecipe> 
             CraftingBookCategory.CODEC.optionalFieldOf("category", CraftingBookCategory.MISC).forGetter(SalvageRecipe::category),
             Ingredient.CODEC_NONEMPTY.fieldOf("ingredient").forGetter(SalvageRecipe::getInput),
             Codec.INT.optionalFieldOf("required", 1).forGetter(SalvageRecipe::getRequired),
-            ItemStack.CODEC.fieldOf("result").forGetter(SalvageRecipe::getOutputPrototype)
-        ).apply(instance, SalvageRecipe::new)
+            BuiltInRegistries.ITEM.byNameCodec().fieldOf("result").forGetter(SalvageRecipe::getOutputItem),
+            Codec.INT.optionalFieldOf("count", 1).forGetter(SalvageRecipe::getOutputCount)
+        ).apply(instance, (category, ingredient, required, resultItem, count) ->
+            new SalvageRecipe(category, ingredient, required, new ItemStack(resultItem, count))
+        )
     );
 
     private static final StreamCodec<RegistryFriendlyByteBuf, SalvageRecipe> STREAM_CODEC = StreamCodec.composite(


### PR DESCRIPTION
## Summary
- allow salvage recipes to define results using the legacy `result` + `count` fields by decoding item IDs directly
- expose salvage recipe output item/count accessors used by the serializer to avoid extra stack copies

## Testing
- ./gradlew compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68db95f7a6148326a8fee798c8065c49