### PR TITLE
Add Guzhenren organ score resource syncing

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/GuzhenrenOrganScoreEffects.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/GuzhenrenOrganScoreEffects.java
@@ -1,0 +1,151 @@
+package net.tigereye.chestcavity.compat.guzhenren.module;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.listeners.OrganScoreEffects;
+import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Registers organ score effects that proxy Guzhenren resource adjustments through
+ * {@link GuzhenrenResourceBridge}. Only applies to player-owned chest cavities.
+ */
+public final class GuzhenrenOrganScoreEffects {
+
+    private static final double EPSILON = 1.0E-6;
+    private static boolean registered;
+
+    private GuzhenrenOrganScoreEffects() {
+    }
+
+    public static synchronized void bootstrap() {
+        if (registered) {
+            return;
+        }
+        registered = true;
+
+        registerWithMax("zhenyuan", "zuida_zhenyuan");
+        registerMaxField("zuida_zhenyuan", "zhenyuan", "zuida_zhenyuan");
+        registerSimple("shouyuan");
+        registerWithMax("jingli", "zuida_jingli", "zuida_jingli");
+        registerMaxField("zuida_jingli", "jingli", "zuida_jingli");
+        registerSimple("tizhi");
+        registerWithMax("hunpo", "zuida_hunpo");
+        registerMaxField("zuida_hunpo", "hunpo", "zuida_hunpo");
+        registerWithMax("hunpo_kangxing", "hunpo_kangxing_shangxian", "hunpo_stability");
+        registerMaxField("hunpo_kangxing_shangxian", "hunpo_kangxing", "hunpo_kangxing_shangxian", "hunpo_stability_max");
+        registerWithMax("niantou", "niantou_zhida", "niantou_zuida");
+        registerMaxField("niantou_zhida", "niantou", "niantou_zhida", "niantou_zuida");
+        registerSimple("renqi");
+        registerSimple("qiyun");
+        registerSimple("daode");
+
+        registerSimple("daohen_jindao");
+        registerSimple("daohen_shuidao");
+        registerSimple("daohen_mudao");
+        registerSimple("daohen_yandao");
+        registerSimple("daohen_tudao");
+        registerSimple("daohen_fengdao");
+        registerSimple("daohen_guangdao");
+        registerSimple("daohen_andao");
+        registerSimple("daohen_leidao");
+        registerSimple("daohen_dudao");
+        registerSimple("daohen_yudao");
+        registerSimple("dahen_zhoudao", "daohen_zhoudao");
+        registerSimple("dahen_rendao", "daohen_rendao");
+        registerSimple("dahen_tiandao", "daohen_tiandao");
+        registerSimple("daohen_bingxuedao", "daohen_bingxue");
+        registerSimple("dahen_qidao", "daohen_qidao");
+        registerSimple("dahen_nudao", "daohen_nudao");
+        registerSimple("dahen_zhidao", "daohen_zhidao");
+        registerSimple("dahen_xingdao", "daohen_xingdao");
+        registerSimple("dahen_zhendao", "daohen_zhendao");
+        registerSimple("daohen_yingdao");
+        registerSimple("daohen_lvdao");
+        registerSimple("dahen_liandao", "daohen_liandao");
+        registerSimple("daohen_lidao");
+        registerSimple("daohen_shidao");
+        registerSimple("daohen_huadao");
+        registerSimple("daohen_toudao");
+        registerSimple("daohen_yundao2", "daohen_yundao", "daohen_yundao_cloud");
+        registerSimple("daohen_xindao");
+        registerSimple("daohen_yindao");
+        registerSimple("daohen_gudao");
+        registerSimple("daohen_xudao");
+        registerSimple("daohen_jindao2", "daohen_jindao", "daohen_jindao_forbidden");
+        registerSimple("daohen_jiandao");
+        registerSimple("daohen_daodao");
+        registerSimple("daohen_hundao");
+        registerSimple("daohen_dandao");
+        registerSimple("daohen_xuedao");
+        registerSimple("daohen_huandao");
+        registerSimple("daohen_yuedao");
+        registerSimple("daohen_mengdao");
+        registerSimple("daohen_bingdao");
+        registerSimple("daohen_bianhuadao");
+    }
+
+    private static void registerSimple(String canonicalField, String... aliases) {
+        registerEffect(canonicalField, true, null, null, aliases);
+    }
+
+    private static void registerWithMax(String canonicalField, String maxField, String... aliases) {
+        registerEffect(canonicalField, true, maxField, null, aliases);
+    }
+
+    private static void registerMaxField(String canonicalField, String baseField, String... aliases) {
+        registerEffect(canonicalField, true, null, baseField, aliases);
+    }
+
+    private static void registerEffect(
+            String canonicalField,
+            boolean clampZero,
+            String maxField,
+            String clampBaseField,
+            String... aliases
+    ) {
+        OrganScoreEffects.Effect effect = (entity, chestCavity, previous, current) -> {
+            if (!(entity instanceof Player player) || player.level().isClientSide()) {
+                return;
+            }
+            double delta = current - previous;
+            if (Math.abs(delta) < EPSILON) {
+                return;
+            }
+            GuzhenrenResourceBridge.open(player).ifPresent(handle -> {
+                if (maxField != null && !maxField.isBlank()) {
+                    handle.adjustDouble(canonicalField, delta, clampZero, maxField);
+                } else {
+                    handle.adjustDouble(canonicalField, delta, clampZero);
+                }
+                if (clampBaseField != null && !clampBaseField.isBlank()) {
+                    handle.clampToMax(clampBaseField, canonicalField);
+                }
+            });
+        };
+
+        Set<String> scoreIds = new LinkedHashSet<>();
+        scoreIds.add(canonicalField);
+        if (aliases != null && aliases.length > 0) {
+            scoreIds.addAll(Arrays.asList(aliases));
+        }
+        for (String id : scoreIds) {
+            if (id == null || id.isBlank()) {
+                continue;
+            }
+            registerForId(effect, id.toLowerCase(Locale.ROOT));
+        }
+    }
+
+    private static void registerForId(OrganScoreEffects.Effect effect, String path) {
+        ResourceLocation chestId = ChestCavity.id(path);
+        OrganScoreEffects.register(chestId, effect);
+        ResourceLocation compatId = ResourceLocation.fromNamespaceAndPath("guzhenren", path);
+        OrganScoreEffects.register(compatId, effect);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/guzhenren/GuzhenrenModule.java
+++ b/src/main/java/net/tigereye/chestcavity/guzhenren/GuzhenrenModule.java
@@ -20,6 +20,7 @@ import net.tigereye.chestcavity.guscript.GuScriptModule;
 import net.tigereye.chestcavity.guscript.ability.guzhenren.blood_bone_bomb.BloodBoneBombClient;
 import net.tigereye.chestcavity.guzhenren.network.GuzhenrenNetworkBridge;
 import net.tigereye.chestcavity.compat.guzhenren.module.GuzhenrenIntegrationModule;
+import net.tigereye.chestcavity.compat.guzhenren.module.GuzhenrenOrganScoreEffects;
 import net.tigereye.chestcavity.util.retention.OrganRetentionRules;
 
 import java.util.Objects;
@@ -109,6 +110,7 @@ public final class GuzhenrenModule {
         OrganRetentionRules.registerNamespace(MOD_ID);
         Abilities.bootstrap();
         GuzhenrenIntegrationModule.bootstrap();
+        GuzhenrenOrganScoreEffects.bootstrap();
         GuzhenrenNetworkBridge.bootstrap();
         GuScriptModule.bootstrap();
     }

--- a/src/main/java/net/tigereye/chestcavity/listeners/OrganScoreEffects.java
+++ b/src/main/java/net/tigereye/chestcavity/listeners/OrganScoreEffects.java
@@ -1,0 +1,78 @@
+package net.tigereye.chestcavity.listeners;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Registry for organ score side-effects. This allows compat modules to react when specific
+ * organ score values change without patching {@link OrganUpdateListeners} directly.
+ */
+public final class OrganScoreEffects {
+
+    @FunctionalInterface
+    public interface Effect {
+        void apply(LivingEntity entity, ChestCavityInstance chestCavity, float previousValue, float currentValue);
+    }
+
+    private static final Map<ResourceLocation, Effect> EFFECTS = new LinkedHashMap<>();
+
+    private OrganScoreEffects() {
+    }
+
+    /**
+     * Registers an effect that will be invoked whenever the organ score identified by {@code id}
+     * changes during a chest cavity evaluation pass.
+     */
+    public static synchronized void register(ResourceLocation id, Effect effect) {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(effect, "effect");
+        Effect previous = EFFECTS.put(id, effect);
+        if (previous != null && previous != effect && ChestCavity.LOGGER.isWarnEnabled()) {
+            ChestCavity.LOGGER.warn("Organ score effect for {} replaced: {} -> {}", id, previous.getClass().getName(), effect.getClass().getName());
+        }
+    }
+
+    /**
+     * Applies all registered effects whose tracked organ score changed during the current update pass.
+     */
+    public static void applyAll(LivingEntity entity, ChestCavityInstance chestCavity) {
+        if (entity == null || chestCavity == null) {
+            return;
+        }
+        Map<ResourceLocation, Effect> snapshot;
+        synchronized (OrganScoreEffects.class) {
+            if (EFFECTS.isEmpty()) {
+                return;
+            }
+            snapshot = new LinkedHashMap<>(EFFECTS);
+        }
+        for (Map.Entry<ResourceLocation, Effect> entry : snapshot.entrySet()) {
+            ResourceLocation id = entry.getKey();
+            Effect effect = entry.getValue();
+            float previous = chestCavity.getOldOrganScore(id);
+            float current = chestCavity.getOrganScore(id);
+            if (Float.compare(previous, current) == 0) {
+                continue;
+            }
+            try {
+                effect.apply(entity, chestCavity, previous, current);
+            } catch (Exception exception) {
+                ChestCavity.LOGGER.error("Error applying organ score effect for {}", id, exception);
+            }
+        }
+    }
+
+    /**
+     * Returns an immutable snapshot of the currently registered effects. Primarily intended for tests.
+     */
+    public static synchronized Map<ResourceLocation, Effect> snapshot() {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(EFFECTS));
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/listeners/OrganUpdateListeners.java
+++ b/src/main/java/net/tigereye/chestcavity/listeners/OrganUpdateListeners.java
@@ -28,6 +28,7 @@ public class OrganUpdateListeners {
         UpdateSpine(entity, cc);
         UpdateKnockbackResistance(entity, cc);
         UpdateIncompatibility(entity, cc);
+        OrganScoreEffects.applyAll(entity, cc);
 
     }
 


### PR DESCRIPTION
## Summary
- add an OrganScoreEffects registry so organ score changes can trigger modular side-effects
- hook Guzhenren organ score entries into the registry to adjust player resources through GuzhenrenResourceBridge
- bootstrap the new effects during Guzhenren compat setup so they apply automatically for players only

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68deef9f0a448326ba8c1a57a5273033