### PR TITLE
Support non-player Quan Yong Ming Gu effects

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shui_dao/ShuiDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shui_dao/ShuiDaoOrganRegistry.java
@@ -2,6 +2,7 @@ package net.tigereye.chestcavity.compat.guzhenren.item.shui_dao;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.behavior.LingXianguOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.behavior.QuanYongMingGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.behavior.ShuiTiGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
 
@@ -18,6 +19,8 @@ public final class ShuiDaoOrganRegistry {
             ResourceLocation.fromNamespaceAndPath(MOD_ID, "ling_xian_gu");
     private static final ResourceLocation SHUI_TI_GU_ID =
             ResourceLocation.fromNamespaceAndPath(MOD_ID, "shui_ti_gu");
+    private static final ResourceLocation QUAN_YONG_MING_GU_ID =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "quan_yong_ming_gu");
 
     private static final List<OrganIntegrationSpec> SPECS = List.of(
             OrganIntegrationSpec.builder(LING_XIAN_GU_ID)
@@ -29,6 +32,12 @@ public final class ShuiDaoOrganRegistry {
                     .addRemovalListener(ShuiTiGuOrganBehavior.INSTANCE)
                     .ensureAttached(ShuiTiGuOrganBehavior.INSTANCE::ensureAttached)
                     .onEquip(ShuiTiGuOrganBehavior.INSTANCE::onEquip)
+                    .build(),
+            OrganIntegrationSpec.builder(QUAN_YONG_MING_GU_ID)
+                    .addSlowTickListener(QuanYongMingGuOrganBehavior.INSTANCE)
+                    .addRemovalListener(QuanYongMingGuOrganBehavior.INSTANCE)
+                    .ensureAttached(QuanYongMingGuOrganBehavior.INSTANCE::ensureAttached)
+                    .onEquip(QuanYongMingGuOrganBehavior.INSTANCE::onEquip)
                     .build()
     );
 

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shui_dao/behavior/QuanYongMingGuOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/shui_dao/behavior/QuanYongMingGuOrganBehavior.java
@@ -1,0 +1,240 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.behavior;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.AbstractGuzhenrenOrganBehavior;
+import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.guzhenren.util.GuzhenrenResourceCostHelper;
+import net.tigereye.chestcavity.guzhenren.util.GuzhenrenResourceCostHelper.ConsumptionResult;
+import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.linkage.IncreaseEffectContributor;
+import net.tigereye.chestcavity.linkage.IncreaseEffectLedger;
+import net.tigereye.chestcavity.linkage.LinkageChannel;
+import net.tigereye.chestcavity.linkage.LinkageManager;
+import net.tigereye.chestcavity.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.listeners.OrganRemovalContext;
+import net.tigereye.chestcavity.listeners.OrganRemovalListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.util.ChestCavityUtil;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Behaviour for 泉涌命蛊 (Quan Yong Ming Gu).
+ */
+public final class QuanYongMingGuOrganBehavior extends AbstractGuzhenrenOrganBehavior
+        implements OrganSlowTickListener, OrganRemovalListener, IncreaseEffectContributor {
+
+    public static final QuanYongMingGuOrganBehavior INSTANCE = new QuanYongMingGuOrganBehavior();
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation ORGAN_ID =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "quan_yong_ming_gu");
+    private static final ResourceLocation SHUI_TI_GU_ID =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "shui_ti_gu");
+    private static final ResourceLocation SHUI_DAO_INCREASE_EFFECT =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/shui_dao_increase_effect");
+
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    private static final double INCREASE_EFFECT_BONUS = 0.30;
+    private static final double ZHENYUAN_COST_PER_SECOND = 800.0;
+    private static final double JINGLI_GAIN_PER_SECOND = 5.0;
+    private static final double HEALTH_PERCENT_PER_SECOND = 0.01;
+    private static final float PURE_WATER_ABSORPTION = 10.0f;
+
+    private QuanYongMingGuOrganBehavior() {
+    }
+
+    public void onEquip(ChestCavityInstance cc, ItemStack organ, List<OrganRemovalContext> staleRemovalContexts) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID)) {
+            return;
+        }
+
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        context.getOrCreateChannel(SHUI_DAO_INCREASE_EFFECT).addPolicy(NON_NEGATIVE);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        ledger.registerContributor(organ, this, SHUI_DAO_INCREASE_EFFECT);
+
+        registerRemovalHook(cc, organ, this, staleRemovalContexts);
+        refreshIncreaseContribution(cc, organ, isPrimaryOrgan(cc, organ));
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (entity == null || entity.level().isClientSide()) {
+            return;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID)) {
+            return;
+        }
+
+        boolean primary = isPrimaryOrgan(cc, organ);
+        refreshIncreaseContribution(cc, organ, primary);
+        if (!primary) {
+            return;
+        }
+        if (cc == null || !entity.isAlive()) {
+            return;
+        }
+
+        int stackCount = Math.max(1, organ.getCount());
+
+        if (entity instanceof Player player) {
+            double zhenyuanCost = ZHENYUAN_COST_PER_SECOND * stackCount;
+            ConsumptionResult result = GuzhenrenResourceCostHelper.consumeStrict(player, zhenyuanCost, 0.0);
+            if (!result.succeeded()) {
+                return;
+            }
+
+            applyHealing(entity, stackCount);
+            grantJingli(player, stackCount);
+
+            if (hasShuiTiGu(cc, organ)) {
+                ensurePureWaterAbsorption(entity, stackCount);
+            }
+            return;
+        }
+
+        applyHealing(entity, stackCount);
+
+        if (hasShuiTiGu(cc, organ)) {
+            ensurePureWaterAbsorption(entity, stackCount);
+        }
+    }
+
+    @Override
+    public void onRemoved(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID)) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        double removed = ledger.remove(organ, SHUI_DAO_INCREASE_EFFECT);
+        ledger.unregisterContributor(organ);
+        context.lookupChannel(SHUI_DAO_INCREASE_EFFECT)
+                .ifPresent(channel -> channel.adjust(-removed));
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        if (cc == null) {
+            return;
+        }
+        LinkageManager.getContext(cc)
+                .getOrCreateChannel(SHUI_DAO_INCREASE_EFFECT)
+                .addPolicy(NON_NEGATIVE);
+    }
+
+    @Override
+    public void rebuildIncreaseEffects(
+            ChestCavityInstance cc,
+            ActiveLinkageContext context,
+            ItemStack organ,
+            IncreaseEffectLedger.Registrar registrar
+    ) {
+        if (organ == null || organ.isEmpty()) {
+            return;
+        }
+        boolean primary = isPrimaryOrgan(cc, organ);
+        double effect = primary ? INCREASE_EFFECT_BONUS : 0.0;
+        registrar.record(SHUI_DAO_INCREASE_EFFECT, Math.max(1, organ.getCount()), effect);
+    }
+
+    private void applyHealing(LivingEntity entity, int stackCount) {
+        if (HEALTH_PERCENT_PER_SECOND <= 0.0) {
+            return;
+        }
+        float maxHealth = entity.getMaxHealth();
+        if (maxHealth <= 0.0f || entity.getHealth() >= maxHealth) {
+            return;
+        }
+        float healAmount = (float) (maxHealth * HEALTH_PERCENT_PER_SECOND * stackCount);
+        if (healAmount <= 0.0f) {
+            return;
+        }
+        ChestCavityUtil.runWithOrganHeal(() -> entity.heal(healAmount));
+    }
+
+    private void grantJingli(Player player, int stackCount) {
+        if (JINGLI_GAIN_PER_SECOND <= 0.0) {
+            return;
+        }
+        double delta = JINGLI_GAIN_PER_SECOND * stackCount;
+        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+        handleOpt.ifPresent(handle -> handle.adjustJingli(delta, true));
+    }
+
+    private void ensurePureWaterAbsorption(LivingEntity entity, int stackCount) {
+        float target = PURE_WATER_ABSORPTION * Math.max(1, stackCount);
+        if (target <= 0.0f) {
+            return;
+        }
+        float current = entity.getAbsorptionAmount();
+        if (current + 0.01f >= target) {
+            return;
+        }
+        entity.setAbsorptionAmount(target);
+    }
+
+    private void refreshIncreaseContribution(ChestCavityInstance cc, ItemStack organ, boolean primary) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        LinkageChannel channel = context.getOrCreateChannel(SHUI_DAO_INCREASE_EFFECT).addPolicy(NON_NEGATIVE);
+        IncreaseEffectLedger ledger = context.increaseEffects();
+        double previous = ledger.adjust(organ, SHUI_DAO_INCREASE_EFFECT, 0.0);
+        double target = primary ? INCREASE_EFFECT_BONUS : 0.0;
+        double delta = target - previous;
+        if (delta == 0.0) {
+            return;
+        }
+        channel.adjust(delta);
+        ledger.adjust(organ, SHUI_DAO_INCREASE_EFFECT, delta);
+    }
+
+    private boolean isPrimaryOrgan(ChestCavityInstance cc, ItemStack organ) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return false;
+        }
+        int slotIndex = ChestCavityUtil.findOrganSlot(cc, organ);
+        if (slotIndex < 0) {
+            return true;
+        }
+        for (int i = 0; i < slotIndex; i++) {
+            ItemStack candidate = cc.inventory.getItem(i);
+            if (matchesOrgan(candidate, ORGAN_ID)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean hasShuiTiGu(ChestCavityInstance cc, ItemStack self) {
+        if (cc == null) {
+            return false;
+        }
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack candidate = cc.inventory.getItem(i);
+            if (candidate == self || candidate == null || candidate.isEmpty()) {
+                continue;
+            }
+            if (matchesOrgan(candidate, SHUI_TI_GU_ID)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/src/main/resources/assets/chestcavity/lang/en_us.json
+++ b/src/main/resources/assets/chestcavity/lang/en_us.json
@@ -83,6 +83,7 @@
     "item.chestcavity.vuld_cleaver": "Vuld Cleaver",
     "item.guzhenren.xie_di_gu": "Blood Drop Gu",
     "item.guzhenren.rou_bai_gu": "Rou Bai Gu",
+    "item.guzhenren.quan_yong_ming_gu": "Spring Surge Life Gu",
     "item.chestcavity.appendix": "Appendix",
     "item.chestcavity.heart": "Heart",
     "item.chestcavity.intestine": "Intestine",

--- a/src/main/resources/assets/chestcavity/lang/zh_cn.json
+++ b/src/main/resources/assets/chestcavity/lang/zh_cn.json
@@ -75,6 +75,7 @@
   "item.guzhenren.xie_di_gu": "血滴蛊",
   "item.guzhenren.rou_bai_gu": "肉白骨",
   "item.guzhenren.shui_ti_gu": "水体蛊",
+  "item.guzhenren.quan_yong_ming_gu": "泉涌命蛊",
   "item.guzhenren.xueqigu": "血气蛊",
   "item.chestcavity.appendix": "阑尾",
   "item.chestcavity.heart": "心脏",

--- a/src/main/resources/data/chestcavity/organs/guzhenren/human/quan_yong_ming_gu.json
+++ b/src/main/resources/data/chestcavity/organs/guzhenren/human/quan_yong_ming_gu.json
@@ -1,0 +1,6 @@
+{
+  "itemID": "guzhenren:quan_yong_ming_gu",
+  "organScores": [
+    {"id":"chestcavity:health","value": "2"}
+  ]
+}


### PR DESCRIPTION
## Summary
- let Quan Yong Ming Gu skip zhenyuan upkeep on non-player holders while still refreshing Shui Dao, healing, and absorption
- restrict Jingli restoration to player entities that successfully pay the upkeep

## Testing
- `./gradlew compileJava --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68de74b890208326a4c441a2154c4c1d