### PR TITLE
Fix sword slash projectile spawn packets for NeoForge 1.21.1

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/ChestCavity.java
+++ b/src/main/java/net/tigereye/chestcavity/ChestCavity.java
@@ -30,6 +30,7 @@ import net.tigereye.chestcavity.guscript.ui.GuScriptScreen;
 import net.tigereye.chestcavity.listeners.KeybindingClientListeners;
 
 import net.tigereye.chestcavity.guscript.registry.GeckoFxDefinitionLoader;
+import net.tigereye.chestcavity.client.render.ChestCavityClientRenderers;
 import net.tigereye.chestcavity.guscript.registry.GuScriptFlowLoader;
 import net.tigereye.chestcavity.guscript.registry.GuScriptLeafLoader;
 import net.tigereye.chestcavity.guscript.registry.GuScriptRuleLoader;
@@ -102,6 +103,7 @@ public class ChestCavity { //TODO: fix 1.19 version to include color thing, fix 
 
                 if (FMLEnvironment.dist.isClient()) {
                         bus.addListener(this::registerClientReloadListeners);
+                        bus.addListener(ChestCavityClientRenderers::onRegisterRenderers);
                 }
 
 		AutoConfig.register(CCConfig.class, GsonConfigSerializer::new);

--- a/src/main/java/net/tigereye/chestcavity/client/render/ChestCavityClientRenderers.java
+++ b/src/main/java/net/tigereye/chestcavity/client/render/ChestCavityClientRenderers.java
@@ -1,0 +1,17 @@
+package net.tigereye.chestcavity.client.render;
+
+import net.neoforged.neoforge.client.event.EntityRenderersEvent;
+import net.tigereye.chestcavity.registration.CCEntities;
+
+/**
+ * Registers general-purpose client renderers for Chest Cavity entities.
+ */
+public final class ChestCavityClientRenderers {
+
+    private ChestCavityClientRenderers() {
+    }
+
+    public static void onRegisterRenderers(EntityRenderersEvent.RegisterRenderers event) {
+        event.registerEntityRenderer(CCEntities.SWORD_SLASH.get(), SwordSlashRenderer::new);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/client/render/SwordSlashRenderer.java
+++ b/src/main/java/net/tigereye/chestcavity/client/render/SwordSlashRenderer.java
@@ -1,0 +1,94 @@
+package net.tigereye.chestcavity.client.render;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.math.Axis;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.config.CCConfig;
+import net.tigereye.chestcavity.entity.SwordSlashProjectile;
+import org.joml.Matrix4f;
+
+/**
+ * Minimal glowing renderer for sword slash projectiles.
+ */
+public class SwordSlashRenderer extends EntityRenderer<SwordSlashProjectile> {
+
+    private static final CCConfig.SwordSlashConfig DEFAULTS = new CCConfig.SwordSlashConfig();
+
+    public SwordSlashRenderer(EntityRendererProvider.Context context) {
+        super(context);
+        this.shadowRadius = 0.0F;
+    }
+
+    @Override
+    public void render(SwordSlashProjectile entity, float entityYaw, float partialTicks, PoseStack poseStack,
+                       MultiBufferSource buffer, int packedLight) {
+        poseStack.pushPose();
+        Vec3 motion = entity.getDeltaMovement();
+        Vec3 direction = motion.lengthSqr() > 1.0E-4 ? motion.normalize() : entity.getForward();
+        if (direction.lengthSqr() < 1.0E-4) {
+            direction = new Vec3(0.0D, 0.0D, 1.0D);
+        }
+        float yaw = (float) Math.toDegrees(Math.atan2(direction.x, direction.z));
+        float pitch = (float) Math.toDegrees(Math.asin(Mth.clamp(direction.y, -1.0D, 1.0D)));
+        poseStack.mulPose(Axis.YP.rotationDegrees(yaw));
+        poseStack.mulPose(Axis.XP.rotationDegrees(-pitch));
+
+        float length = (float) entity.getLength();
+        float halfWidth = (float) (entity.getThickness() * 0.5D);
+        CCConfig.SwordSlashConfig config = config();
+        float alphaStart = Mth.clamp((float) config.visuals.slashAlpha, 0.0F, 1.0F);
+        float alphaEnd = Mth.clamp((float) config.visuals.slashEndAlpha, 0.0F, alphaStart);
+        int color = config.visuals.slashColor;
+        float red = ((color >> 16) & 0xFF) / 255.0F;
+        float green = ((color >> 8) & 0xFF) / 255.0F;
+        float blue = (color & 0xFF) / 255.0F;
+
+        PoseStack.Pose pose = poseStack.last();
+        VertexConsumer consumer = buffer.getBuffer(RenderType.lightning());
+
+        addQuad(consumer, pose, -halfWidth, halfWidth, 0.0F, length, red, green, blue, alphaStart, alphaEnd);
+        poseStack.mulPose(Axis.YP.rotationDegrees(90.0F));
+        pose = poseStack.last();
+        addQuad(consumer, pose, -halfWidth, halfWidth, 0.0F, length, red, green, blue, alphaStart * 0.6F, alphaEnd * 0.6F);
+
+        poseStack.popPose();
+        super.render(entity, entityYaw, partialTicks, poseStack, buffer, packedLight);
+    }
+
+    private void addQuad(VertexConsumer consumer, PoseStack.Pose pose, float minX, float maxX, float minZ, float maxZ,
+                          float red, float green, float blue, float alphaStart, float alphaEnd) {
+        addVertex(consumer, pose, minX, 0.0F, minZ, red, green, blue, alphaStart);
+        addVertex(consumer, pose, maxX, 0.0F, minZ, red, green, blue, alphaStart);
+        addVertex(consumer, pose, maxX, 0.0F, maxZ, red, green, blue, alphaEnd);
+        addVertex(consumer, pose, minX, 0.0F, maxZ, red, green, blue, alphaEnd);
+    }
+
+    private void addVertex(VertexConsumer consumer, PoseStack.Pose pose, float x, float y, float z,
+                            float red, float green, float blue, float alpha) {
+        consumer.addVertex(pose, x, y, z)
+                .setColor(red, green, blue, alpha)
+                .setOverlay(0)
+                .setLight(0x00F000F0)
+                .setNormal(pose, 0.0F, 1.0F, 0.0F);
+    }
+
+    private static CCConfig.SwordSlashConfig config() {
+        if (ChestCavity.config != null && ChestCavity.config.SWORD_SLASH != null) {
+            return ChestCavity.config.SWORD_SLASH;
+        }
+        return DEFAULTS;
+    }
+
+    @Override
+    public ResourceLocation getTextureLocation(SwordSlashProjectile entity) {
+        return ResourceLocation.fromNamespaceAndPath("minecraft", "textures/misc/white.png");
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/client/render/SwordSlashRenderer.java
+++ b/src/main/java/net/tigereye/chestcavity/client/render/SwordSlashRenderer.java
@@ -74,10 +74,7 @@ public class SwordSlashRenderer extends EntityRenderer<SwordSlashProjectile> {
     private void addVertex(VertexConsumer consumer, PoseStack.Pose pose, float x, float y, float z,
                             float red, float green, float blue, float alpha) {
         consumer.addVertex(pose, x, y, z)
-                .setColor(red, green, blue, alpha)
-                .setOverlay(0)
-                .setLight(0x00F000F0)
-                .setNormal(pose, 0.0F, 1.0F, 0.0F);
+                .setColor(red, green, blue, alpha);
     }
 
     private static CCConfig.SwordSlashConfig config() {

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/jian_dao/entity/SingleSwordProjectile.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/jian_dao/entity/SingleSwordProjectile.java
@@ -11,6 +11,7 @@ import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.server.level.ServerEntity;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -283,19 +284,8 @@ public class SingleSwordProjectile extends Entity {
         return distance < 64.0;
     }
 
-    public Packet<ClientGamePacketListener> getAddEntityPacket() {
-        return new ClientboundAddEntityPacket(
-                this.getId(),
-                this.getUUID(),
-                this.getX(),
-                this.getY(),
-                this.getZ(),
-                this.getYRot(),
-                this.getXRot(),
-                this.getType(),
-                0,
-                this.getDeltaMovement(),
-                this.getYHeadRot()
-        );
+    @Override
+    public Packet<ClientGamePacketListener> getAddEntityPacket(ServerEntity serverEntity) {
+        return new ClientboundAddEntityPacket(this, serverEntity);
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
+++ b/src/main/java/net/tigereye/chestcavity/config/CCConfig.java
@@ -126,6 +126,10 @@ public class CCConfig implements ConfigData {
     @ConfigEntry.Gui.CollapsibleObject
     public GuScriptExecutionConfig GUSCRIPT_EXECUTION = new GuScriptExecutionConfig();
 
+    @ConfigEntry.Category("sword_slash")
+    @ConfigEntry.Gui.CollapsibleObject
+    public SwordSlashConfig SWORD_SLASH = new SwordSlashConfig();
+
     public static class GuScriptUIConfig {
         @ConfigEntry.Gui.Tooltip
         public double bindingRightPaddingSlots = 0.5D;
@@ -194,6 +198,37 @@ public class CCConfig implements ConfigData {
         MULTIPLY,
         MAX,
         OVERRIDE
+    }
+
+    public static class SwordSlashConfig {
+        @ConfigEntry.Gui.Tooltip
+        public double defaultLength = 7.5D;
+        @ConfigEntry.Gui.Tooltip
+        public double defaultThickness = 0.9D;
+        @ConfigEntry.Gui.Tooltip
+        public int defaultLifespanTicks = 12;
+        @ConfigEntry.Gui.Tooltip
+        public double defaultDamage = 10.0D;
+        @ConfigEntry.Gui.Tooltip
+        public double defaultBreakPower = 1.5D;
+        @ConfigEntry.Gui.Tooltip
+        public int defaultMaxPierce = 3;
+        @ConfigEntry.Gui.Tooltip
+        public boolean enableBlockBreaking = true;
+        @ConfigEntry.Gui.Tooltip
+        public int blockBreakCapPerTick = 6;
+
+        @ConfigEntry.Gui.CollapsibleObject
+        public SwordSlashVisualConfig visuals = new SwordSlashVisualConfig();
+    }
+
+    public static class SwordSlashVisualConfig {
+        @ConfigEntry.Gui.Tooltip
+        public int slashColor = 0xFFE0A0;
+        @ConfigEntry.Gui.Tooltip
+        public double slashAlpha = 0.85D;
+        @ConfigEntry.Gui.Tooltip
+        public double slashEndAlpha = 0.3D;
     }
 
 }

--- a/src/main/java/net/tigereye/chestcavity/entity/SwordSlashProjectile.java
+++ b/src/main/java/net/tigereye/chestcavity/entity/SwordSlashProjectile.java
@@ -1,0 +1,410 @@
+package net.tigereye.chestcavity.entity;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.Mth;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.protocol.game.ClientboundAddEntityPacket;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityDimensions;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.MoverType;
+import net.minecraft.world.entity.Pose;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.server.level.ServerEntity;
+import net.minecraft.world.level.GameRules;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.config.CCConfig;
+import net.tigereye.chestcavity.registration.CCTags;
+import net.tigereye.chestcavity.util.ProjectileParameterReceiver;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Server-authoritative projectile that represents a Jian Dao style sword slash.
+ */
+public class SwordSlashProjectile extends Entity implements ProjectileParameterReceiver {
+
+    private static final EntityDataAccessor<Float> DATA_LENGTH =
+            SynchedEntityData.defineId(SwordSlashProjectile.class, EntityDataSerializers.FLOAT);
+    private static final EntityDataAccessor<Float> DATA_THICKNESS =
+            SynchedEntityData.defineId(SwordSlashProjectile.class, EntityDataSerializers.FLOAT);
+    private static final EntityDataAccessor<Integer> DATA_LIFESPAN =
+            SynchedEntityData.defineId(SwordSlashProjectile.class, EntityDataSerializers.INT);
+    private static final EntityDataAccessor<Float> DATA_DAMAGE =
+            SynchedEntityData.defineId(SwordSlashProjectile.class, EntityDataSerializers.FLOAT);
+    private static final EntityDataAccessor<Float> DATA_BREAK_POWER =
+            SynchedEntityData.defineId(SwordSlashProjectile.class, EntityDataSerializers.FLOAT);
+    private static final EntityDataAccessor<Integer> DATA_MAX_PIERCE =
+            SynchedEntityData.defineId(SwordSlashProjectile.class, EntityDataSerializers.INT);
+
+    private static final CCConfig.SwordSlashConfig DEFAULTS = new CCConfig.SwordSlashConfig();
+
+    private int lifespan;
+    private int age;
+    private double damage;
+    private double breakPower;
+    private int maxPierce;
+    private double speedPerTick;
+    private Vec3 direction = Vec3.ZERO;
+    private UUID ownerId;
+    private LivingEntity cachedOwner;
+    private final Set<UUID> damagedEntities = new HashSet<>();
+    private int pierceCount;
+    private boolean configured;
+
+    public SwordSlashProjectile(EntityType<? extends SwordSlashProjectile> type, Level level) {
+        super(type, level);
+        this.noPhysics = true;
+        this.noCulling = true;
+        this.lifespan = DEFAULTS.defaultLifespanTicks;
+        this.damage = DEFAULTS.defaultDamage;
+        this.breakPower = DEFAULTS.defaultBreakPower;
+        this.maxPierce = DEFAULTS.defaultMaxPierce;
+        this.speedPerTick = Math.max(0.05D, DEFAULTS.defaultLength / Math.max(1, this.lifespan));
+        this.setNoGravity(true);
+    }
+
+    @Override
+    protected void defineSynchedData(SynchedEntityData.Builder builder) {
+        builder.define(DATA_LENGTH, (float) DEFAULTS.defaultLength);
+        builder.define(DATA_THICKNESS, (float) DEFAULTS.defaultThickness);
+        builder.define(DATA_LIFESPAN, DEFAULTS.defaultLifespanTicks);
+        builder.define(DATA_DAMAGE, (float) DEFAULTS.defaultDamage);
+        builder.define(DATA_BREAK_POWER, (float) DEFAULTS.defaultBreakPower);
+        builder.define(DATA_MAX_PIERCE, DEFAULTS.defaultMaxPierce);
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+        Vec3 motion = this.getDeltaMovement();
+        if (motion.lengthSqr() < 1.0E-6 && direction.lengthSqr() > 1.0E-6) {
+            motion = direction.scale(speedPerTick);
+        }
+        Vec3 start = this.position();
+        Vec3 end = start.add(motion);
+        if (!this.level().isClientSide) {
+            handleEntityHits(start, end);
+            handleBlockBreaks(start, end);
+        } else {
+            spawnClientTrail();
+        }
+        this.move(MoverType.SELF, motion);
+        if (motion.lengthSqr() > 1.0E-6) {
+            direction = motion.normalize();
+            this.setDeltaMovement(direction.scale(speedPerTick));
+            updateRotationFromDirection();
+        }
+        age++;
+        if (age >= lifespan) {
+            discard();
+        }
+    }
+
+    private void handleEntityHits(Vec3 start, Vec3 end) {
+        if (!(this.level() instanceof ServerLevel server)) {
+            return;
+        }
+        AABB sweep = new AABB(start, end).inflate(getThickness() * 0.5D);
+        for (LivingEntity target : server.getEntitiesOfClass(LivingEntity.class, sweep, this::canHitEntity)) {
+            if (damagedEntities.add(target.getUUID())) {
+                applyDamage(target);
+                pierceCount++;
+                if (maxPierce > 0 && pierceCount >= maxPierce) {
+                    discard();
+                    break;
+                }
+            }
+        }
+    }
+
+    private boolean canHitEntity(LivingEntity entity) {
+        if (!entity.isAlive()) {
+            return false;
+        }
+        LivingEntity owner = getOwner();
+        if (owner != null) {
+            if (entity == owner) {
+                return false;
+            }
+            if (entity.isAlliedTo(owner)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void applyDamage(LivingEntity target) {
+        LivingEntity owner = getOwner();
+        DamageSource source;
+        if (owner instanceof Player player) {
+            source = this.damageSources().playerAttack(player);
+        } else if (owner != null) {
+            source = this.damageSources().mobAttack(owner);
+        } else {
+            source = this.damageSources().magic();
+        }
+        float amount = (float) Math.max(0.0D, damage);
+        if (amount <= 0.0F) {
+            return;
+        }
+        boolean hurt = target.hurt(source, amount);
+        if (hurt) {
+            Vec3 push = direction.lengthSqr() > 1.0E-6 ? direction : this.getForward();
+            if (push.lengthSqr() > 1.0E-6) {
+                push = push.normalize();
+                target.push(push.x * 0.5D, 0.1D + Math.abs(push.y) * 0.2D, push.z * 0.5D);
+                target.hurtMarked = true;
+            }
+        }
+    }
+
+    private void handleBlockBreaks(Vec3 start, Vec3 end) {
+        Level level = this.level();
+        if (!(level instanceof ServerLevel server)) {
+            return;
+        }
+        CCConfig.SwordSlashConfig config = config();
+        if (!config.enableBlockBreaking) {
+            return;
+        }
+        if (!mobGriefingEnabled(server) && !(getOwner() instanceof Player)) {
+            return;
+        }
+        int cap = Math.max(0, config.blockBreakCapPerTick);
+        if (cap == 0) {
+            return;
+        }
+        AABB box = new AABB(start, end).inflate(getThickness() * 0.5D);
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        int broken = 0;
+        int minX = Mth.floor(box.minX);
+        int minY = Mth.floor(box.minY);
+        int minZ = Mth.floor(box.minZ);
+        int maxX = Mth.floor(box.maxX);
+        int maxY = Mth.floor(box.maxY);
+        int maxZ = Mth.floor(box.maxZ);
+        for (int x = minX; x <= maxX && broken < cap; x++) {
+            for (int y = minY; y <= maxY && broken < cap; y++) {
+                for (int z = minZ; z <= maxZ && broken < cap; z++) {
+                    cursor.set(x, y, z);
+                    BlockState state = server.getBlockState(cursor);
+                    if (state.isAir()) {
+                        continue;
+                    }
+                    if (!state.is(CCTags.Blocks.BREAKABLE_BY_SWORD_SLASH)) {
+                        continue;
+                    }
+                    float hardness = state.getDestroySpeed(server, cursor);
+                    if (hardness < 0.0F || hardness > breakPower) {
+                        continue;
+                    }
+                    boolean destroyed = server.destroyBlock(cursor, true);
+                    if (destroyed) {
+                        broken++;
+                    }
+                }
+            }
+        }
+        if (broken >= cap && ChestCavity.LOGGER.isDebugEnabled()) {
+            ChestCavity.LOGGER.debug("[SwordSlash] Block break cap reached ({} per tick)", cap);
+        }
+    }
+
+    private boolean mobGriefingEnabled(ServerLevel level) {
+        return level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING);
+    }
+
+    private void spawnClientTrail() {
+        if (!this.level().isClientSide) {
+            return;
+        }
+        double length = getLength();
+        for (int i = 0; i < 3; i++) {
+            double t = this.random.nextDouble();
+            Vec3 offset = direction.scale(length * t);
+            double ox = this.getX() + offset.x;
+            double oy = this.getY() + offset.y + 0.2D;
+            double oz = this.getZ() + offset.z;
+            this.level().addParticle(ParticleTypes.SWEEP_ATTACK, ox, oy, oz, 0.0, 0.0, 0.0);
+        }
+    }
+
+    private void updateRotationFromDirection() {
+        if (direction.lengthSqr() < 1.0E-6) {
+            return;
+        }
+        float yaw = (float) Math.toDegrees(Math.atan2(direction.x, direction.z));
+        float pitch = (float) Math.toDegrees(Math.asin(Mth.clamp(direction.y, -1.0D, 1.0D)));
+        this.setYRot(yaw);
+        this.setXRot(pitch);
+        this.yRotO = yaw;
+        this.xRotO = pitch;
+    }
+
+    @Override
+    public void addAdditionalSaveData(CompoundTag tag) {
+        if (ownerId != null) {
+            tag.putUUID("Owner", ownerId);
+        }
+        tag.putInt("Age", age);
+        tag.putInt("Lifespan", lifespan);
+        tag.putDouble("Damage", damage);
+        tag.putDouble("BreakPower", breakPower);
+        tag.putInt("MaxPierce", maxPierce);
+        tag.putDouble("SpeedPerTick", speedPerTick);
+        tag.putDouble("DirX", direction.x);
+        tag.putDouble("DirY", direction.y);
+        tag.putDouble("DirZ", direction.z);
+        tag.putBoolean("Configured", configured);
+        tag.putDouble("Length", getLength());
+        tag.putDouble("Thickness", getThickness());
+    }
+
+    @Override
+    public void readAdditionalSaveData(CompoundTag tag) {
+        if (tag.hasUUID("Owner")) {
+            ownerId = tag.getUUID("Owner");
+        }
+        age = tag.getInt("Age");
+        lifespan = Math.max(1, tag.getInt("Lifespan"));
+        damage = tag.getDouble("Damage");
+        breakPower = tag.getDouble("BreakPower");
+        maxPierce = Math.max(0, tag.getInt("MaxPierce"));
+        speedPerTick = tag.contains("SpeedPerTick") ? tag.getDouble("SpeedPerTick") : speedPerTick;
+        double x = tag.getDouble("DirX");
+        double y = tag.getDouble("DirY");
+        double z = tag.getDouble("DirZ");
+        direction = new Vec3(x, y, z);
+        configured = tag.getBoolean("Configured");
+        this.entityData.set(DATA_LIFESPAN, lifespan);
+        this.entityData.set(DATA_DAMAGE, (float) damage);
+        this.entityData.set(DATA_BREAK_POWER, (float) breakPower);
+        this.entityData.set(DATA_MAX_PIERCE, maxPierce);
+        if (tag.contains("Length")) {
+            this.entityData.set(DATA_LENGTH, (float) tag.getDouble("Length"));
+        }
+        if (tag.contains("Thickness")) {
+            this.entityData.set(DATA_THICKNESS, (float) tag.getDouble("Thickness"));
+        }
+    }
+
+    @Override
+    public boolean isPickable() {
+        return false;
+    }
+
+    @Override
+    public boolean hurt(DamageSource source, float amount) {
+        return false;
+    }
+
+    @Override
+    public EntityDimensions getDimensions(Pose pose) {
+        float thickness = Math.max(0.2F, this.entityData.get(DATA_THICKNESS));
+        return EntityDimensions.scalable(thickness, thickness);
+    }
+
+    @Override
+    public Packet<ClientGamePacketListener> getAddEntityPacket(ServerEntity serverEntity) {
+        return new ClientboundAddEntityPacket(this, serverEntity);
+    }
+
+    @Override
+    public void applyProjectileParameters(@Nullable LivingEntity owner, CompoundTag parameters, double baseDamage) {
+        if (owner != null) {
+            this.cachedOwner = owner;
+            this.ownerId = owner.getUUID();
+        }
+        CompoundTag tag = parameters == null ? new CompoundTag() : parameters;
+        CCConfig.SwordSlashConfig config = config();
+        double length = readDouble(tag, "length", config.defaultLength);
+        double thickness = readDouble(tag, "thickness", config.defaultThickness);
+        this.lifespan = Math.max(1, (int) Math.round(readDouble(tag, "lifespan", config.defaultLifespanTicks)));
+        this.damage = baseDamage;
+        if (tag.contains("damage")) {
+            this.damage = tag.getDouble("damage");
+        }
+        this.breakPower = readDouble(tag, "break_power", config.defaultBreakPower);
+        this.maxPierce = Math.max(0, tag.contains("max_pierce") ? tag.getInt("max_pierce") : config.defaultMaxPierce);
+        this.speedPerTick = Math.max(0.05D, length / (double) this.lifespan);
+        this.direction = initialDirection(owner);
+        this.age = 0;
+        this.damagedEntities.clear();
+        this.pierceCount = 0;
+        this.entityData.set(DATA_LENGTH, (float) length);
+        this.entityData.set(DATA_THICKNESS, (float) thickness);
+        this.entityData.set(DATA_LIFESPAN, lifespan);
+        this.entityData.set(DATA_DAMAGE, (float) damage);
+        this.entityData.set(DATA_BREAK_POWER, (float) breakPower);
+        this.entityData.set(DATA_MAX_PIERCE, maxPierce);
+        this.refreshDimensions();
+        this.setDeltaMovement(direction.scale(speedPerTick));
+        updateRotationFromDirection();
+        this.configured = true;
+    }
+
+    private double readDouble(CompoundTag tag, String key, double fallback) {
+        if (tag.contains(key)) {
+            return tag.getDouble(key);
+        }
+        return fallback;
+    }
+
+    private Vec3 initialDirection(@Nullable LivingEntity owner) {
+        Vec3 forward = this.getForward();
+        if (forward.lengthSqr() < 1.0E-4 && owner != null) {
+            forward = owner.getLookAngle();
+        }
+        if (forward.lengthSqr() < 1.0E-4) {
+            forward = new Vec3(0.0D, 0.0D, 1.0D);
+        }
+        return forward.normalize();
+    }
+
+    public double getLength() {
+        return Math.max(0.1D, this.entityData.get(DATA_LENGTH));
+    }
+
+    public double getThickness() {
+        return Math.max(0.1D, this.entityData.get(DATA_THICKNESS));
+    }
+
+    @Nullable
+    public LivingEntity getOwner() {
+        if (cachedOwner != null && cachedOwner.isAlive()) {
+            return cachedOwner;
+        }
+        if (ownerId != null && this.level() instanceof ServerLevel server) {
+            Entity entity = server.getEntity(ownerId);
+            if (entity instanceof LivingEntity living) {
+                cachedOwner = living;
+                return living;
+            }
+        }
+        return null;
+    }
+
+    private static CCConfig.SwordSlashConfig config() {
+        if (ChestCavity.config != null && ChestCavity.config.SWORD_SLASH != null) {
+            return ChestCavity.config.SWORD_SLASH;
+        }
+        return DEFAULTS;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guscript/actions/EmitProjectileAction.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/actions/EmitProjectileAction.java
@@ -1,10 +1,34 @@
 package net.tigereye.chestcavity.guscript.actions;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.util.Mth;
 import net.tigereye.chestcavity.guscript.ast.Action;
 import net.tigereye.chestcavity.guscript.runtime.exec.GuScriptContext;
 
-public record EmitProjectileAction(String projectileId, double damage) implements Action {
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public record EmitProjectileAction(String projectileId, double damage, Map<String, ParameterSource> parameters) implements Action {
     public static final String ID = "emit.projectile";
+
+    public EmitProjectileAction(String projectileId, double damage) {
+        this(projectileId, damage, Map.of());
+    }
+
+    public EmitProjectileAction {
+        Objects.requireNonNull(projectileId, "projectileId");
+        if (projectileId.isBlank()) {
+            throw new IllegalArgumentException("projectileId must not be blank");
+        }
+        if (Double.isNaN(damage) || Double.isInfinite(damage)) {
+            throw new IllegalArgumentException("damage must be finite");
+        }
+        parameters = parameters == null || parameters.isEmpty() ? Map.of() : Collections.unmodifiableMap(parameters);
+    }
 
     @Override
     public String id() {
@@ -19,6 +43,117 @@ public record EmitProjectileAction(String projectileId, double damage) implement
     @Override
     public void execute(GuScriptContext context) {
         double finalDamage = context.applyDamageModifiers(damage);
-        context.bridge().emitProjectile(projectileId, finalDamage);
+        CompoundTag tag = parameters.isEmpty() ? null : buildParameterTag(context);
+        context.bridge().emitProjectile(projectileId, finalDamage, tag);
+    }
+
+    private CompoundTag buildParameterTag(GuScriptContext context) {
+        CompoundTag tag = new CompoundTag();
+        for (Map.Entry<String, ParameterSource> entry : parameters.entrySet()) {
+            String key = entry.getKey();
+            ParameterSource source = entry.getValue();
+            if (key == null || key.isBlank() || source == null) {
+                continue;
+            }
+            source.write(tag, key, context);
+        }
+        return tag.isEmpty() ? null : tag;
+    }
+
+    public static Map<String, ParameterSource> parseParameters(JsonObject json) {
+        if (json == null || !json.has("parameters")) {
+            return Map.of();
+        }
+        JsonObject raw = json.getAsJsonObject("parameters");
+        if (raw == null || raw.entrySet().isEmpty()) {
+            return Map.of();
+        }
+        Map<String, ParameterSource> values = new LinkedHashMap<>();
+        for (Map.Entry<String, JsonElement> entry : raw.entrySet()) {
+            ParameterSource source = ParameterSource.fromJson(entry.getValue());
+            if (source != null) {
+                values.put(entry.getKey(), source);
+            }
+        }
+        return values.isEmpty() ? Map.of() : Collections.unmodifiableMap(values);
+    }
+
+    public record ParameterSource(String flowParam, Double constantValue, Double defaultValue, boolean integerHint) {
+
+        private static final double EPSILON = 1.0E-6;
+
+        public static ParameterSource ofConstant(double value, boolean integerHint) {
+            return new ParameterSource(null, value, null, integerHint);
+        }
+
+        public static ParameterSource ofFlowParam(String name, Double fallback, boolean integerHint) {
+            if (name == null || name.isBlank()) {
+                return null;
+            }
+            return new ParameterSource(name, null, fallback, integerHint);
+        }
+
+        public static ParameterSource fromJson(JsonElement element) {
+            if (element == null || element.isJsonNull()) {
+                return null;
+            }
+            boolean integerHint = false;
+            if (element.isJsonPrimitive()) {
+                if (element.getAsJsonPrimitive().isNumber()) {
+                    double value = element.getAsDouble();
+                    integerHint = Math.abs(value - Math.rint(value)) < EPSILON;
+                    return ofConstant(value, integerHint);
+                }
+                String flowParam = element.getAsString();
+                return ofFlowParam(flowParam, null, false);
+            }
+            if (!element.isJsonObject()) {
+                return null;
+            }
+            JsonObject obj = element.getAsJsonObject();
+            Double constant = obj.has("value") ? obj.get("value").getAsDouble() : null;
+            Double fallback = obj.has("default") ? obj.get("default").getAsDouble() : null;
+            String flowParam = obj.has("flow_param") ? obj.get("flow_param").getAsString() : null;
+            if (obj.has("integer") && obj.get("integer").getAsBoolean()) {
+                integerHint = true;
+            }
+            if (flowParam != null && !flowParam.isBlank()) {
+                return ofFlowParam(flowParam, constant != null ? constant : fallback, integerHint);
+            }
+            if (constant != null) {
+                if (fallback != null && Math.abs(constant - Math.rint(constant)) < EPSILON) {
+                    integerHint = true;
+                }
+                return ofConstant(constant, integerHint);
+            }
+            if (fallback != null) {
+                return ofConstant(fallback, integerHint);
+            }
+            return null;
+        }
+
+        void write(CompoundTag tag, String key, GuScriptContext context) {
+            double value = resolve(context);
+            if (Double.isNaN(value) || Double.isInfinite(value)) {
+                return;
+            }
+            if (integerHint) {
+                int clamped = Mth.clamp((int) Math.round(value), Integer.MIN_VALUE, Integer.MAX_VALUE);
+                tag.putInt(key, clamped);
+            } else {
+                tag.putDouble(key, value);
+            }
+        }
+
+        private double resolve(GuScriptContext context) {
+            if (flowParam != null && !flowParam.isBlank()) {
+                double fallback = defaultValue != null ? defaultValue : (constantValue != null ? constantValue : 0.0D);
+                return context.resolveParameterAsDouble(flowParam, fallback);
+            }
+            if (constantValue != null) {
+                return constantValue;
+            }
+            return defaultValue != null ? defaultValue : 0.0D;
+        }
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/action/ActionRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/action/ActionRegistry.java
@@ -41,7 +41,8 @@ public final class ActionRegistry {
         register(ConsumeHealthAction.ID, json -> new ConsumeHealthAction(json.get("amount").getAsInt()));
         register(EmitProjectileAction.ID, json -> new EmitProjectileAction(
                 json.get("projectileId").getAsString(),
-                json.get("damage").getAsDouble()
+                json.get("damage").getAsDouble(),
+                EmitProjectileAction.parseParameters(json)
         ));
         register(AddDamageMultiplierAction.ID, json -> new AddDamageMultiplierAction(json.get("amount").getAsDouble()));
         register(AddFlatDamageAction.ID, json -> new AddFlatDamageAction(json.get("amount").getAsDouble()));

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptContext.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptContext.java
@@ -61,6 +61,14 @@ public interface GuScriptContext {
         return 0.0;
     }
 
+    default String resolveParameter(String name) {
+        return null;
+    }
+
+    default double resolveParameterAsDouble(String name, double defaultValue) {
+        return defaultValue;
+    }
+
     default double applyDamageModifiers(double baseDamage) {
         double scaled = baseDamage * (1.0 + damageMultiplier());
         return Math.max(0.0, scaled + flatDamageBonus());

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutionBridge.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptExecutionBridge.java
@@ -1,7 +1,9 @@
 package net.tigereye.chestcavity.guscript.runtime.exec;
 
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.guscript.fx.FxEventParameters;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Bridge exposed to action execution for resource manipulation and effect dispatch.
@@ -14,7 +16,7 @@ public interface GuScriptExecutionBridge {
 
     void consumeHealth(int amount);
 
-    void emitProjectile(String projectileId, double damage);
+    void emitProjectile(String projectileId, double damage, @Nullable CompoundTag parameters);
 
     void playFx(ResourceLocation fxId, FxEventParameters parameters);
 }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/FlowActions.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/FlowActions.java
@@ -268,7 +268,10 @@ public final class FlowActions {
                     return;
                 }
                 DefaultGuScriptExecutionBridge bridge = new DefaultGuScriptExecutionBridge(performer, target);
-                DefaultGuScriptContext context = new DefaultGuScriptContext(performer, target, bridge);
+                java.util.function.Function<String, String> resolver = controller != null
+                        ? controller::resolveFlowParam
+                        : null;
+                DefaultGuScriptContext context = new DefaultGuScriptContext(performer, target, bridge, null, resolver);
                 for (Action action : immutable) {
                     try {
                         action.execute(context);

--- a/src/main/java/net/tigereye/chestcavity/registration/CCEntities.java
+++ b/src/main/java/net/tigereye/chestcavity/registration/CCEntities.java
@@ -6,6 +6,7 @@ import net.minecraft.world.entity.MobCategory;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.entity.SwordSlashProjectile;
 import net.tigereye.chestcavity.guscript.ability.guzhenren.blood_bone_bomb.BoneGunProjectile;
 
 import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.entity.SingleSwordProjectile;
@@ -46,5 +47,13 @@ public final class CCEntities {
                     .clientTrackingRange(48)
                     .updateInterval(2)
                     .build(ChestCavity.MODID + ":sword_shadow_clone"));
+
+    public static final DeferredHolder<EntityType<?>, EntityType<SwordSlashProjectile>> SWORD_SLASH =
+            ENTITY_TYPES.register("sword_slash", () -> EntityType.Builder
+                    .<SwordSlashProjectile>of(SwordSlashProjectile::new, MobCategory.MISC)
+                    .sized(0.6f, 0.6f)
+                    .clientTrackingRange(64)
+                    .updateInterval(1)
+                    .build(ChestCavity.MODID + ":sword_slash"));
 
 }

--- a/src/main/java/net/tigereye/chestcavity/registration/CCTags.java
+++ b/src/main/java/net/tigereye/chestcavity/registration/CCTags.java
@@ -3,6 +3,7 @@ package net.tigereye.chestcavity.registration;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
 import net.tigereye.chestcavity.ChestCavity;
 
 public class CCTags {
@@ -17,4 +18,12 @@ public class CCTags {
     //public static final Tag<Item> CARNIVORE_FOOD = TagRegistry.item(new ResourceLocation(ChestCavity.MODID,"carnivore_food"));
     //public static final Tag<Item> SALVAGEABLE = TagRegistry.item(new ResourceLocation(ChestCavity.MODID,"salvageable"));
     //public static final Tag<Item> IRON_REPAIR_MATERIAL = TagRegistry.item(new ResourceLocation(ChestCavity.MODID,"iron_repair_material"));
+
+    public static final class Blocks {
+        public static final TagKey<Block> BREAKABLE_BY_SWORD_SLASH =
+                TagKey.create(Registries.BLOCK, ChestCavity.id("breakable_by_sword_slash"));
+
+        private Blocks() {
+        }
+    }
 }

--- a/src/main/java/net/tigereye/chestcavity/util/ProjectileParameterReceiver.java
+++ b/src/main/java/net/tigereye/chestcavity/util/ProjectileParameterReceiver.java
@@ -1,0 +1,13 @@
+package net.tigereye.chestcavity.util;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.LivingEntity;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Marker interface for projectiles that can be configured via GuScript before being spawned.
+ */
+public interface ProjectileParameterReceiver {
+
+    void applyProjectileParameters(@Nullable LivingEntity owner, CompoundTag parameters, double baseDamage);
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/sword_slash_impact.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/sword_slash_impact.json
@@ -1,0 +1,26 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:block.glass.break",
+      "volume": 0.9,
+      "pitch": 1.2
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:cloud",
+      "count": 8,
+      "speed": 0.05,
+      "spread": [0.35, 0.2, 0.35],
+      "offset": [0.0, 0.6, 0.0]
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:crit",
+      "count": 14,
+      "speed": 0.3,
+      "spread": [0.4, 0.25, 0.4],
+      "offset": [0.0, 0.7, 0.0]
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/sword_slash_spawn.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/sword_slash_spawn.json
@@ -1,0 +1,31 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:entity.player.attack.sweep",
+      "volume": 1.0,
+      "pitch": 1.1
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:crit",
+      "count": 18,
+      "speed": 0.25,
+      "spread": [0.45, 0.2, 0.45],
+      "offset": [0.0, 0.7, 0.0]
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:sweep_attack",
+      "count": 6,
+      "speed": 0.0,
+      "spread": [0.12, 0.0, 0.12],
+      "offset": [0.0, 0.8, 0.0]
+    },
+    {
+      "type": "screen_shake",
+      "intensity": 0.2,
+      "duration": 6
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/sword_slash_trail.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/sword_slash_trail.json
@@ -1,0 +1,22 @@
+{
+  "modules": [
+    {
+      "type": "particle",
+      "particle": "minecraft:dust",
+      "color": "#f8d777",
+      "size": 1.1,
+      "count": 10,
+      "speed": 0.02,
+      "spread": [0.14, 0.12, 0.14],
+      "offset": [0.0, 0.6, 0.0]
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:crit",
+      "count": 6,
+      "speed": 0.1,
+      "spread": [0.28, 0.08, 0.28],
+      "offset": [0.0, 0.65, 0.0]
+    }
+  ]
+}

--- a/src/main/resources/data/chestcavity/guscript/flows/sword_slash.json
+++ b/src/main/resources/data/chestcavity/guscript/flows/sword_slash.json
@@ -1,0 +1,52 @@
+{
+  "initial_state": "idle",
+  "states": {
+    "idle": {
+      "transitions": [
+        {
+          "trigger": "start",
+          "target": "releasing",
+          "guards": [
+            { "type": "cooldown", "key": "chestcavity:sword_slash" }
+          ],
+          "actions": [
+            { "type": "set_cooldown", "key": "chestcavity:sword_slash", "ticks": 40 }
+          ]
+        }
+      ]
+    },
+    "releasing": {
+      "enter_fx": [ "chestcavity:sword_slash_spawn" ],
+      "enter_actions": [
+        {
+          "id": "emit.projectile",
+          "projectileId": "chestcavity:sword_slash",
+          "damage": 10.0,
+          "parameters": {
+            "length": { "flow_param": "length", "default": 7.5 },
+            "thickness": { "flow_param": "thickness", "default": 0.9 },
+            "lifespan": { "flow_param": "lifespan", "default": 12.0 },
+            "break_power": { "flow_param": "break_power", "default": 1.5 },
+            "max_pierce": { "flow_param": "max_pierce", "default": 3, "integer": true }
+          }
+        },
+        { "id": "emit.fx", "fxId": "chestcavity:sword_slash_trail", "intensity": 1.0 }
+      ],
+      "update_period": 5,
+      "update_actions": [
+        { "id": "emit.fx", "fxId": "chestcavity:sword_slash_trail", "intensity": 0.6 }
+      ],
+      "transitions": [
+        { "trigger": "auto", "target": "cooldown", "min_ticks": 8 }
+      ]
+    },
+    "cooldown": {
+      "enter_actions": [
+        { "id": "emit.fx", "fxId": "chestcavity:sword_slash_impact", "intensity": 1.0 }
+      ],
+      "transitions": [
+        { "trigger": "auto", "target": "idle", "min_ticks": 20 }
+      ]
+    }
+  }
+}

--- a/src/main/resources/data/chestcavity/guscript/rules/jian_dao_sword_slash.json
+++ b/src/main/resources/data/chestcavity/guscript/rules/jian_dao_sword_slash.json
@@ -1,0 +1,19 @@
+{
+  "arity": 2,
+  "priority": 28,
+  "required": { "剑道": 1, "杀招": 1 },
+  "result": {
+    "name": "杀招·剑光",
+    "operator_id": "chestcavity:sword_slash",
+    "kind": "composite",
+    "tags": ["杀招", "剑光"],
+    "flow_id": "chestcavity:sword_slash",
+    "flow_params": {
+      "length": "7.5",
+      "thickness": "0.9",
+      "lifespan": "12",
+      "break_power": "1.5",
+      "max_pierce": "3"
+    }
+  }
+}

--- a/src/main/resources/data/chestcavity/tags/blocks/breakable_by_sword_slash.json
+++ b/src/main/resources/data/chestcavity/tags/blocks/breakable_by_sword_slash.json
@@ -1,0 +1,33 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:grass_block",
+    "minecraft:dirt",
+    "minecraft:coarse_dirt",
+    "minecraft:podzol",
+    "minecraft:sand",
+    "minecraft:red_sand",
+    "minecraft:glass",
+    "minecraft:glass_pane",
+    "minecraft:white_stained_glass",
+    "minecraft:white_stained_glass_pane",
+    "minecraft:ice",
+    "minecraft:packed_ice",
+    "minecraft:snow_block",
+    "minecraft:melon",
+    "minecraft:pumpkin",
+    "minecraft:carved_pumpkin",
+    "minecraft:jack_o_lantern",
+    "minecraft:honey_block",
+    "minecraft:scaffolding",
+    "minecraft:bookshelf",
+    "#minecraft:leaves",
+    "#minecraft:flowers",
+    "#minecraft:small_flowers",
+    "#minecraft:tall_flowers",
+    "#minecraft:crops",
+    "#minecraft:saplings",
+    "#minecraft:replaceable_plants",
+    "#minecraft:wool"
+  ]
+}

--- a/src/test/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptRuntimeTest.java
+++ b/src/test/java/net/tigereye/chestcavity/guscript/runtime/exec/GuScriptRuntimeTest.java
@@ -273,7 +273,7 @@ class GuScriptRuntimeTest {
         }
 
         @Override
-        public void emitProjectile(String projectileId, double damage) {
+        public void emitProjectile(String projectileId, double damage, net.minecraft.nbt.CompoundTag parameters) {
             projectiles.incrementAndGet();
         }
 


### PR DESCRIPTION
## Summary
- update the sword slash and Jian Dao visual projectiles to implement the NeoForge 1.21.1 spawn packet signature using ServerEntity context

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68dcabff63fc8326ab8b8bcfa60de900