### PR TITLE
Add Shui Ti Gu and Xueqigu organs

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shui_dao/ShuiDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shui_dao/ShuiDaoOrganRegistry.java
@@ -2,6 +2,7 @@ package net.tigereye.chestcavity.compat.guzhenren.item.shui_dao;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.behavior.LingXianguOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.behavior.ShuiTiGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
 
 import java.util.List;
@@ -15,11 +16,19 @@ public final class ShuiDaoOrganRegistry {
 
     private static final ResourceLocation LING_XIAN_GU_ID =
             ResourceLocation.fromNamespaceAndPath(MOD_ID, "ling_xian_gu");
+    private static final ResourceLocation SHUI_TI_GU_ID =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "shui_ti_gu");
 
     private static final List<OrganIntegrationSpec> SPECS = List.of(
             OrganIntegrationSpec.builder(LING_XIAN_GU_ID)
                     .addSlowTickListener(LingXianguOrganBehavior.INSTANCE)
                     .ensureAttached(LingXianguOrganBehavior.INSTANCE::ensureAttached)
+                    .build(),
+            OrganIntegrationSpec.builder(SHUI_TI_GU_ID)
+                    .addSlowTickListener(ShuiTiGuOrganBehavior.INSTANCE)
+                    .addRemovalListener(ShuiTiGuOrganBehavior.INSTANCE)
+                    .ensureAttached(ShuiTiGuOrganBehavior.INSTANCE::ensureAttached)
+                    .onEquip(ShuiTiGuOrganBehavior.INSTANCE::onEquip)
                     .build()
     );
 

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shui_dao/behavior/ShuiTiGuOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shui_dao/behavior/ShuiTiGuOrganBehavior.java
@@ -1,0 +1,198 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.behavior;
+
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.AbstractGuzhenrenOrganBehavior;
+import net.tigereye.chestcavity.guzhenren.util.GuzhenrenResourceCostHelper;
+import net.tigereye.chestcavity.guzhenren.util.GuzhenrenResourceCostHelper.ConsumptionResult;
+import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.linkage.IncreaseEffectLedger;
+import net.tigereye.chestcavity.linkage.LinkageChannel;
+import net.tigereye.chestcavity.linkage.LinkageManager;
+import net.tigereye.chestcavity.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.listeners.OrganRemovalContext;
+import net.tigereye.chestcavity.listeners.OrganRemovalListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.util.ChestCavityUtil;
+import net.tigereye.chestcavity.util.NBTCharge;
+import net.tigereye.chestcavity.util.NetworkUtil;
+
+/**
+ * Behaviour for 水体蛊 (Shui Ti Gu).
+ */
+public final class ShuiTiGuOrganBehavior extends AbstractGuzhenrenOrganBehavior
+        implements OrganSlowTickListener, OrganRemovalListener, IncreaseEffectContributor {
+
+    public static final ShuiTiGuOrganBehavior INSTANCE = new ShuiTiGuOrganBehavior();
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation ORGAN_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "shui_ti_gu");
+    private static final ResourceLocation SHUI_SHEN_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "shuishengu");
+    private static final ResourceLocation SHUI_DAO_INCREASE_EFFECT =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/shui_dao_increase_effect");
+
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    private static final double INCREASE_PER_STACK = 0.01;
+    private static final float HEAL_PER_SECOND = 3.0f;
+    private static final double ZHENYUAN_PER_SECOND = 20.0;
+    private static final int SHIELD_CHARGE_PER_TICK = 1;
+
+    private ShuiTiGuOrganBehavior() {
+    }
+
+    public void onEquip(ChestCavityInstance cc, ItemStack organ, java.util.List<OrganRemovalContext> staleRemovalContexts) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID)) {
+            return;
+        }
+
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        context.getOrCreateChannel(SHUI_DAO_INCREASE_EFFECT).addPolicy(NON_NEGATIVE);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        ledger.registerContributor(organ, this, SHUI_DAO_INCREASE_EFFECT);
+
+        registerRemovalHook(cc, organ, this, staleRemovalContexts);
+        refreshIncreaseContribution(cc, organ);
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (entity == null || entity.level().isClientSide()) {
+            return;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID)) {
+            return;
+        }
+        refreshIncreaseContribution(cc, organ);
+
+        if (cc == null || !entity.isAlive()) {
+            return;
+        }
+
+        int stackCount = Math.max(1, organ.getCount());
+        double totalCost = ZHENYUAN_PER_SECOND * stackCount;
+        ConsumptionResult payment;
+        if (entity instanceof Player player) {
+            payment = GuzhenrenResourceCostHelper.consumeStrict(player, totalCost, 0.0);
+        } else {
+            payment = GuzhenrenResourceCostHelper.consumeWithFallback(entity, totalCost, 0.0);
+        }
+        if (!payment.succeeded()) {
+            return;
+        }
+
+        if (HEAL_PER_SECOND > 0.0f && entity.getHealth() < entity.getMaxHealth()) {
+            float heal = HEAL_PER_SECOND * stackCount;
+            ChestCavityUtil.runWithOrganHeal(() -> entity.heal(heal));
+        }
+
+        rechargeShuishengu(cc, stackCount * SHIELD_CHARGE_PER_TICK);
+    }
+
+    @Override
+    public void onRemoved(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID)) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        double removed = ledger.remove(organ, SHUI_DAO_INCREASE_EFFECT);
+        ledger.unregisterContributor(organ);
+        context.lookupChannel(SHUI_DAO_INCREASE_EFFECT)
+                .ifPresent(channel -> channel.adjust(-removed));
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        if (cc == null) {
+            return;
+        }
+        LinkageManager.getContext(cc)
+                .getOrCreateChannel(SHUI_DAO_INCREASE_EFFECT)
+                .addPolicy(NON_NEGATIVE);
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        if (organ == null || organ.isEmpty()) {
+            return;
+        }
+        int stackCount = Math.max(1, organ.getCount());
+        double effect = stackCount * INCREASE_PER_STACK;
+        registrar.record(SHUI_DAO_INCREASE_EFFECT, stackCount, effect);
+    }
+
+    private void refreshIncreaseContribution(ChestCavityInstance cc, ItemStack organ) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        LinkageChannel channel = context.getOrCreateChannel(SHUI_DAO_INCREASE_EFFECT).addPolicy(NON_NEGATIVE);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        double previous = ledger.adjust(organ, SHUI_DAO_INCREASE_EFFECT, 0.0);
+        double target = Math.max(1, organ.getCount()) * INCREASE_PER_STACK;
+        double delta = target - previous;
+        if (delta != 0.0) {
+            channel.adjust(delta);
+            ledger.adjust(organ, SHUI_DAO_INCREASE_EFFECT, delta);
+        }
+    }
+
+    private void rechargeShuishengu(ChestCavityInstance cc, int chargeAmount) {
+        if (cc == null || chargeAmount <= 0) {
+            return;
+        }
+        int containerSize = cc.inventory.getContainerSize();
+        int totalCharge = 0;
+        int totalMax = 0;
+        boolean anyChanged = false;
+        for (int i = 0; i < containerSize; i++) {
+            ItemStack candidate = cc.inventory.getItem(i);
+            if (candidate.isEmpty()) {
+                continue;
+            }
+            if (!matchesShuishengu(candidate)) {
+                continue;
+            }
+            int stackCount = Math.max(1, candidate.getCount());
+            int maxCharge = ShuishenguShield.getEffectiveMaxCharge(stackCount);
+            int current = Math.min(NBTCharge.getCharge(candidate, ShuishenguShield.STATE_KEY), maxCharge);
+            int updated = Math.min(maxCharge, current + chargeAmount);
+            totalCharge += updated;
+            totalMax += maxCharge;
+            if (updated != current) {
+                ShuishenguShield.setCharge(candidate, updated, stackCount);
+                NetworkUtil.sendOrganSlotUpdate(cc, candidate);
+                anyChanged = true;
+            }
+        }
+        if (anyChanged && totalMax > 0) {
+            ShuishenguShield.broadcastChargeRatio(cc, totalMax, totalCharge);
+        }
+    }
+
+    private boolean matchesShuishengu(ItemStack stack) {
+        if (stack == null || stack.isEmpty()) {
+            return false;
+        }
+        Item item = stack.getItem();
+        ResourceLocation id = BuiltInRegistries.ITEM.getKey(item);
+        return SHUI_SHEN_GU_ID.equals(id);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/XueDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/XueDaoOrganRegistry.java
@@ -4,6 +4,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.behavior.TiexueguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.behavior.XieFeiguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.behavior.XiediguOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.behavior.XueqiguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.behavior.XieyanguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
 
@@ -20,11 +21,8 @@ public final class XueDaoOrganRegistry {
     private static final ResourceLocation XUE_FEI_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "xie_fei_gu");
 
     private static final ResourceLocation XIE_DI_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "xie_di_gu");
-
-
+    private static final ResourceLocation XUE_QI_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "xueqigu");
     private static final ResourceLocation XIE_YAN_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "xie_yan_gu");
-
-
 
     private static final List<OrganIntegrationSpec> SPECS = List.of(
             OrganIntegrationSpec.builder(TIE_XUE_GU_ID)
@@ -32,6 +30,12 @@ public final class XueDaoOrganRegistry {
                     .addRemovalListener(TiexueguOrganBehavior.INSTANCE)
                     .ensureAttached(TiexueguOrganBehavior.INSTANCE::ensureAttached)
                     .onEquip(TiexueguOrganBehavior.INSTANCE::onEquip)
+                    .build(),
+            OrganIntegrationSpec.builder(XUE_QI_GU_ID)
+                    .addSlowTickListener(XueqiguOrganBehavior.INSTANCE)
+                    .addRemovalListener(XueqiguOrganBehavior.INSTANCE)
+                    .ensureAttached(XueqiguOrganBehavior.INSTANCE::ensureAttached)
+                    .onEquip(XueqiguOrganBehavior.INSTANCE::onEquip)
                     .build(),
             OrganIntegrationSpec.builder(XUE_FEI_GU_ID)
                     .addSlowTickListener(XieFeiguOrganBehavior.INSTANCE)

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/behavior/XueqiguOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/xue_dao/behavior/XueqiguOrganBehavior.java
@@ -1,0 +1,181 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.behavior;
+
+import com.mojang.logging.LogUtils;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.AbstractGuzhenrenOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.OrganState;
+import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.guzhenren.util.GuzhenrenResourceCostHelper;
+import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.linkage.IncreaseEffectLedger;
+import net.tigereye.chestcavity.linkage.LinkageChannel;
+import net.tigereye.chestcavity.linkage.LinkageManager;
+import net.tigereye.chestcavity.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.listeners.OrganRemovalContext;
+import net.tigereye.chestcavity.listeners.OrganRemovalListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.util.ChestCavityUtil;
+import net.tigereye.chestcavity.util.NetworkUtil;
+import org.slf4j.Logger;
+
+import java.util.List;
+
+/**
+ * Behaviour for 血气蛊 (Xue Qi Gu).
+ */
+public final class XueqiguOrganBehavior extends AbstractGuzhenrenOrganBehavior
+        implements OrganSlowTickListener, OrganRemovalListener, IncreaseEffectContributor {
+
+    public static final XueqiguOrganBehavior INSTANCE = new XueqiguOrganBehavior();
+
+    private static final Logger LOGGER = LogUtils.getLogger();
+    private static final String LOG_PREFIX = "[Xue Qi Gu]";
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation ORGAN_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "xueqigu");
+    private static final ResourceLocation XUE_DAO_INCREASE_EFFECT =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/xue_dao_increase_effect");
+
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    private static final double INCREASE_PER_STACK = 0.1;
+    private static final double JINGLI_PER_SECOND = 5.0;
+    private static final float HEAL_PER_SECOND = 3.0f;
+    private static final float HEALTH_DRAIN_PER_MINUTE = 8.0f;
+    private static final float HEALTH_DRAIN_RESERVE = 1.0f;
+    private static final int SLOW_TICKS_PER_MINUTE = 60;
+    private static final int FAILURE_RETRY_TICKS = 5;
+
+    private static final String STATE_KEY = "Xueqigu";
+    private static final String TIMER_KEY = "DrainTimer";
+
+    private XueqiguOrganBehavior() {
+    }
+
+    public void onEquip(ChestCavityInstance cc, ItemStack organ, List<OrganRemovalContext> staleRemovalContexts) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID)) {
+            return;
+        }
+
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        context.getOrCreateChannel(XUE_DAO_INCREASE_EFFECT).addPolicy(NON_NEGATIVE);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        ledger.registerContributor(organ, this, XUE_DAO_INCREASE_EFFECT);
+
+        RemovalRegistration registration = registerRemovalHook(cc, organ, this, staleRemovalContexts);
+        refreshIncreaseContribution(cc, organ);
+        if (!registration.alreadyRegistered()) {
+            OrganState state = organState(organ, STATE_KEY);
+            var change = state.setInt(TIMER_KEY, SLOW_TICKS_PER_MINUTE, value -> Math.max(1, value), SLOW_TICKS_PER_MINUTE);
+            logStateChange(LOGGER, LOG_PREFIX, organ, TIMER_KEY, change);
+            sendSlotUpdate(cc, organ);
+        }
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (entity == null || entity.level().isClientSide()) {
+            return;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID)) {
+            return;
+        }
+        refreshIncreaseContribution(cc, organ);
+
+        if (cc == null || !entity.isAlive()) {
+            return;
+        }
+
+        int stackCount = Math.max(1, organ.getCount());
+        if (entity instanceof Player player) {
+            GuzhenrenResourceBridge.open(player).ifPresent(handle -> {
+                double amount = JINGLI_PER_SECOND * stackCount;
+                handle.adjustJingli(amount, true);
+            });
+        }
+
+        if (HEAL_PER_SECOND > 0.0f && entity.getHealth() < entity.getMaxHealth()) {
+            float heal = HEAL_PER_SECOND * stackCount;
+            ChestCavityUtil.runWithOrganHeal(() -> entity.heal(heal));
+        }
+
+        OrganState state = organState(organ, STATE_KEY);
+        int timer = Math.max(1, state.getInt(TIMER_KEY, SLOW_TICKS_PER_MINUTE));
+        timer -= 1;
+        boolean drained = false;
+        if (timer <= 0) {
+            float drainAmount = HEALTH_DRAIN_PER_MINUTE * stackCount;
+            drained = GuzhenrenResourceCostHelper.drainHealth(entity, drainAmount, HEALTH_DRAIN_RESERVE, entity.damageSources().generic());
+            timer = drained ? SLOW_TICKS_PER_MINUTE : FAILURE_RETRY_TICKS;
+        }
+        var timerChange = state.setInt(TIMER_KEY, timer, value -> Math.max(1, value), SLOW_TICKS_PER_MINUTE);
+        if (timerChange.changed()) {
+            logStateChange(LOGGER, LOG_PREFIX, organ, TIMER_KEY, timerChange);
+            NetworkUtil.sendOrganSlotUpdate(cc, organ);
+        }
+    }
+
+    @Override
+    public void onRemoved(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID)) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        double removed = ledger.remove(organ, XUE_DAO_INCREASE_EFFECT);
+        ledger.unregisterContributor(organ);
+        context.lookupChannel(XUE_DAO_INCREASE_EFFECT)
+                .ifPresent(channel -> channel.adjust(-removed));
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        if (cc == null) {
+            return;
+        }
+        LinkageManager.getContext(cc)
+                .getOrCreateChannel(XUE_DAO_INCREASE_EFFECT)
+                .addPolicy(NON_NEGATIVE);
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        if (organ == null || organ.isEmpty()) {
+            return;
+        }
+        int stackCount = Math.max(1, organ.getCount());
+        double effect = stackCount * INCREASE_PER_STACK;
+        registrar.record(XUE_DAO_INCREASE_EFFECT, stackCount, effect);
+    }
+
+    private void refreshIncreaseContribution(ChestCavityInstance cc, ItemStack organ) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        LinkageChannel channel = context.getOrCreateChannel(XUE_DAO_INCREASE_EFFECT).addPolicy(NON_NEGATIVE);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        double previous = ledger.adjust(organ, XUE_DAO_INCREASE_EFFECT, 0.0);
+        double target = Math.max(1, organ.getCount()) * INCREASE_PER_STACK;
+        double delta = target - previous;
+        if (delta != 0.0) {
+            channel.adjust(delta);
+            ledger.adjust(organ, XUE_DAO_INCREASE_EFFECT, delta);
+        }
+    }
+}

--- a/src/main/resources/assets/chestcavity/lang/zh_cn.json
+++ b/src/main/resources/assets/chestcavity/lang/zh_cn.json
@@ -74,6 +74,8 @@
   "item.chestcavity.vuld_cleaver": "Vuld 剁刀",
   "item.guzhenren.xie_di_gu": "血滴蛊",
   "item.guzhenren.rou_bai_gu": "肉白骨",
+  "item.guzhenren.shui_ti_gu": "水体蛊",
+  "item.guzhenren.xueqigu": "血气蛊",
   "item.chestcavity.appendix": "阑尾",
   "item.chestcavity.heart": "心脏",
   "item.chestcavity.intestine": "肠道",

--- a/src/main/resources/data/chestcavity/organs/guzhenren/human/shui_ti_gu.json
+++ b/src/main/resources/data/chestcavity/organs/guzhenren/human/shui_ti_gu.json
@@ -1,0 +1,8 @@
+{
+  "itemID": "guzhenren:shui_ti_gu",
+  "organScores": [
+    {"id":"chestcavity:strength","value": "12"},
+    {"id":"chestcavity:speed","value": "12"},
+    {"id":"chestcavity:defense","value": "0.5"}
+  ]
+}

--- a/src/main/resources/data/chestcavity/organs/guzhenren/human/xueqigu.json
+++ b/src/main/resources/data/chestcavity/organs/guzhenren/human/xueqigu.json
@@ -1,0 +1,7 @@
+{
+  "itemID": "guzhenren:xueqigu",
+  "organScores": [
+    {"id":"chestcavity:filtration","value": "3"},
+    {"id":"chestcavity:defense","value": "0.5"}
+  ]
+}


### PR DESCRIPTION
## Summary
- implement Shui Ti Gu behaviour to consume zhenyuan, grant water-path bonuses, and recharge Shuishengu shields
- add Xueqigu behaviour that restores jingli, heals, and periodically drains health while contributing to blood-path increase
- register and localise the new organs with their organ-score definitions

## Testing
- ./gradlew compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dd2188f2c483268f6b4fc9be5954ed