### PR TITLE
Add Jian Dao sword slash projectile and flow

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/jian_dao/JiandaoClientRenderers.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/jian_dao/JiandaoClientRenderers.java
@@ -3,6 +3,7 @@ package net.tigereye.chestcavity.compat.guzhenren.item.jian_dao;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
 import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.client.SingleSwordProjectileRenderer;
 import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.client.SwordShadowCloneRenderer;
+import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.client.SwordSlashProjectileRenderer;
 import net.tigereye.chestcavity.registration.CCEntities;
 
 /**
@@ -16,6 +17,7 @@ public final class JiandaoClientRenderers {
     public static void onRegisterRenderers(EntityRenderersEvent.RegisterRenderers event) {
         event.registerEntityRenderer(CCEntities.SINGLE_SWORD_PROJECTILE.get(), SingleSwordProjectileRenderer::new);
         event.registerEntityRenderer(CCEntities.SWORD_SHADOW_CLONE.get(), SwordShadowCloneRenderer::new);
+        event.registerEntityRenderer(CCEntities.SWORD_SLASH_PROJECTILE.get(), SwordSlashProjectileRenderer::new);
     }
 }
 

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/jian_dao/client/SwordSlashProjectileRenderer.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/jian_dao/client/SwordSlashProjectileRenderer.java
@@ -1,0 +1,31 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.client;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.InventoryMenu;
+import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.entity.SwordSlashProjectile;
+
+/**
+ * Placeholder renderer – visuals are supplied by FX modules and particles spawned client-side.
+ */
+public class SwordSlashProjectileRenderer extends EntityRenderer<SwordSlashProjectile> {
+
+    public SwordSlashProjectileRenderer(EntityRendererProvider.Context context) {
+        super(context);
+        this.shadowRadius = 0.0f;
+    }
+
+    @Override
+    public void render(SwordSlashProjectile entity, float entityYaw, float partialTicks,
+                       PoseStack poseStack, MultiBufferSource buffer, int packedLight) {
+        // No direct geometry – FX pipeline handles visuals for the sword light.
+    }
+
+    @Override
+    public ResourceLocation getTextureLocation(SwordSlashProjectile entity) {
+        return InventoryMenu.BLOCK_ATLAS;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/jian_dao/entity/SwordSlashProjectile.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/jian_dao/entity/SwordSlashProjectile.java
@@ -1,0 +1,452 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.entity;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.Mth;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityDimensions;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Pose;
+import net.minecraft.world.entity.projectile.Projectile;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.GameRules;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.config.CCConfig;
+import net.tigereye.chestcavity.guscript.runtime.exec.ProjectileEmission;
+import net.tigereye.chestcavity.registration.CCTags;
+
+import java.util.Objects;
+
+/**
+ * Data-driven Jian Dao sword slash projectile. Handles sweeping melee damage and fragile block
+ * destruction on the server; visuals come from GuScript FX definitions.
+ */
+public class SwordSlashProjectile extends Projectile {
+
+    private static final EntityDataAccessor<Float> DATA_LENGTH =
+            SynchedEntityData.defineId(SwordSlashProjectile.class, EntityDataSerializers.FLOAT);
+    private static final EntityDataAccessor<Float> DATA_THICKNESS =
+            SynchedEntityData.defineId(SwordSlashProjectile.class, EntityDataSerializers.FLOAT);
+    private static final EntityDataAccessor<Integer> DATA_LIFESPAN =
+            SynchedEntityData.defineId(SwordSlashProjectile.class, EntityDataSerializers.INT);
+    private static final EntityDataAccessor<Float> DATA_DAMAGE =
+            SynchedEntityData.defineId(SwordSlashProjectile.class, EntityDataSerializers.FLOAT);
+    private static final EntityDataAccessor<Integer> DATA_MAX_PIERCE =
+            SynchedEntityData.defineId(SwordSlashProjectile.class, EntityDataSerializers.INT);
+    private static final EntityDataAccessor<Float> DATA_BREAK_POWER =
+            SynchedEntityData.defineId(SwordSlashProjectile.class, EntityDataSerializers.FLOAT);
+
+    private static final int FALLBACK_LIFESPAN_TICKS = 16;
+    private static final double FALLBACK_LENGTH = 6.5D;
+    private static final double FALLBACK_THICKNESS = 1.1D;
+    private static final double FALLBACK_DAMAGE = 10.0D;
+    private static final int FALLBACK_MAX_PIERCE = 4;
+    private static final double FALLBACK_BREAK_POWER = 2.5D;
+    private static final int FALLBACK_BLOCKS_PER_TICK = 8;
+
+    private final IntSet hitEntityIds = new IntOpenHashSet();
+    private int ticksExisted;
+    private int pierceCount;
+
+    public SwordSlashProjectile(EntityType<? extends SwordSlashProjectile> type, Level level) {
+        super(type, level);
+        this.setNoGravity(true);
+        this.noPhysics = true;
+    }
+
+    @Override
+    protected void defineSynchedData(SynchedEntityData.Builder builder) {
+        builder.define(DATA_LENGTH, (float) defaultLength());
+        builder.define(DATA_THICKNESS, (float) defaultThickness());
+        builder.define(DATA_LIFESPAN, defaultLifespanTicks());
+        builder.define(DATA_DAMAGE, (float) defaultDamage());
+        builder.define(DATA_MAX_PIERCE, defaultMaxPierce());
+        builder.define(DATA_BREAK_POWER, (float) defaultBreakPower());
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+        Vec3 direction = forwardDirection();
+        Vec3 current = this.position();
+        updateRotation(direction);
+
+        if (this.level().isClientSide) {
+            spawnClientParticles(direction);
+            return;
+        }
+
+        sweepForEntities(current, direction);
+        breakBlocks(current, direction);
+
+        this.ticksExisted++;
+        if (this.ticksExisted >= getLifespanTicks()) {
+            this.discard();
+        }
+    }
+
+    @Override
+    protected void onHit(net.minecraft.world.phys.HitResult result) {
+        // Ignore vanilla collision handling; sweeping logic governs lifetime and contact.
+    }
+
+    public void configureFromEmission(ProjectileEmission emission) {
+        Objects.requireNonNull(emission, "emission");
+        setBaseDamage(emission.damage());
+        if (emission.length() != null) {
+            setLength(Math.max(0.5D, emission.length()));
+        }
+        if (emission.thickness() != null) {
+            setThickness(Math.max(0.25D, emission.thickness()));
+        }
+        if (emission.lifespanTicks() != null) {
+            setLifespan(Math.max(1, emission.lifespanTicks()));
+        }
+        if (emission.maxPierce() != null) {
+            setMaxPierce(Math.max(0, emission.maxPierce()));
+        }
+        if (emission.breakPower() != null) {
+            setBreakPower(Math.max(0.0D, emission.breakPower()));
+        }
+    }
+
+    public double getLength() {
+        return Math.max(0.25D, this.entityData.get(DATA_LENGTH));
+    }
+
+    public void setLength(double length) {
+        this.entityData.set(DATA_LENGTH, (float) length);
+    }
+
+    public double getThickness() {
+        return Math.max(0.1D, this.entityData.get(DATA_THICKNESS));
+    }
+
+    public void setThickness(double thickness) {
+        this.entityData.set(DATA_THICKNESS, (float) thickness);
+        this.refreshDimensions();
+    }
+
+    public int getLifespanTicks() {
+        return Math.max(1, this.entityData.get(DATA_LIFESPAN));
+    }
+
+    public void setLifespan(int lifespan) {
+        this.entityData.set(DATA_LIFESPAN, Math.max(1, lifespan));
+    }
+
+    public double getBaseDamage() {
+        return Math.max(0.0D, this.entityData.get(DATA_DAMAGE));
+    }
+
+    public void setBaseDamage(double damage) {
+        this.entityData.set(DATA_DAMAGE, (float) Math.max(0.0D, damage));
+    }
+
+    public int getMaxPierce() {
+        return Math.max(0, this.entityData.get(DATA_MAX_PIERCE));
+    }
+
+    public void setMaxPierce(int maxPierce) {
+        this.entityData.set(DATA_MAX_PIERCE, Math.max(0, maxPierce));
+    }
+
+    public double getBreakPower() {
+        return Math.max(0.0D, this.entityData.get(DATA_BREAK_POWER));
+    }
+
+    public void setBreakPower(double breakPower) {
+        this.entityData.set(DATA_BREAK_POWER, (float) Math.max(0.0D, breakPower));
+    }
+
+    @Override
+    public EntityDimensions getDimensions(Pose pose) {
+        float diameter = (float) Math.max(0.2D, getThickness());
+        return EntityDimensions.scalable(diameter, diameter);
+    }
+
+    private void sweepForEntities(Vec3 head, Vec3 direction) {
+        if (direction.lengthSqr() < 1.0E-6) {
+            return;
+        }
+        double length = getLength();
+        double thickness = getThickness();
+        Vec3 tail = head.subtract(direction.scale(length));
+        AABB sweepBounds = new AABB(head, tail).inflate(thickness, thickness * 0.8D, thickness);
+
+        Entity owner = this.getOwner();
+        for (Entity entity : this.level().getEntities(this, sweepBounds, e -> e.isAlive() && e != this)) {
+            if (entity == owner) {
+                continue;
+            }
+            if (!(entity instanceof LivingEntity living)) {
+                continue;
+            }
+            if (hitEntityIds.contains(entity.getId())) {
+                continue;
+            }
+            if (!isWithinSlash(living, head, tail, direction, thickness)) {
+                continue;
+            }
+            DamageSource source = resolveDamageSource(living);
+            boolean damaged = living.hurt(source, (float) getBaseDamage());
+            if (damaged) {
+                living.push(direction.x * 0.45D, Math.max(0.1D, direction.y * 0.2D), direction.z * 0.45D);
+                hitEntityIds.add(entity.getId());
+                pierceCount++;
+                int maxPierce = getMaxPierce();
+                if (maxPierce > 0 && pierceCount >= maxPierce) {
+                    this.discard();
+                    return;
+                }
+            }
+        }
+    }
+
+    private boolean isWithinSlash(LivingEntity entity, Vec3 head, Vec3 tail, Vec3 direction, double thickness) {
+        Vec3 center = entity.position().add(0.0D, entity.getBbHeight() * 0.5D, 0.0D);
+        Vec3 closest = closestPointOnSegment(center, tail, head);
+        double distanceSq = closest.distanceToSqr(center);
+        double limit = thickness * thickness;
+        return distanceSq <= limit + 1.0E-4;
+    }
+
+    private Vec3 closestPointOnSegment(Vec3 point, Vec3 start, Vec3 end) {
+        Vec3 delta = end.subtract(start);
+        double lengthSq = delta.lengthSqr();
+        if (lengthSq < 1.0E-6) {
+            return start;
+        }
+        double t = (point.subtract(start)).dot(delta) / lengthSq;
+        t = Mth.clamp(t, 0.0D, 1.0D);
+        return start.add(delta.scale(t));
+    }
+
+    private DamageSource resolveDamageSource(LivingEntity target) {
+        Entity owner = this.getOwner();
+        if (owner instanceof Player player) {
+            return target.damageSources().playerAttack(player);
+        }
+        if (owner instanceof LivingEntity living) {
+            return target.damageSources().mobAttack(living);
+        }
+        return target.damageSources().magic();
+    }
+
+    private void breakBlocks(Vec3 head, Vec3 direction) {
+        if (!(this.level() instanceof ServerLevel server)) {
+            return;
+        }
+        if (!shouldBreakBlocks(server)) {
+            return;
+        }
+        double breakPower = getBreakPower();
+        if (breakPower <= 0.0D) {
+            return;
+        }
+        double thickness = getThickness();
+        Vec3 tail = head.subtract(direction.scale(getLength()));
+        AABB sweep = new AABB(head, tail).inflate(thickness);
+        int minX = Mth.floor(sweep.minX);
+        int minY = Mth.floor(sweep.minY);
+        int minZ = Mth.floor(sweep.minZ);
+        int maxX = Mth.floor(sweep.maxX);
+        int maxY = Mth.floor(sweep.maxY);
+        int maxZ = Mth.floor(sweep.maxZ);
+
+        int broken = 0;
+        int blockLimit = blockBreakLimit();
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        for (int x = minX; x <= maxX; x++) {
+            for (int y = minY; y <= maxY; y++) {
+                for (int z = minZ; z <= maxZ; z++) {
+                    if (broken >= blockLimit) {
+                        return;
+                    }
+                    cursor.set(x, y, z);
+                    if (!server.isLoaded(cursor)) {
+                        continue;
+                    }
+                    BlockState state = server.getBlockState(cursor);
+                    if (state.isAir() || !state.is(CCTags.SWORD_SLASH_BREAKABLE)) {
+                        continue;
+                    }
+                    float hardness = state.getDestroySpeed(server, cursor);
+                    if (hardness < 0.0F || hardness > breakPower) {
+                        continue;
+                    }
+                    Vec3 blockCenter = Vec3.atCenterOf(cursor);
+                    if (closestPointOnSegment(blockCenter, tail, head).distanceToSqr(blockCenter) > thickness * thickness + 1.0E-4) {
+                        continue;
+                    }
+                    if (server.destroyBlock(cursor, true)) {
+                        broken++;
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean shouldBreakBlocks(ServerLevel server) {
+        CCConfig.GuScriptExecutionConfig.SwordSlashConfig config = swordSlashConfig();
+        if (config != null && !config.enableBlockBreaking) {
+            return false;
+        }
+        if (!server.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
+            Entity owner = this.getOwner();
+            if (!(owner instanceof Player)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void spawnClientParticles(Vec3 direction) {
+        if (direction.lengthSqr() < 1.0E-6) {
+            return;
+        }
+        Level level = this.level();
+        double length = getLength();
+        int segments = Math.max(3, Mth.ceil(length));
+        for (int i = 0; i < segments; i++) {
+            double t = i / (double) segments;
+            Vec3 point = this.position().subtract(direction.scale(t * length));
+            level.addParticle(ParticleTypes.SWEEP_ATTACK, point.x, point.y + 0.1D, point.z, 0.0D, 0.0D, 0.0D);
+        }
+    }
+
+    private Vec3 forwardDirection() {
+        Vec3 movement = this.getDeltaMovement();
+        if (movement.lengthSqr() > 1.0E-6) {
+            return movement.normalize();
+        }
+        Vec3 look = Vec3.directionFromRotation(this.getXRot(), this.getYRot());
+        if (look.lengthSqr() > 1.0E-6) {
+            return look.normalize();
+        }
+        return new Vec3(0.0D, 0.0D, 1.0D);
+    }
+
+    private void updateRotation(Vec3 direction) {
+        if (direction.lengthSqr() < 1.0E-6) {
+            return;
+        }
+        double horizontal = Math.sqrt(direction.x * direction.x + direction.z * direction.z);
+        this.setYRot((float) (Math.atan2(direction.x, direction.z) * (180.0F / Math.PI)));
+        this.setXRot((float) (Math.atan2(direction.y, horizontal) * (180.0F / Math.PI)));
+    }
+
+    @Override
+    protected void addAdditionalSaveData(CompoundTag tag) {
+        super.addAdditionalSaveData(tag);
+        tag.putFloat("Length", (float) getLength());
+        tag.putFloat("Thickness", (float) getThickness());
+        tag.putInt("Lifespan", getLifespanTicks());
+        tag.putDouble("Damage", getBaseDamage());
+        tag.putInt("MaxPierce", getMaxPierce());
+        tag.putDouble("BreakPower", getBreakPower());
+        tag.putInt("PierceCount", pierceCount);
+        tag.putInt("TicksExisted", ticksExisted);
+    }
+
+    @Override
+    protected void readAdditionalSaveData(CompoundTag tag) {
+        super.readAdditionalSaveData(tag);
+        if (tag.contains("Length")) {
+            setLength(tag.getFloat("Length"));
+        }
+        if (tag.contains("Thickness")) {
+            setThickness(tag.getFloat("Thickness"));
+        }
+        if (tag.contains("Lifespan")) {
+            setLifespan(tag.getInt("Lifespan"));
+        }
+        if (tag.contains("Damage")) {
+            setBaseDamage(tag.getDouble("Damage"));
+        }
+        if (tag.contains("MaxPierce")) {
+            setMaxPierce(tag.getInt("MaxPierce"));
+        }
+        if (tag.contains("BreakPower")) {
+            setBreakPower(tag.getDouble("BreakPower"));
+        }
+        this.pierceCount = tag.getInt("PierceCount");
+        this.ticksExisted = tag.getInt("TicksExisted");
+    }
+
+    private static CCConfig.GuScriptExecutionConfig.SwordSlashConfig swordSlashConfig() {
+        if (ChestCavity.config == null || ChestCavity.config.GUSCRIPT_EXECUTION == null) {
+            return null;
+        }
+        return ChestCavity.config.GUSCRIPT_EXECUTION.swordSlash;
+    }
+
+    private static double defaultLength() {
+        CCConfig.GuScriptExecutionConfig.SwordSlashConfig config = swordSlashConfig();
+        if (config != null && config.defaultLength > 0.0D) {
+            return config.defaultLength;
+        }
+        return FALLBACK_LENGTH;
+    }
+
+    private static double defaultThickness() {
+        CCConfig.GuScriptExecutionConfig.SwordSlashConfig config = swordSlashConfig();
+        if (config != null && config.defaultThickness > 0.0D) {
+            return config.defaultThickness;
+        }
+        return FALLBACK_THICKNESS;
+    }
+
+    private static int defaultLifespanTicks() {
+        CCConfig.GuScriptExecutionConfig.SwordSlashConfig config = swordSlashConfig();
+        if (config != null && config.defaultLifespanTicks > 0) {
+            return config.defaultLifespanTicks;
+        }
+        return FALLBACK_LIFESPAN_TICKS;
+    }
+
+    private static double defaultDamage() {
+        CCConfig.GuScriptExecutionConfig.SwordSlashConfig config = swordSlashConfig();
+        if (config != null && config.defaultDamage > 0.0D) {
+            return config.defaultDamage;
+        }
+        return FALLBACK_DAMAGE;
+    }
+
+    private static int defaultMaxPierce() {
+        CCConfig.GuScriptExecutionConfig.SwordSlashConfig config = swordSlashConfig();
+        if (config != null && config.defaultMaxPierce >= 0) {
+            return config.defaultMaxPierce;
+        }
+        return FALLBACK_MAX_PIERCE;
+    }
+
+    private static double defaultBreakPower() {
+        CCConfig.GuScriptExecutionConfig.SwordSlashConfig config = swordSlashConfig();
+        if (config != null && config.defaultBreakPower >= 0.0D) {
+            return config.defaultBreakPower;
+        }
+        return FALLBACK_BREAK_POWER;
+    }
+
+    private static int blockBreakLimit() {
+        CCConfig.GuScriptExecutionConfig.SwordSlashConfig config = swordSlashConfig();
+        if (config != null && config.maxBlocksBrokenPerTick > 0) {
+            return config.maxBlocksBrokenPerTick;
+        }
+        return FALLBACK_BLOCKS_PER_TICK;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
+++ b/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
@@ -188,6 +188,27 @@ public class CCConfig implements ConfigData {
         public TimeScaleCombineStrategy timeScaleCombine = TimeScaleCombineStrategy.MULTIPLY;
         @ConfigEntry.Gui.Tooltip
         public boolean preferUiOrder = true; // prioritize page/slot ordering over compilation order when available
+        @ConfigEntry.Gui.CollapsibleObject
+        public SwordSlashConfig swordSlash = new SwordSlashConfig();
+
+        public static class SwordSlashConfig {
+            @ConfigEntry.Gui.Tooltip
+            public double defaultLength = 6.5D;
+            @ConfigEntry.Gui.Tooltip
+            public double defaultThickness = 1.1D;
+            @ConfigEntry.Gui.Tooltip
+            public int defaultLifespanTicks = 16;
+            @ConfigEntry.Gui.Tooltip
+            public double defaultDamage = 10.0D;
+            @ConfigEntry.Gui.Tooltip
+            public int defaultMaxPierce = 4;
+            @ConfigEntry.Gui.Tooltip
+            public double defaultBreakPower = 2.5D;
+            @ConfigEntry.Gui.Tooltip
+            public int maxBlocksBrokenPerTick = 8;
+            @ConfigEntry.Gui.Tooltip
+            public boolean enableBlockBreaking = true;
+        }
     }
 
     public enum TimeScaleCombineStrategy {

--- a/src/main/java/net/tigereye/chestcavity/guscript/actions/EmitProjectileAction.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/actions/EmitProjectileAction.java
@@ -1,9 +1,26 @@
 package net.tigereye.chestcavity.guscript.actions;
 
+import javax.annotation.Nullable;
+
 import net.tigereye.chestcavity.guscript.ast.Action;
 import net.tigereye.chestcavity.guscript.runtime.exec.GuScriptContext;
+import net.tigereye.chestcavity.guscript.runtime.exec.FlowVariableProvider;
+import net.tigereye.chestcavity.guscript.runtime.exec.ProjectileEmission;
 
-public record EmitProjectileAction(String projectileId, double damage) implements Action {
+public record EmitProjectileAction(
+        String projectileId,
+        double damage,
+        @Nullable Double length,
+        @Nullable Double thickness,
+        @Nullable Integer lifespanTicks,
+        @Nullable Integer maxPierce,
+        @Nullable Double breakPower,
+        @Nullable String lengthVariable,
+        @Nullable String thicknessVariable,
+        @Nullable String lifespanVariable,
+        @Nullable String maxPierceVariable,
+        @Nullable String breakPowerVariable
+) implements Action {
     public static final String ID = "emit.projectile";
 
     @Override
@@ -19,6 +36,38 @@ public record EmitProjectileAction(String projectileId, double damage) implement
     @Override
     public void execute(GuScriptContext context) {
         double finalDamage = context.applyDamageModifiers(damage);
-        context.bridge().emitProjectile(projectileId, finalDamage);
+        Double resolvedLength = resolveDouble(length, lengthVariable, context);
+        Double resolvedThickness = resolveDouble(thickness, thicknessVariable, context);
+        Integer resolvedLifespan = resolveInteger(lifespanTicks, lifespanVariable, context);
+        Integer resolvedMaxPierce = resolveInteger(maxPierce, maxPierceVariable, context);
+        Double resolvedBreakPower = resolveDouble(breakPower, breakPowerVariable, context);
+        ProjectileEmission emission = new ProjectileEmission(
+                projectileId,
+                finalDamage,
+                resolvedLength,
+                resolvedThickness,
+                resolvedLifespan,
+                resolvedMaxPierce,
+                resolvedBreakPower
+        );
+        context.bridge().emitProjectile(emission);
+    }
+
+    private static Double resolveDouble(@Nullable Double base, @Nullable String variable, GuScriptContext context) {
+        Double result = base;
+        if (variable != null && context instanceof FlowVariableProvider provider) {
+            double fallback = result != null ? result : 0.0D;
+            result = provider.resolveFlowVariable(variable, fallback);
+        }
+        return result;
+    }
+
+    private static Integer resolveInteger(@Nullable Integer base, @Nullable String variable, GuScriptContext context) {
+        Integer result = base;
+        if (variable != null && context instanceof FlowVariableProvider provider) {
+            long fallback = result != null ? result : 0L;
+            result = (int) provider.resolveFlowVariableAsLong(variable, fallback);
+        }
+        return result;
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/command/GuScriptCommands.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/command/GuScriptCommands.java
@@ -204,7 +204,8 @@ public final class GuScriptCommands {
 
         GuNode bone = new LeafGuNode("骨蛊", ImmutableMultiset.of("骨"), List.of(new ConsumeHealthAction(2)));
         GuNode blood = new LeafGuNode("血蛊", ImmutableMultiset.of("血"), List.of(new ConsumeZhenyuanAction(5)));
-        GuNode burst = new LeafGuNode("爆发蛊", ImmutableMultiset.of("爆发"), List.of(new EmitProjectileAction("minecraft:arrow", 4.0)));
+        GuNode burst = new LeafGuNode("爆发蛊", ImmutableMultiset.of("爆发"),
+                List.of(new EmitProjectileAction("minecraft:arrow", 4.0, null, null, null, null, null, null, null, null, null, null)));
 
         ReactionRule bloodBoneCore = ReactionRule.builder("blood_bone_core")
                 .arity(2)

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/action/ActionRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/action/ActionRegistry.java
@@ -41,7 +41,17 @@ public final class ActionRegistry {
         register(ConsumeHealthAction.ID, json -> new ConsumeHealthAction(json.get("amount").getAsInt()));
         register(EmitProjectileAction.ID, json -> new EmitProjectileAction(
                 json.get("projectileId").getAsString(),
-                json.get("damage").getAsDouble()
+                json.get("damage").getAsDouble(),
+                json.has("length") ? json.get("length").getAsDouble() : null,
+                json.has("thickness") ? json.get("thickness").getAsDouble() : null,
+                json.has("lifespan") ? json.get("lifespan").getAsInt() : null,
+                json.has("maxPierce") ? json.get("maxPierce").getAsInt() : null,
+                json.has("breakPower") ? json.get("breakPower").getAsDouble() : null,
+                json.has("lengthVariable") ? json.get("lengthVariable").getAsString() : null,
+                json.has("thicknessVariable") ? json.get("thicknessVariable").getAsString() : null,
+                json.has("lifespanVariable") ? json.get("lifespanVariable").getAsString() : null,
+                json.has("maxPierceVariable") ? json.get("maxPierceVariable").getAsString() : null,
+                json.has("breakPowerVariable") ? json.get("breakPowerVariable").getAsString() : null
         ));
         register(AddDamageMultiplierAction.ID, json -> new AddDamageMultiplierAction(json.get("amount").getAsDouble()));
         register(AddFlatDamageAction.ID, json -> new AddFlatDamageAction(json.get("amount").getAsDouble()));

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/DefaultGuScriptContext.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/DefaultGuScriptContext.java
@@ -6,12 +6,15 @@ import net.minecraft.world.entity.player.Player;
 /**
  * Mutable runtime context capturing performer, target, and runtime modifiers.
  */
-public final class DefaultGuScriptContext implements GuScriptContext {
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowController;
+
+public final class DefaultGuScriptContext implements GuScriptContext, FlowVariableProvider {
 
     private final Player performer;
     private final LivingEntity target;
     private final GuScriptExecutionBridge bridge;
     private final ExecutionSession session;
+    private final FlowController flowController;
     private double damageMultiplier;
     private double flatDamageBonus;
     private double addedMultiplier;
@@ -25,10 +28,15 @@ public final class DefaultGuScriptContext implements GuScriptContext {
     private boolean exportFlatDelta;
 
     public DefaultGuScriptContext(Player performer, LivingEntity target, GuScriptExecutionBridge bridge) {
-        this(performer, target, bridge, null);
+        this(performer, target, bridge, null, null);
     }
 
     public DefaultGuScriptContext(Player performer, LivingEntity target, GuScriptExecutionBridge bridge, ExecutionSession session) {
+        this(performer, target, bridge, session, null);
+    }
+
+    public DefaultGuScriptContext(Player performer, LivingEntity target, GuScriptExecutionBridge bridge,
+                                  ExecutionSession session, FlowController flowController) {
         if (bridge == null) {
             throw new IllegalArgumentException("GuScriptExecutionBridge must not be null");
         }
@@ -36,6 +44,7 @@ public final class DefaultGuScriptContext implements GuScriptContext {
         this.target = target;
         this.bridge = bridge;
         this.session = session;
+        this.flowController = flowController;
         if (session != null) {
             this.damageMultiplier = session.currentMultiplier();
             this.flatDamageBonus = session.currentFlat();
@@ -158,5 +167,21 @@ public final class DefaultGuScriptContext implements GuScriptContext {
     @Override
     public double directExportedTimeScaleFlat() {
         return directTimeScaleFlat;
+    }
+
+    @Override
+    public double resolveFlowVariable(String name, double defaultValue) {
+        if (flowController == null || name == null) {
+            return defaultValue;
+        }
+        return flowController.getDouble(name, defaultValue);
+    }
+
+    @Override
+    public long resolveFlowVariableAsLong(String name, long defaultValue) {
+        if (flowController == null || name == null) {
+            return defaultValue;
+        }
+        return flowController.getLong(name, defaultValue);
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/FlowVariableProvider.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/FlowVariableProvider.java
@@ -1,0 +1,11 @@
+package net.tigereye.chestcavity.guscript.runtime.exec;
+
+/**
+ * Optional capability for GuScript contexts to expose live flow variables to actions.
+ */
+public interface FlowVariableProvider {
+
+    double resolveFlowVariable(String name, double defaultValue);
+
+    long resolveFlowVariableAsLong(String name, long defaultValue);
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutionBridge.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutionBridge.java
@@ -14,7 +14,7 @@ public interface GuScriptExecutionBridge {
 
     void consumeHealth(int amount);
 
-    void emitProjectile(String projectileId, double damage);
+    void emitProjectile(ProjectileEmission emission);
 
     void playFx(ResourceLocation fxId, FxEventParameters parameters);
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/ProjectileEmission.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/ProjectileEmission.java
@@ -1,0 +1,27 @@
+package net.tigereye.chestcavity.guscript.runtime.exec;
+
+import javax.annotation.Nullable;
+
+/**
+ * Immutable description of a projectile spawn request produced by GuScript actions.
+ */
+public record ProjectileEmission(
+        String projectileId,
+        double damage,
+        @Nullable Double length,
+        @Nullable Double thickness,
+        @Nullable Integer lifespanTicks,
+        @Nullable Integer maxPierce,
+        @Nullable Double breakPower
+) {
+
+    public ProjectileEmission {
+        if (projectileId == null || projectileId.isBlank()) {
+            throw new IllegalArgumentException("projectileId must be provided");
+        }
+    }
+
+    public static ProjectileEmission of(String projectileId, double damage) {
+        return new ProjectileEmission(projectileId, damage, null, null, null, null, null);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/FlowActions.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/FlowActions.java
@@ -260,7 +260,7 @@ public final class FlowActions {
                     return;
                 }
                 DefaultGuScriptExecutionBridge bridge = new DefaultGuScriptExecutionBridge(performer, target);
-                DefaultGuScriptContext context = new DefaultGuScriptContext(performer, target, bridge);
+                DefaultGuScriptContext context = new DefaultGuScriptContext(performer, target, bridge, null, controller);
                 for (Action action : immutable) {
                     try {
                         action.execute(context);

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/reduce/GuScriptReducerDebug.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/reduce/GuScriptReducerDebug.java
@@ -26,7 +26,8 @@ public final class GuScriptReducerDebug {
     public static void logDemo() {
         GuNode bone = new LeafGuNode("骨蛊", ImmutableMultiset.of("骨"), List.of(new ConsumeHealthAction(2)));
         GuNode blood = new LeafGuNode("血蛊", ImmutableMultiset.of("血"), List.of(new ConsumeZhenyuanAction(3)));
-        GuNode burst = new LeafGuNode("爆发蛊", ImmutableMultiset.of("爆发"), List.of(new EmitProjectileAction("explosion_shard", 6.0)));
+        GuNode burst = new LeafGuNode("爆发蛊", ImmutableMultiset.of("爆发"),
+                List.of(new EmitProjectileAction("explosion_shard", 6.0, null, null, null, null, null, null, null, null, null, null)));
 
         ReactionRule bloodBoneCore = ReactionRule.builder("blood_bone_core")
                 .arity(2)
@@ -42,7 +43,7 @@ public final class GuScriptReducerDebug {
                 .priority(5)
                 .operator((ruleId, inputs) -> new OperatorGuNode(ruleId, "血骨爆裂枪", GuNodeKind.COMPOSITE,
                         unionTags(inputs, "杀招"),
-                        List.of(new EmitProjectileAction("blood_burst", 12.0)), inputs))
+                        List.of(new EmitProjectileAction("blood_burst", 12.0, null, null, null, null, null, null, null, null, null, null)), inputs))
                 .build();
 
         GuScriptReducer reducer = new GuScriptReducer();

--- a/src/main/java/net/tigereye/chestcavity/registration/CCEntities.java
+++ b/src/main/java/net/tigereye/chestcavity/registration/CCEntities.java
@@ -10,6 +10,7 @@ import net.tigereye.chestcavity.guscript.ability.guzhenren.blood_bone_bomb.BoneG
 
 import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.entity.SingleSwordProjectile;
 import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.entity.SwordShadowClone;
+import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.entity.SwordSlashProjectile;
 
 
 /**
@@ -46,5 +47,13 @@ public final class CCEntities {
                     .clientTrackingRange(48)
                     .updateInterval(2)
                     .build(ChestCavity.MODID + ":sword_shadow_clone"));
+
+    public static final DeferredHolder<EntityType<?>, EntityType<SwordSlashProjectile>> SWORD_SLASH_PROJECTILE =
+            ENTITY_TYPES.register("sword_slash", () -> EntityType.Builder
+                    .<SwordSlashProjectile>of(SwordSlashProjectile::new, MobCategory.MISC)
+                    .sized(1.0f, 1.0f)
+                    .clientTrackingRange(96)
+                    .updateInterval(1)
+                    .build(ChestCavity.MODID + ":sword_slash"));
 
 }

--- a/src/main/java/net/tigereye/chestcavity/registration/CCTags.java
+++ b/src/main/java/net/tigereye/chestcavity/registration/CCTags.java
@@ -3,6 +3,7 @@ package net.tigereye.chestcavity.registration;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
 import net.tigereye.chestcavity.ChestCavity;
 
 public class CCTags {
@@ -11,6 +12,7 @@ public class CCTags {
     public static final TagKey<Item> CARNIVORE_FOOD = TagKey.create(Registries.ITEM, ChestCavity.id("carnivore_food"));
     public static final TagKey<Item> SALVAGEABLE = TagKey.create(Registries.ITEM, ChestCavity.id("salvageable"));
     public static final TagKey<Item> IRON_REPAIR_MATERIAL = TagKey.create(Registries.ITEM, ChestCavity.id("iron_repair_material"));
+    public static final TagKey<Block> SWORD_SLASH_BREAKABLE = TagKey.create(Registries.BLOCK, ChestCavity.id("breakable_by_sword_slash"));
 
     //public static final Tag<Item> BUTCHERING_TOOL = TagRegistry.item(new ResourceLocation(ChestCavity.MODID,"butchering_tool"));
     //public static final Tag<Item> ROTTEN_FOOD = TagRegistry.item(new ResourceLocation(ChestCavity.MODID,"rotten_food"));

--- a/src/main/resources/assets/chestcavity/guscript/fx/sword_slash_impact.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/sword_slash_impact.json
@@ -1,0 +1,31 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:block.glass.break",
+      "volume": 0.65,
+      "pitch": 1.3
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:cloud",
+      "count": 8,
+      "speed": 0.15,
+      "spread": [0.25, 0.15, 0.25],
+      "offset": [0.0, 0.6, 0.0]
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:crit",
+      "count": 10,
+      "speed": 0.25,
+      "spread": [0.2, 0.2, 0.2],
+      "offset": [0.0, 0.7, 0.0]
+    },
+    {
+      "type": "screen_shake",
+      "intensity": 0.1,
+      "duration": 5
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/sword_slash_spawn.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/sword_slash_spawn.json
@@ -1,0 +1,33 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:entity.player.attack.sweep",
+      "volume": 0.9,
+      "pitch": 1.1
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:crit",
+      "count": 16,
+      "speed": 0.2,
+      "spread": [0.3, 0.15, 0.3],
+      "offset": [0.0, 0.7, 0.0]
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:dust",
+      "color": "#8fd3ff",
+      "size": 1.1,
+      "count": 8,
+      "speed": 0.05,
+      "spread": [0.2, 0.2, 0.2],
+      "offset": [0.0, 0.85, 0.0]
+    },
+    {
+      "type": "screen_shake",
+      "intensity": 0.12,
+      "duration": 4
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/sword_slash_trail.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/sword_slash_trail.json
@@ -1,0 +1,22 @@
+{
+  "modules": [
+    {
+      "type": "trail",
+      "particle": "minecraft:dust",
+      "color": "#5fc4ff",
+      "size": 0.8,
+      "segments": 10,
+      "spacing": 0.35,
+      "spread": [0.08, 0.08, 0.08],
+      "offset": [0.0, 0.6, 0.0]
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:sweep_attack",
+      "count": 2,
+      "speed": 0.0,
+      "spread": [0.12, 0.12, 0.12],
+      "offset": [0.0, 0.6, 0.0]
+    }
+  ]
+}

--- a/src/main/resources/data/chestcavity/guscript/flows/sword_slash.json
+++ b/src/main/resources/data/chestcavity/guscript/flows/sword_slash.json
@@ -1,0 +1,89 @@
+{
+  "initial_state": "idle",
+  "states": {
+    "idle": {
+      "transitions": [
+        {
+          "trigger": "start",
+          "target": "windup",
+          "guards": [
+            { "type": "cooldown", "key": "chestcavity:sword_slash" }
+          ],
+          "actions": [
+            { "type": "set_cooldown", "key": "chestcavity:sword_slash", "ticks": 40 }
+          ]
+        }
+      ]
+    },
+    "windup": {
+      "enter_fx": [ "chestcavity:sword_slash_spawn" ],
+      "enter_actions": [
+        { "type": "set_variable_from_param", "param": "slash.length", "name": "slash.length", "default": 6.5 },
+        { "type": "set_variable_from_param", "param": "slash.thickness", "name": "slash.thickness", "default": 1.1 },
+        { "type": "set_variable_from_param", "param": "slash.lifespan", "name": "slash.lifespan", "default": 16.0 },
+        { "type": "set_variable_from_param", "param": "slash.maxPierce", "name": "slash.maxPierce", "default": 4.0 },
+        { "type": "set_variable_from_param", "param": "slash.breakPower", "name": "slash.breakPower", "default": 2.5 }
+      ],
+      "transitions": [
+        { "trigger": "auto", "target": "releasing", "min_ticks": 10 },
+        { "trigger": "cancel", "target": "cancel" }
+      ]
+    },
+    "releasing": {
+      "enter_actions": [
+        {
+          "id": "emit.projectile",
+          "projectileId": "chestcavity:sword_slash",
+          "damage": 10.0,
+          "length": 6.5,
+          "thickness": 1.1,
+          "lifespan": 16,
+          "maxPierce": 4,
+          "breakPower": 2.5,
+          "lengthVariable": "slash.length",
+          "thicknessVariable": "slash.thickness",
+          "lifespanVariable": "slash.lifespan",
+          "maxPierceVariable": "slash.maxPierce",
+          "breakPowerVariable": "slash.breakPower"
+        },
+        {
+          "type": "trigger_actions",
+          "actions": [
+            { "id": "emit.fx", "fxId": "chestcavity:sword_slash_trail", "intensity": 1.0 }
+          ]
+        }
+      ],
+      "update_period": 4,
+      "update_actions": [
+        {
+          "type": "trigger_actions",
+          "actions": [
+            { "id": "emit.fx", "fxId": "chestcavity:sword_slash_trail", "intensity": 1.0 }
+          ]
+        }
+      ],
+      "transitions": [
+        { "trigger": "auto", "target": "cooldown", "min_ticks": 8 }
+      ]
+    },
+    "cooldown": {
+      "enter_fx": [ "chestcavity:sword_slash_impact" ],
+      "transitions": [
+        { "trigger": "auto", "target": "idle", "min_ticks": 20 }
+      ]
+    },
+    "cancel": {
+      "enter_actions": [
+        {
+          "type": "trigger_actions",
+          "actions": [
+            { "id": "emit.fx", "fxId": "chestcavity:sword_slash_impact", "intensity": 0.8 }
+          ]
+        }
+      ],
+      "transitions": [
+        { "trigger": "auto", "target": "cooldown", "min_ticks": 5 }
+      ]
+    }
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/leaves/guzhenren/jian_dao/jian_ying_gu.json
+++ b/src/main/resources/data/chestcavity/guscript/leaves/guzhenren/jian_dao/jian_ying_gu.json
@@ -1,0 +1,5 @@
+{
+  "item": "guzhenren:jian_ying_gu",
+  "name": "剑影蛊",
+  "tags": ["剑道", "远程", "伤害", "剑光"]
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/jian_dao_jian_guang.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/jian_dao_jian_guang.json
@@ -1,0 +1,19 @@
+{
+  "arity": 1,
+  "priority": 40,
+  "required": { "剑道": 1 },
+  "result": {
+    "name": "杀招·剑光",
+    "operator_id": "chestcavity:sword_light_slash",
+    "kind": "operator",
+    "tags": ["杀招", "剑光", "远程", "伤害"],
+    "flow_id": "chestcavity:sword_slash",
+    "flow_params": {
+      "slash.length": 6.5,
+      "slash.thickness": 1.1,
+      "slash.lifespan": 16,
+      "slash.maxPierce": 4,
+      "slash.breakPower": 2.5
+    }
+  }
+}

--- a/src/main/resources/data/chestcavity/tags/blocks/breakable_by_sword_slash.json
+++ b/src/main/resources/data/chestcavity/tags/blocks/breakable_by_sword_slash.json
@@ -1,0 +1,28 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:leaves",
+    "#minecraft:flowers",
+    "#minecraft:saplings",
+    "#minecraft:crops",
+    "#minecraft:replaceable_plants",
+    "#minecraft:wool",
+    "minecraft:vine",
+    "minecraft:glow_lichen",
+    "minecraft:cobweb",
+    "minecraft:sugar_cane",
+    "minecraft:kelp",
+    "minecraft:seagrass",
+    "minecraft:glass",
+    "minecraft:glass_pane",
+    "minecraft:ice",
+    "minecraft:packed_ice",
+    "minecraft:blue_ice",
+    "minecraft:torch",
+    "minecraft:lantern",
+    "minecraft:carved_pumpkin",
+    "minecraft:melon",
+    "minecraft:scaffolding",
+    "minecraft:bamboo"
+  ]
+}

--- a/src/test/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptRuntimeTest.java
+++ b/src/test/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptRuntimeTest.java
@@ -68,7 +68,7 @@ class GuScriptRuntimeTest {
                 .priority(40)
                 .operator((ruleId, inputs) -> new OperatorGuNode(ruleId, "血骨爆裂枪", GuNodeKind.COMPOSITE,
                         ImmutableMultiset.of("杀招"),
-                        List.of(new EmitProjectileAction("minecraft:arrow", 6.0)),
+                        List.of(new EmitProjectileAction("minecraft:arrow", 6.0, null, null, null, null, null, null, null, null, null, null)),
                         inputs))
                 .build();
 
@@ -273,7 +273,7 @@ class GuScriptRuntimeTest {
         }
 
         @Override
-        public void emitProjectile(String projectileId, double damage) {
+        public void emitProjectile(net.tigereye.chestcavity.guscript.runtime.exec.ProjectileEmission emission) {
             projectiles.incrementAndGet();
         }
 


### PR DESCRIPTION
## Summary
- implement the Jian Dao sword slash projectile entity, renderer, registration, and block-breaking tag
- extend GuScript projectile emission to accept flow-driven parameters and expose flow variables to actions
- add sword slash FX JSON definitions and new flow with configurable projectile stats plus config toggle for block breaking

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68dbbd4057f08326b006a63bfe61cf8c