### PR TITLE
Add Le Gu Dun Gu organ behavior and ability

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoClientAbilities.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoClientAbilities.java
@@ -1,6 +1,7 @@
 package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao;
 
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.LeGuDunGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.LuoXuanGuQiangguOrganBehavior;
 import net.tigereye.chestcavity.registration.CCKeybindings;
 
@@ -14,6 +15,9 @@ public final class GuDaoClientAbilities {
     public static void onClientSetup(FMLClientSetupEvent event) {
         if (!CCKeybindings.ATTACK_ABILITY_LIST.contains(LuoXuanGuQiangguOrganBehavior.ABILITY_ID)) {
             CCKeybindings.ATTACK_ABILITY_LIST.add(LuoXuanGuQiangguOrganBehavior.ABILITY_ID);
+        }
+        if (!CCKeybindings.ATTACK_ABILITY_LIST.contains(LeGuDunGuOrganBehavior.ABILITY_ID)) {
+            CCKeybindings.ATTACK_ABILITY_LIST.add(LeGuDunGuOrganBehavior.ABILITY_ID);
         }
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/GuDaoOrganRegistry.java
@@ -6,6 +6,7 @@ import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.GuQiangguO
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.GuzhuguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.HuGuguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.JingtieguguOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.LeGuDunGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.LuoXuanGuQiangguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.RouBaiguOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior.TieGuGuOrganBehavior;
@@ -31,6 +32,7 @@ public final class GuDaoOrganRegistry {
     private static final ResourceLocation TIGER_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "hugugu");
     private static final ResourceLocation JADE_BONE_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "yu_gu_gu"); // 新增玉骨蛊
     private static final ResourceLocation ROU_BAI_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "rou_bai_gu");
+    private static final ResourceLocation RIB_SHIELD_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "le_gu_dun_gu");
     private static final List<OrganIntegrationSpec> SPECS;
 
     static {
@@ -79,6 +81,12 @@ public final class GuDaoOrganRegistry {
                         .addSlowTickListener(YuGuguOrganBehavior.INSTANCE)
                         .ensureAttached(YuGuguOrganBehavior.INSTANCE::ensureAttached)
                         .onEquip(YuGuguOrganBehavior.INSTANCE::onEquip)
+                        .build(),
+                OrganIntegrationSpec.builder(RIB_SHIELD_ID)
+                        .addSlowTickListener(LeGuDunGuOrganBehavior.INSTANCE)
+                        .addRemovalListener(LeGuDunGuOrganBehavior.INSTANCE)
+                        .ensureAttached(LeGuDunGuOrganBehavior.INSTANCE::ensureAttached)
+                        .onEquip(LeGuDunGuOrganBehavior.INSTANCE::onEquip)
                         .build(),
                 OrganIntegrationSpec.builder(ROU_BAI_GU_ID)
                         .addSlowTickListener(RouBaiguOrganBehavior.INSTANCE)

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/LeGuDunGuOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/gu_dao/behavior/LeGuDunGuOrganBehavior.java
@@ -1,0 +1,297 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.behavior;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.Mth;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.AbstractGuzhenrenOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.OrganState;
+import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.linkage.IncreaseEffectLedger;
+import net.tigereye.chestcavity.linkage.LinkageChannel;
+import net.tigereye.chestcavity.linkage.LinkageManager;
+import net.tigereye.chestcavity.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.listeners.OrganActivationListeners;
+import net.tigereye.chestcavity.listeners.OrganRemovalContext;
+import net.tigereye.chestcavity.listeners.OrganRemovalListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.util.NetworkUtil;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+/**
+ * Behaviour for 肋骨盾蛊 – a defensive bone Gu that fuels bone growth, grants increase effect and
+ * stores "不屈" stacks for the Bone Guard active ability.
+ */
+public final class LeGuDunGuOrganBehavior extends AbstractGuzhenrenOrganBehavior
+        implements OrganSlowTickListener, OrganRemovalListener, IncreaseEffectContributor {
+
+    public static final LeGuDunGuOrganBehavior INSTANCE = new LeGuDunGuOrganBehavior();
+
+    private static final String MOD_ID = "guzhenren";
+
+    private static final ResourceLocation ORGAN_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "le_gu_dun_gu");
+    public static final ResourceLocation ABILITY_ID = ORGAN_ID;
+
+    private static final ResourceLocation BONE_GROWTH_CHANNEL =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/bone_growth");
+    private static final ResourceLocation GU_DAO_INCREASE_CHANNEL =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/gu_dao_increase_effect");
+
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    private static final String STATE_ROOT = "LeGuDunGu";
+    private static final String BU_QU_KEY = "BuQu";
+
+    private static final double BONE_GROWTH_PER_SECOND = 60.0;
+    private static final double GU_DAO_INCREASE_PER_STACK = 0.08;
+    private static final int MAX_EFFECTIVE_STACKS = 1;
+    private static final int MAX_BU_QU = 10;
+
+    private static final double BASE_ZHENYUAN_COST_PER_SECOND = 200.0;
+    private static final int INVULN_DURATION_TICKS = 40;
+
+    static {
+        OrganActivationListeners.register(ABILITY_ID, LeGuDunGuOrganBehavior::activateAbility);
+    }
+
+    private LeGuDunGuOrganBehavior() {
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (entity == null || entity.level().isClientSide()) {
+            return;
+        }
+
+        boolean primary = isPrimaryOrgan(cc, organ);
+        refreshIncreaseContribution(cc, organ, primary);
+
+        OrganState state = organState(organ, STATE_ROOT);
+        if (!primary) {
+            resetBuQuIfNeeded(cc, organ, state);
+            return;
+        }
+
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        ensureChannel(context, BONE_GROWTH_CHANNEL).addPolicy(NON_NEGATIVE).adjust(BONE_GROWTH_PER_SECOND);
+
+        int current = clampBuQu(state.getInt(BU_QU_KEY, 0));
+        if (current < MAX_BU_QU) {
+            OrganState.Change<Integer> change = state.setInt(
+                    BU_QU_KEY,
+                    current + 1,
+                    value -> clampBuQu(value),
+                    0
+            );
+            if (change.changed()) {
+                sendSlotUpdate(cc, organ);
+            }
+        } else if (current != state.getInt(BU_QU_KEY, 0)) {
+            state.setInt(BU_QU_KEY, current, value -> clampBuQu(value), 0);
+        }
+    }
+
+    public void onEquip(ChestCavityInstance cc, ItemStack organ, List<OrganRemovalContext> staleRemovalContexts) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        RemovalRegistration registration = registerRemovalHook(cc, organ, this, staleRemovalContexts);
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        ledger.registerContributor(organ, this, GU_DAO_INCREASE_CHANNEL);
+        refreshIncreaseContribution(cc, organ, isPrimaryOrgan(cc, organ));
+        if (!registration.alreadyRegistered() && ChestCavity.LOGGER.isDebugEnabled()) {
+            ChestCavity.LOGGER.debug("[compat/guzhenren][le_gu_dun_gu] registered removal hook for {}", describeStack(organ));
+        }
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        if (cc == null) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        ensureChannel(context, BONE_GROWTH_CHANNEL).addPolicy(NON_NEGATIVE);
+        ensureChannel(context, GU_DAO_INCREASE_CHANNEL).addPolicy(NON_NEGATIVE);
+    }
+
+    @Override
+    public void onRemoved(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        double removed = ledger.remove(organ, GU_DAO_INCREASE_CHANNEL);
+        ledger.unregisterContributor(organ);
+        if (removed != 0.0) {
+            ensureChannel(context, GU_DAO_INCREASE_CHANNEL).addPolicy(NON_NEGATIVE).adjust(-removed);
+        }
+        ledger.verifyAndRebuildIfNeeded();
+        organState(organ, STATE_ROOT).setInt(BU_QU_KEY, 0, value -> 0, 0);
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        if (cc == null || organ == null || organ.isEmpty() || registrar == null) {
+            return;
+        }
+        boolean active = isPrimaryOrgan(cc, organ);
+        int effectiveStacks = active ? Math.min(MAX_EFFECTIVE_STACKS, Math.max(1, organ.getCount())) : 0;
+        double effect = effectiveStacks * GU_DAO_INCREASE_PER_STACK;
+        registrar.record(GU_DAO_INCREASE_CHANNEL, effectiveStacks, effect);
+    }
+
+    private static void activateAbility(LivingEntity entity, ChestCavityInstance cc) {
+        if (!(entity instanceof ServerPlayer player) || entity.level().isClientSide()) {
+            return;
+        }
+        INSTANCE.tryActivateBoneGuard(player, cc);
+    }
+
+    private void tryActivateBoneGuard(ServerPlayer player, ChestCavityInstance cc) {
+        if (player == null || cc == null || cc.inventory == null) {
+            return;
+        }
+        ItemStack organ = findPrimaryOrgan(cc);
+        if (organ.isEmpty()) {
+            return;
+        }
+        OrganState state = organState(organ, STATE_ROOT);
+        int buQu = clampBuQu(state.getInt(BU_QU_KEY, 0));
+        if (buQu < MAX_BU_QU) {
+            return;
+        }
+
+        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+        if (handleOpt.isEmpty()) {
+            return;
+        }
+
+        double durationSeconds = INVULN_DURATION_TICKS / 20.0;
+        double totalCost = BASE_ZHENYUAN_COST_PER_SECOND * durationSeconds;
+        OptionalDouble costResult = handleOpt.get().consumeScaledZhenyuan(totalCost);
+        if (costResult.isEmpty()) {
+            return;
+        }
+
+        applyBoneGuardInvulnerability(player);
+        OrganState.Change<Integer> change = state.setInt(BU_QU_KEY, 0, value -> 0, 0);
+        if (change.changed()) {
+            sendSlotUpdate(cc, organ);
+        } else {
+            NetworkUtil.sendOrganSlotUpdate(cc, organ);
+        }
+    }
+
+    private void applyBoneGuardInvulnerability(ServerPlayer player) {
+        player.invulnerableTime = Math.max(player.invulnerableTime, INVULN_DURATION_TICKS);
+        player.hurtTime = 0;
+        player.level().playSound(
+                null,
+                player.getX(),
+                player.getY(),
+                player.getZ(),
+                SoundEvents.SHIELD_BLOCK,
+                SoundSource.PLAYERS,
+                1.0f,
+                0.85f + player.getRandom().nextFloat() * 0.3f
+        );
+        player.addEffect(new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, INVULN_DURATION_TICKS, 4, false, true, true));
+    }
+
+    private void refreshIncreaseContribution(ChestCavityInstance cc, ItemStack organ, boolean active) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        LinkageChannel channel = ensureChannel(context, GU_DAO_INCREASE_CHANNEL).addPolicy(NON_NEGATIVE);
+
+        double target = active
+                ? Math.min(MAX_EFFECTIVE_STACKS, Math.max(1, organ.getCount())) * GU_DAO_INCREASE_PER_STACK
+                : 0.0;
+        double previous = ledger.adjust(organ, GU_DAO_INCREASE_CHANNEL, 0.0);
+        double delta = target - previous;
+        if (delta != 0.0) {
+            channel.adjust(delta);
+            ledger.adjust(organ, GU_DAO_INCREASE_CHANNEL, delta);
+        }
+    }
+
+    private void resetBuQuIfNeeded(ChestCavityInstance cc, ItemStack organ, OrganState state) {
+        if (state == null) {
+            return;
+        }
+        int current = state.getInt(BU_QU_KEY, 0);
+        if (current != 0) {
+            OrganState.Change<Integer> change = state.setInt(BU_QU_KEY, 0, value -> 0, 0);
+            if (change.changed()) {
+                sendSlotUpdate(cc, organ);
+            }
+        }
+    }
+
+    private static int clampBuQu(int value) {
+        return Mth.clamp(value, 0, MAX_BU_QU);
+    }
+
+    private static boolean isPrimaryOrgan(ChestCavityInstance cc, ItemStack organ) {
+        if (cc == null || cc.inventory == null || organ == null || organ.isEmpty()) {
+            return false;
+        }
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (stack == null || stack.isEmpty()) {
+                continue;
+            }
+            if (!matchesOrgan(stack, ORGAN_ID)) {
+                continue;
+            }
+            return stack == organ;
+        }
+        return false;
+    }
+
+    private static ItemStack findPrimaryOrgan(ChestCavityInstance cc) {
+        if (cc == null || cc.inventory == null) {
+            return ItemStack.EMPTY;
+        }
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (stack == null || stack.isEmpty()) {
+                continue;
+            }
+            if (matchesOrgan(stack, ORGAN_ID)) {
+                return stack;
+            }
+        }
+        return ItemStack.EMPTY;
+    }
+
+    private static boolean matchesOrgan(ItemStack stack, ResourceLocation organId) {
+        if (stack == null || stack.isEmpty() || organId == null) {
+            return false;
+        }
+        ResourceLocation id = net.minecraft.core.registries.BuiltInRegistries.ITEM.getKey(stack.getItem());
+        return organId.equals(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated behaviour for the Guzhenren rib shield gu that grants bone growth, gu dao increase effect and manages the Bone Guard active ability
- register the rib shield gu with the bone-path organ registry and expose its attack ability on the client hotkey list

## Testing
- ./gradlew compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68de77d6590c8326966bcd1ac37fdf96