### PR TITLE
Add Hun Dao organ scaffolding with beast soul storage API

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/HunDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/HunDaoOrganRegistry.java
@@ -1,0 +1,33 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.hun_dao;
+
+import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.behavior.HunDaoSoulBeastBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
+
+/**
+ * Registry wiring for 魂道（Hun Dao） organs.
+ */
+public final class HunDaoOrganRegistry {
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation XIAO_HUN_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "xiao_hun_gu");
+
+    private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(XIAO_HUN_GU_ID)
+                    .addSlowTickListener(HunDaoSoulBeastBehavior.INSTANCE)
+                    .addOnHitListener(HunDaoSoulBeastBehavior.INSTANCE)
+                    .addRemovalListener(HunDaoSoulBeastBehavior.INSTANCE)
+                    .ensureAttached(HunDaoSoulBeastBehavior.INSTANCE::ensureAttached)
+                    .onEquip(HunDaoSoulBeastBehavior.INSTANCE::onEquip)
+                    .build()
+    );
+
+    private HunDaoOrganRegistry() {
+    }
+
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/behavior/HunDaoSoulBeastBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/behavior/HunDaoSoulBeastBehavior.java
@@ -1,0 +1,198 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.behavior;
+
+import com.mojang.logging.LogUtils;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.DamageTypeTags;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.food.FoodData;
+import net.minecraft.world.item.ItemStack;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.AbstractGuzhenrenOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.OrganState;
+import net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.storage.BeastSoulStorage;
+import net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.storage.OrganBeastSoulStorage;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.linkage.LinkageChannel;
+import net.tigereye.chestcavity.linkage.LinkageManager;
+import net.tigereye.chestcavity.listeners.OrganOnHitListener;
+import net.tigereye.chestcavity.listeners.OrganRemovalContext;
+import net.tigereye.chestcavity.listeners.OrganRemovalListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.util.DoTManager;
+import org.slf4j.Logger;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Behaviour scaffold for 小魂蛊，负责魂兽形态的资源流转与攻击挂钩。
+ */
+public final class HunDaoSoulBeastBehavior extends AbstractGuzhenrenOrganBehavior implements OrganSlowTickListener, OrganOnHitListener, OrganRemovalListener {
+
+    public static final HunDaoSoulBeastBehavior INSTANCE = new HunDaoSoulBeastBehavior();
+
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation HUN_DAO_INCREASE_EFFECT = ResourceLocation.fromNamespaceAndPath(MOD_ID, "linkage/hun_dao_increase_effect");
+
+    private static final double PASSIVE_HUNPO_LEAK = 3.0;
+    private static final double ATTACK_HUNPO_COST = 18.0;
+    private static final double SOUL_FLAME_PERCENT = 0.01;
+    private static final int SOUL_FLAME_DURATION_SECONDS = 5;
+
+    private static final String STATE_ROOT_KEY = "HunDaoSoulBeast";
+    private static final String KEY_BOUND = "bound";
+    private static final String KEY_ACTIVE = "active";
+    private static final String KEY_OWNER_MSB = "owner_msb";
+    private static final String KEY_OWNER_LSB = "owner_lsb";
+    private static final String KEY_BOUND_TIME = "bound_time";
+    private static final String KEY_LAST_SYNC_TICK = "last_sync_tick";
+
+    private final BeastSoulStorage beastSoulStorage = new OrganBeastSoulStorage(STATE_ROOT_KEY);
+
+    private HunDaoSoulBeastBehavior() {
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        if (cc == null) {
+            return;
+        }
+        ActiveLinkageContext context = LinkageManager.getContext(cc);
+        ensureChannel(context, HUN_DAO_INCREASE_EFFECT);
+    }
+
+    public void onEquip(ChestCavityInstance cc, ItemStack organ, List<OrganRemovalContext> staleRemovalContexts) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        registerRemovalHook(cc, organ, this, staleRemovalContexts);
+        ensureAttached(cc);
+        bindOrganState(cc, organ);
+        sendSlotUpdate(cc, organ);
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (!(entity instanceof Player player) || entity.level().isClientSide()) {
+            return;
+        }
+        ensureAttached(cc);
+        ensureActiveState(entity, organ);
+        drainHunpo(player, PASSIVE_HUNPO_LEAK, "passive leak");
+        maintainSatiation(player);
+        OrganState state = organState(organ, STATE_ROOT_KEY);
+        logStateChange(LOGGER, prefix(), organ, KEY_LAST_SYNC_TICK, state.setLong(KEY_LAST_SYNC_TICK, entity.level().getGameTime()));
+    }
+
+    @Override
+    public float onHit(DamageSource source, LivingEntity attacker, LivingEntity target, ChestCavityInstance cc, ItemStack organ, float damage) {
+        if (!(attacker instanceof Player player) || attacker.level().isClientSide()) {
+            return damage;
+        }
+        if (source == null || source.is(DamageTypeTags.IS_PROJECTILE) || target == null || !target.isAlive()) {
+            return damage;
+        }
+        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+        if (handleOpt.isEmpty()) {
+            return damage;
+        }
+        GuzhenrenResourceBridge.ResourceHandle handle = handleOpt.get();
+        double currentHunpo = handle.read("hunpo").orElse(0.0);
+        if (currentHunpo < ATTACK_HUNPO_COST) {
+            LOGGER.debug("{} {} lacks hunpo for soul flame ({} / {})", prefix(), describePlayer(player), format(currentHunpo), format(ATTACK_HUNPO_COST));
+            return damage;
+        }
+        handle.adjustDouble("hunpo", -ATTACK_HUNPO_COST, true, "zuida_hunpo");
+        double maxHunpo = handle.read("zuida_hunpo").orElse(0.0);
+        double efficiency = 1.0;
+        if (cc != null) {
+            ActiveLinkageContext context = LinkageManager.getContext(cc);
+            LinkageChannel channel = ensureChannel(context, HUN_DAO_INCREASE_EFFECT);
+            if (channel != null) {
+                efficiency += Math.max(0.0, channel.get());
+            }
+        }
+        double dotDamage = Math.max(0.0, maxHunpo * SOUL_FLAME_PERCENT * efficiency);
+        if (dotDamage > 0.0) {
+            DoTManager.schedulePerSecond(player, target, dotDamage, SOUL_FLAME_DURATION_SECONDS, null, 0.0f, 0.0f);
+            LOGGER.debug("{} applied soul flame DoT={}s @{} dmg to {}", prefix(), SOUL_FLAME_DURATION_SECONDS, format(dotDamage), target.getName().getString());
+        }
+        return damage;
+    }
+
+    @Override
+    public void onRemoved(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (!(entity instanceof Player player)) {
+            return;
+        }
+        ensureActiveState(entity, organ);
+        LOGGER.debug("{} soul beast organ removed but state retained for {}", prefix(), describePlayer(player));
+    }
+
+    public BeastSoulStorage beastSoulStorage() {
+        return beastSoulStorage;
+    }
+
+    private void bindOrganState(ChestCavityInstance cc, ItemStack organ) {
+        OrganState state = organState(organ, STATE_ROOT_KEY);
+        logStateChange(LOGGER, prefix(), organ, KEY_BOUND, state.setBoolean(KEY_BOUND, true));
+        if (cc.owner != null) {
+            UUID ownerId = cc.owner.getUUID();
+            logStateChange(LOGGER, prefix(), organ, KEY_OWNER_MSB, state.setLong(KEY_OWNER_MSB, ownerId.getMostSignificantBits()));
+            logStateChange(LOGGER, prefix(), organ, KEY_OWNER_LSB, state.setLong(KEY_OWNER_LSB, ownerId.getLeastSignificantBits()));
+            logStateChange(LOGGER, prefix(), organ, KEY_BOUND_TIME, state.setLong(KEY_BOUND_TIME, cc.owner.level().getGameTime()));
+        }
+        logStateChange(LOGGER, prefix(), organ, KEY_ACTIVE, state.setBoolean(KEY_ACTIVE, true));
+    }
+
+    private void ensureActiveState(LivingEntity entity, ItemStack organ) {
+        if (!(entity instanceof Player player) || organ == null || organ.isEmpty()) {
+            return;
+        }
+        OrganState state = organState(organ, STATE_ROOT_KEY);
+        logStateChange(LOGGER, prefix(), organ, KEY_ACTIVE, state.setBoolean(KEY_ACTIVE, true));
+        if (state.getLong(KEY_OWNER_MSB, 0L) == 0L && state.getLong(KEY_OWNER_LSB, 0L) == 0L) {
+            UUID uuid = player.getUUID();
+            logStateChange(LOGGER, prefix(), organ, KEY_OWNER_MSB, state.setLong(KEY_OWNER_MSB, uuid.getMostSignificantBits()));
+            logStateChange(LOGGER, prefix(), organ, KEY_OWNER_LSB, state.setLong(KEY_OWNER_LSB, uuid.getLeastSignificantBits()));
+        }
+    }
+
+    private void drainHunpo(Player player, double amount, String reason) {
+        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+        if (handleOpt.isEmpty()) {
+            return;
+        }
+        GuzhenrenResourceBridge.ResourceHandle handle = handleOpt.get();
+        handle.adjustDouble("hunpo", -amount, true, "zuida_hunpo");
+        LOGGER.trace("{} drained {} hunpo from {} ({})", prefix(), format(amount), describePlayer(player), reason);
+    }
+
+    private void maintainSatiation(Player player) {
+        FoodData foodData = player.getFoodData();
+        if (foodData.getFoodLevel() < 18) {
+            foodData.eat(1, 0.6f);
+        }
+        if (foodData.getSaturationLevel() < foodData.getFoodLevel()) {
+            foodData.eat(0, 0.4f);
+        }
+    }
+
+    private String describePlayer(Player player) {
+        return player.getScoreboardName();
+    }
+
+    private String format(double value) {
+        return String.format(Locale.ROOT, "%.2f", value);
+    }
+
+    private String prefix() {
+        return "[compat/guzhenren][hun_dao]";
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/storage/BeastSoulRecord.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/storage/BeastSoulRecord.java
@@ -1,0 +1,60 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.storage;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable representation of a stored beast soul.
+ * Encapsulates the entity type, raw serialized data and the game time when the soul was captured.
+ */
+public record BeastSoulRecord(ResourceLocation entityTypeId, CompoundTag entityData, long storedGameTime) {
+
+    public BeastSoulRecord {
+        Objects.requireNonNull(entityTypeId, "entityTypeId");
+        entityData = entityData == null ? new CompoundTag() : entityData.copy();
+    }
+
+    /**
+     * Serialises the provided entity into a {@link BeastSoulRecord} snapshot.
+     */
+    public static Optional<BeastSoulRecord> fromEntity(LivingEntity entity, long storedGameTime) {
+        if (entity == null || entity.level().isClientSide()) {
+            return Optional.empty();
+        }
+        ResourceLocation id = EntityType.getKey(entity.getType());
+        if (id == null) {
+            return Optional.empty();
+        }
+        CompoundTag tag = new CompoundTag();
+        entity.saveWithoutId(tag);
+        return Optional.of(new BeastSoulRecord(id, tag, storedGameTime));
+    }
+
+    /**
+     * Attempts to materialise the stored entity in the provided level.
+     * The caller is responsible for positioning and adding the entity to the world.
+     */
+    public Optional<Entity> createEntity(Level level) {
+        if (level == null || entityTypeId == null) {
+            return Optional.empty();
+        }
+        Optional<EntityType<?>> typeOpt = EntityType.byString(entityTypeId.toString());
+        if (typeOpt.isEmpty()) {
+            return Optional.empty();
+        }
+        EntityType<?> type = typeOpt.get();
+        Entity entity = type.create(level);
+        if (entity == null) {
+            return Optional.empty();
+        }
+        entity.load(entityData.copy());
+        return Optional.of(entity);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/storage/BeastSoulStorage.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/storage/BeastSoulStorage.java
@@ -1,0 +1,45 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.storage;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Optional;
+
+/**
+ * Abstraction over how Hun Dao organs capture and release beast souls.
+ * Implementations are responsible for persisting the serialized entity payload on the organ stack.
+ */
+public interface BeastSoulStorage {
+
+    /** @return {@code true} if a beast soul payload is already present on the provided organ. */
+    boolean hasStoredSoul(ItemStack organ);
+
+    /**
+     * Quick validation hook that callers can use before attempting to store a soul.
+     * Implementations may reject certain entity types (players, bosses, etc.).
+     */
+    default boolean canStore(ItemStack organ, LivingEntity entity) {
+        return organ != null && !organ.isEmpty() && entity != null && !(entity instanceof net.minecraft.world.entity.player.Player) && !hasStoredSoul(organ);
+    }
+
+    /**
+     * Serialises the provided entity and saves the payload into the organ stack.
+     *
+     * @param organ          organ stack that will host the payload
+     * @param entity         entity whose soul should be captured
+     * @param storedGameTime timestamp (in game ticks) when the capture occurred
+     * @return the stored record if successful
+     */
+    Optional<BeastSoulRecord> store(ItemStack organ, LivingEntity entity, long storedGameTime);
+
+    /** Returns the stored soul payload without mutating the underlying stack. */
+    Optional<BeastSoulRecord> peek(ItemStack organ);
+
+    /**
+     * Removes and returns the stored payload. Callers can then respawn the entity elsewhere.
+     */
+    Optional<BeastSoulRecord> consume(ItemStack organ);
+
+    /** Deletes any stored payload without returning it. */
+    void clear(ItemStack organ);
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/storage/OrganBeastSoulStorage.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/storage/OrganBeastSoulStorage.java
@@ -1,0 +1,135 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.storage;
+
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.CustomData;
+import net.tigereye.chestcavity.util.NBTWriter;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Default {@link BeastSoulStorage} implementation that persists data into the organ's CustomData payload.
+ */
+public final class OrganBeastSoulStorage implements BeastSoulStorage {
+
+    private static final String DEFAULT_ROOT_KEY = "HunDaoSoulBeast";
+    private static final String STORAGE_KEY = "BeastSoul";
+    private static final String KEY_ENTITY_TYPE = "EntityType";
+    private static final String KEY_ENTITY_DATA = "EntityData";
+    private static final String KEY_STORED_AT = "StoredGameTime";
+
+    private final String rootKey;
+
+    public OrganBeastSoulStorage() {
+        this(DEFAULT_ROOT_KEY);
+    }
+
+    public OrganBeastSoulStorage(String rootKey) {
+        this.rootKey = Objects.requireNonNull(rootKey, "rootKey");
+    }
+
+    @Override
+    public boolean hasStoredSoul(ItemStack organ) {
+        if (organ == null || organ.isEmpty()) {
+            return false;
+        }
+        CustomData data = organ.get(DataComponents.CUSTOM_DATA);
+        if (data == null) {
+            return false;
+        }
+        CompoundTag root = data.copyTag();
+        if (!root.contains(rootKey, Tag.TAG_COMPOUND)) {
+            return false;
+        }
+        CompoundTag state = root.getCompound(rootKey);
+        return state.contains(STORAGE_KEY, Tag.TAG_COMPOUND);
+    }
+
+    @Override
+    public Optional<BeastSoulRecord> store(ItemStack organ, net.minecraft.world.entity.LivingEntity entity, long storedGameTime) {
+        if (!canStore(organ, entity)) {
+            return Optional.empty();
+        }
+        return BeastSoulRecord.fromEntity(entity, storedGameTime).map(record -> {
+            writeRecord(organ, record);
+            return record;
+        });
+    }
+
+    @Override
+    public Optional<BeastSoulRecord> peek(ItemStack organ) {
+        if (organ == null || organ.isEmpty()) {
+            return Optional.empty();
+        }
+        CustomData data = organ.get(DataComponents.CUSTOM_DATA);
+        if (data == null) {
+            return Optional.empty();
+        }
+        CompoundTag root = data.copyTag();
+        if (!root.contains(rootKey, Tag.TAG_COMPOUND)) {
+            return Optional.empty();
+        }
+        CompoundTag state = root.getCompound(rootKey);
+        if (!state.contains(STORAGE_KEY, Tag.TAG_COMPOUND)) {
+            return Optional.empty();
+        }
+        CompoundTag storage = state.getCompound(STORAGE_KEY);
+        if (!storage.contains(KEY_ENTITY_TYPE, Tag.TAG_STRING)) {
+            return Optional.empty();
+        }
+        String rawId = storage.getString(KEY_ENTITY_TYPE);
+        ResourceLocation id = ResourceLocation.tryParse(rawId);
+        if (id == null) {
+            return Optional.empty();
+        }
+        CompoundTag entityData = storage.contains(KEY_ENTITY_DATA, Tag.TAG_COMPOUND)
+                ? storage.getCompound(KEY_ENTITY_DATA).copy()
+                : new CompoundTag();
+        long storedAt = storage.contains(KEY_STORED_AT, Tag.TAG_LONG) ? storage.getLong(KEY_STORED_AT) : 0L;
+        return Optional.of(new BeastSoulRecord(id, entityData, storedAt));
+    }
+
+    @Override
+    public Optional<BeastSoulRecord> consume(ItemStack organ) {
+        Optional<BeastSoulRecord> record = peek(organ);
+        record.ifPresent(unused -> clear(organ));
+        return record;
+    }
+
+    @Override
+    public void clear(ItemStack organ) {
+        if (organ == null || organ.isEmpty()) {
+            return;
+        }
+        NBTWriter.updateCustomData(organ, tag -> {
+            if (!tag.contains(rootKey, Tag.TAG_COMPOUND)) {
+                return;
+            }
+            CompoundTag state = tag.getCompound(rootKey);
+            if (state.contains(STORAGE_KEY)) {
+                state.remove(STORAGE_KEY);
+            }
+            if (state.isEmpty()) {
+                tag.remove(rootKey);
+            } else {
+                tag.put(rootKey, state);
+            }
+        });
+    }
+
+    private void writeRecord(ItemStack organ, BeastSoulRecord record) {
+        NBTWriter.updateCustomData(organ, tag -> {
+            CompoundTag state = tag.contains(rootKey, Tag.TAG_COMPOUND) ? tag.getCompound(rootKey) : new CompoundTag();
+            CompoundTag storage = new CompoundTag();
+            storage.putString(KEY_ENTITY_TYPE, record.entityTypeId().toString());
+            storage.put(KEY_ENTITY_DATA, record.entityData().copy());
+            storage.putLong(KEY_STORED_AT, record.storedGameTime());
+            state.put(STORAGE_KEY, storage);
+            tag.put(rootKey, state);
+        });
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/GuzhenrenIntegrationModule.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/GuzhenrenIntegrationModule.java
@@ -7,6 +7,7 @@ import net.tigereye.chestcavity.compat.guzhenren.item.du_dao.DuDaoOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_cai.GuCaiOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.gu_dao.GuDaoOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.HunDaoOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.kongqiao.KongqiaoOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.lei_dao.LeiDaoOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.mu_dao.MuDaoOrganRegistry;
@@ -37,6 +38,7 @@ public final class GuzhenrenIntegrationModule {
             LeiDaoOrganRegistry::specs,
             KongqiaoOrganRegistry::specs,
             MuDaoOrganRegistry::specs,
+            HunDaoOrganRegistry::specs,
             TuDaoOrganRegistry::specs,
             ShuiDaoOrganRegistry::specs,
             XueDaoOrganRegistry::specs,


### PR DESCRIPTION
## Summary
- add a Hun Dao organ registry and soul beast behaviour wiring into the Guzhenren integration module
- implement the Hun Dao soul beast behaviour with basic resource drainage, on-hit soul flame DoT, and hunger upkeep
- introduce a reusable beast soul storage API and organ-backed implementation to persist captured entities

## Testing
- ./gradlew compileJava --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68df5f28cec08326be98f9216de6c003