### PR TITLE
Add Quan Yong Ming Gu water-path organ

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shui_dao/ShuiDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shui_dao/ShuiDaoOrganRegistry.java
@@ -2,6 +2,7 @@ package net.tigereye.chestcavity.compat.guzhenren.item.shui_dao;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.behavior.LingXianguOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.behavior.QuanYongMingGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.behavior.ShuiTiGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
 
@@ -18,6 +19,8 @@ public final class ShuiDaoOrganRegistry {
             ResourceLocation.fromNamespaceAndPath(MOD_ID, "ling_xian_gu");
     private static final ResourceLocation SHUI_TI_GU_ID =
             ResourceLocation.fromNamespaceAndPath(MOD_ID, "shui_ti_gu");
+    private static final ResourceLocation QUAN_YONG_MING_GU_ID =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "quan_yong_ming_gu");
 
     private static final List<OrganIntegrationSpec> SPECS = List.of(
             OrganIntegrationSpec.builder(LING_XIAN_GU_ID)
@@ -29,6 +32,12 @@ public final class ShuiDaoOrganRegistry {
                     .addRemovalListener(ShuiTiGuOrganBehavior.INSTANCE)
                     .ensureAttached(ShuiTiGuOrganBehavior.INSTANCE::ensureAttached)
                     .onEquip(ShuiTiGuOrganBehavior.INSTANCE::onEquip)
+                    .build(),
+            OrganIntegrationSpec.builder(QUAN_YONG_MING_GU_ID)
+                    .addSlowTickListener(QuanYongMingGuOrganBehavior.INSTANCE)
+                    .addRemovalListener(QuanYongMingGuOrganBehavior.INSTANCE)
+                    .ensureAttached(QuanYongMingGuOrganBehavior.INSTANCE::ensureAttached)
+                    .onEquip(QuanYongMingGuOrganBehavior.INSTANCE::onEquip)
                     .build()
     );
 

--- a/src/main/resources/assets/chestcavity/lang/en_us.json
+++ b/src/main/resources/assets/chestcavity/lang/en_us.json
@@ -83,6 +83,7 @@
     "item.chestcavity.vuld_cleaver": "Vuld Cleaver",
     "item.guzhenren.xie_di_gu": "Blood Drop Gu",
     "item.guzhenren.rou_bai_gu": "Rou Bai Gu",
+    "item.guzhenren.quan_yong_ming_gu": "Spring Surge Life Gu",
     "item.chestcavity.appendix": "Appendix",
     "item.chestcavity.heart": "Heart",
     "item.chestcavity.intestine": "Intestine",

--- a/src/main/resources/assets/chestcavity/lang/zh_cn.json
+++ b/src/main/resources/assets/chestcavity/lang/zh_cn.json
@@ -75,6 +75,7 @@
   "item.guzhenren.xie_di_gu": "血滴蛊",
   "item.guzhenren.rou_bai_gu": "肉白骨",
   "item.guzhenren.shui_ti_gu": "水体蛊",
+  "item.guzhenren.quan_yong_ming_gu": "泉涌命蛊",
   "item.guzhenren.xueqigu": "血气蛊",
   "item.chestcavity.appendix": "阑尾",
   "item.chestcavity.heart": "心脏",

--- a/src/main/resources/data/chestcavity/organs/guzhenren/human/quan_yong_ming_gu.json
+++ b/src/main/resources/data/chestcavity/organs/guzhenren/human/quan_yong_ming_gu.json
@@ -1,0 +1,6 @@
+{
+  "itemID": "guzhenren:quan_yong_ming_gu",
+  "organScores": [
+    {"id":"chestcavity:health","value": "2"}
+  ]
+}


### PR DESCRIPTION
## Summary
- register the Quan Yong Ming Gu organ with the Shui Dao integration and supply its slow tick behaviour
- grant water-path increase bonuses, per-second healing and jingli gains, zhenyuan upkeep, and Shui Ti Gu absorption synergy via the new behaviour
- add the datapack organ definition and localisation strings for the new item

## Testing
- `./gradlew compileJava`


------
https://chatgpt.com/codex/tasks/task_e_68de74b890208326a4c441a2154c4c1d