### PR TITLE
Add generic entity strike flow action

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/guscript/registry/GuScriptFlowLoader.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/registry/GuScriptFlowLoader.java
@@ -327,6 +327,15 @@ public final class GuScriptFlowLoader extends SimpleJsonResourceReloadListener {
                     GsonHelper.getAsBoolean(json, "invisible", true),
                     GsonHelper.getAsBoolean(json, "allies_only", true)
             );
+            case "entity_strike" -> FlowActions.entityStrike(
+                    json.has("entity_id_variable") ? GsonHelper.getAsString(json, "entity_id_variable") : null,
+                    GsonHelper.getAsDouble(json, "ally_radius", 0.0D),
+                    parseVec3(json, "offset"),
+                    json.has("yaw_offset") ? (float) GsonHelper.getAsDouble(json, "yaw_offset") : 0.0F,
+                    GsonHelper.getAsDouble(json, "dash", 0.0D),
+                    json.has("target") ? GsonHelper.getAsString(json, "target") : null,
+                    json.has("sound") ? ResourceLocation.parse(GsonHelper.getAsString(json, "sound")) : null
+            );
             default -> throw new IllegalArgumentException("Unknown flow action type: " + type);
         };
     }

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/FlowActions.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/FlowActions.java
@@ -6,11 +6,14 @@ import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
@@ -45,6 +48,7 @@ import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -492,6 +496,80 @@ public final class FlowActions {
 
             @Override
             public String describe() { return "set_invisible_nearby(r=" + r + ", alliesOnly=" + alliesOnly + ", invisible=" + invisible + ")"; }
+        };
+    }
+
+    /** Flow edge action: reposition an allied entity and force it to perform a melee strike. */
+    public static FlowEdgeAction entityStrike(
+            String entityIdVariable,
+            double allyRadius,
+            Vec3 relativeOffset,
+            float yawOffset,
+            double dashDistance,
+            String targetSelector,
+            ResourceLocation soundId
+    ) {
+        double radius = Math.max(0.0D, allyRadius);
+        Vec3 offset = relativeOffset == null ? Vec3.ZERO : relativeOffset;
+        float additionalYaw = yawOffset;
+        double dash = Math.max(0.0D, dashDistance);
+        StrikeTargetSelector selector = StrikeTargetSelector.from(targetSelector);
+        ResourceLocation resolvedSound = soundId == null
+                ? ResourceLocation.fromNamespaceAndPath("minecraft", "entity.polar_bear.attack")
+                : soundId;
+        return new FlowEdgeAction() {
+            @Override
+            public void apply(Player performer, LivingEntity target, FlowController controller, long gameTime) {
+                if (performer == null) {
+                    return;
+                }
+                Level level = performer.level();
+                if (!(level instanceof ServerLevel server)) {
+                    return;
+                }
+
+                LivingEntity striker = resolveStrikeSource(server, performer, controller, entityIdVariable, radius);
+                if (striker == null || !striker.isAlive()) {
+                    return;
+                }
+
+                LivingEntity strikeTarget = selector.select(performer, target);
+                if (strikeTarget != null && (!strikeTarget.isAlive() || strikeTarget == striker)) {
+                    strikeTarget = null;
+                }
+
+                float finalYaw = performer.getYRot() + additionalYaw;
+                Vec3 finalPosition = computeEntityStrikePosition(
+                        performer.position(),
+                        performer.getYRot(),
+                        offset,
+                        additionalYaw,
+                        dash
+                );
+
+                float pitch = striker.getXRot();
+                striker.setDeltaMovement(Vec3.ZERO);
+                striker.moveTo(finalPosition.x, finalPosition.y, finalPosition.z, finalYaw, pitch);
+                striker.setYRot(finalYaw);
+                striker.setYBodyRot(finalYaw);
+                striker.setYHeadRot(finalYaw);
+
+                if (striker instanceof Mob mob) {
+                    mob.setTarget(strikeTarget);
+                }
+
+                if (strikeTarget != null) {
+                    striker.swing(InteractionHand.MAIN_HAND, true);
+                    striker.doHurtTarget(strikeTarget);
+                }
+
+                playStrikeSound(server, striker, resolvedSound);
+            }
+
+            @Override
+            public String describe() {
+                return "entity_strike(entityIdVariable=" + entityIdVariable + ")";
+            }
         };
     }
 
@@ -1240,6 +1318,110 @@ public final class FlowActions {
             return true;
         }
         return GuzhenrenNudaoBridge.openSubject(candidate).map(handle -> handle.isOwnedBy(performer)).orElse(false);
+    }
+
+    private static LivingEntity resolveStrikeSource(
+            ServerLevel server,
+            Player performer,
+            FlowController controller,
+            String entityIdVariable,
+            double allyRadius
+    ) {
+        LivingEntity resolved = null;
+        if (controller != null && entityIdVariable != null && !entityIdVariable.isBlank()) {
+            long stored = controller.getLong(entityIdVariable, -1L);
+            if (stored >= 0L) {
+                Entity entity = server.getEntity((int) stored);
+                if (entity instanceof LivingEntity living) {
+                    resolved = living;
+                }
+            }
+        }
+        if (resolved != null) {
+            return resolved;
+        }
+        if (allyRadius <= 0.0D) {
+            return null;
+        }
+        AABB box = new AABB(performer.blockPosition()).inflate(allyRadius);
+        List<LivingEntity> allies = server.getEntitiesOfClass(LivingEntity.class, box, entity -> isAlly(performer, entity));
+        if (allies.isEmpty()) {
+            return null;
+        }
+        return allies.stream()
+                .min(Comparator.comparingDouble(entity -> entity.distanceToSqr(performer)))
+                .orElse(null);
+    }
+
+    static Vec3 rotateOffsetByYaw(Vec3 offset, float yawDegrees) {
+        if (offset == null || offset.equals(Vec3.ZERO)) {
+            return Vec3.ZERO;
+        }
+        double radians = Math.toRadians(-yawDegrees);
+        double sin = Math.sin(radians);
+        double cos = Math.cos(radians);
+        double x = offset.x * cos - offset.z * sin;
+        double z = offset.x * sin + offset.z * cos;
+        return new Vec3(x, offset.y, z);
+    }
+
+    static Vec3 computeEntityStrikePosition(
+            Vec3 performerPosition,
+            float performerYaw,
+            Vec3 offset,
+            float yawOffset,
+            double dashDistance
+    ) {
+        Vec3 base = performerPosition.add(rotateOffsetByYaw(offset, performerYaw));
+        if (dashDistance <= 0.0D) {
+            return base;
+        }
+        Vec3 dashVector = Vec3.directionFromRotation(0.0F, performerYaw + yawOffset).scale(dashDistance);
+        return base.add(dashVector);
+    }
+
+    private static void playStrikeSound(ServerLevel level, LivingEntity striker, ResourceLocation soundId) {
+        if (level == null || striker == null || soundId == null) {
+            return;
+        }
+        Optional<Holder.Reference<SoundEvent>> holder = BuiltInRegistries.SOUND_EVENT.getHolder(soundId);
+        if (holder.isEmpty()) {
+            return;
+        }
+        SoundEvent soundEvent = holder.get().value();
+        level.playSound(
+                null,
+                striker.getX(),
+                striker.getY(),
+                striker.getZ(),
+                soundEvent,
+                striker.getSoundSource(),
+                1.0F,
+                1.0F
+        );
+    }
+
+    private enum StrikeTargetSelector {
+        FLOW_TARGET,
+        PERFORMER;
+
+        static StrikeTargetSelector from(String raw) {
+            if (raw == null || raw.isBlank()) {
+                return FLOW_TARGET;
+            }
+            String normalized = raw.trim().toLowerCase(Locale.ROOT);
+            return switch (normalized) {
+                case "performer", "self" -> PERFORMER;
+                default -> FLOW_TARGET;
+            };
+        }
+
+        LivingEntity select(Player performer, LivingEntity flowTarget) {
+            return switch (this) {
+                case FLOW_TARGET -> flowTarget;
+                case PERFORMER -> performer;
+            };
+        }
     }
 
     private static FlowEdgeAction describe(java.util.function.Supplier<String> description) {

--- a/src/test/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/EntityStrikeActionTest.java
+++ b/src/test/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/EntityStrikeActionTest.java
@@ -1,0 +1,37 @@
+package net.tigereye.chestcavity.guscript.runtime.flow.actions;
+
+import net.minecraft.world.phys.Vec3;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EntityStrikeActionTest {
+
+    @Test
+    void rotateOffsetByYawAlignsRelativeToPerformer() {
+        Vec3 offset = new Vec3(1.0D, 0.5D, -2.0D);
+        Vec3 rotated = FlowActions.rotateOffsetByYaw(offset, 90.0F);
+
+        assertEquals(-2.0D, rotated.x, 1.0E-6D);
+        assertEquals(0.5D, rotated.y, 1.0E-6D);
+        assertEquals(-1.0D, rotated.z, 1.0E-6D);
+    }
+
+    @Test
+    void computeEntityStrikePositionAppliesDashAndYawOffset() {
+        Vec3 performer = new Vec3(10.0D, 65.0D, 10.0D);
+        Vec3 offset = new Vec3(1.0D, 0.5D, -2.0D);
+
+        Vec3 finalPosition = FlowActions.computeEntityStrikePosition(
+                performer,
+                90.0F,
+                offset,
+                -15.0F,
+                3.0D
+        );
+
+        assertEquals(5.1022D, finalPosition.x, 1.0E-3D);
+        assertEquals(65.5D, finalPosition.y, 1.0E-3D);
+        assertEquals(9.7764D, finalPosition.z, 1.0E-3D);
+    }
+}


### PR DESCRIPTION
## Summary
- add `FlowActions.entityStrike` to control allied strike execution with dash, targeting, and configurable sound
- extend the flow loader to parse the new `entity_strike` JSON action wiring
- add unit tests covering strike offset rotation and placement math

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68dcb9fef38083268a13ff0e7c3c1b52