### PR TITLE
Add Soul Beast state change events and listeners

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/guzhenren/nudao/IntimidationHelper.java
+++ b/src/main/java/net/tigereye/chestcavity/guzhenren/nudao/IntimidationHelper.java
@@ -186,4 +186,8 @@ public final class IntimidationHelper {
                 .map(handle -> handle.isOwnedBy(performer))
                 .orElse(false);
     }
+
+    public static boolean isSoulBeastIntimidationActive(Player performer) {
+        return SoulBeastIntimidationHooks.isIntimidationEnabled(performer);
+    }
 }

--- a/src/main/java/net/tigereye/chestcavity/guzhenren/nudao/SoulBeastIntimidationHooks.java
+++ b/src/main/java/net/tigereye/chestcavity/guzhenren/nudao/SoulBeastIntimidationHooks.java
@@ -1,0 +1,40 @@
+package net.tigereye.chestcavity.guzhenren.nudao;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import net.minecraft.world.entity.player.Player;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.soulbeast.state.event.SoulBeastStateChangedEvent;
+
+/**
+ * Tracks which players currently satisfy the soul beast intimidation aura.
+ */
+@EventBusSubscriber(modid = ChestCavity.MODID)
+public final class SoulBeastIntimidationHooks {
+
+    private static final Set<UUID> ACTIVE = ConcurrentHashMap.newKeySet();
+
+    private SoulBeastIntimidationHooks() {
+    }
+
+    @SubscribeEvent
+    public static void onSoulBeastStateChanged(SoulBeastStateChangedEvent event) {
+        if (!(event.entity() instanceof Player player)) {
+            return;
+        }
+        UUID uuid = player.getUUID();
+        if (event.current().isSoulBeast()) {
+            ACTIVE.add(uuid);
+        } else {
+            ACTIVE.remove(uuid);
+        }
+    }
+
+    public static boolean isIntimidationEnabled(Player player) {
+        return player != null && ACTIVE.contains(player.getUUID());
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/soulbeast/SoulBeastRuntimeEvents.java
+++ b/src/main/java/net/tigereye/chestcavity/soulbeast/SoulBeastRuntimeEvents.java
@@ -16,6 +16,7 @@ import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.middleware.HunDaoMiddleware;
 import net.tigereye.chestcavity.soulbeast.state.SoulBeastStateManager;
+import net.tigereye.chestcavity.soulbeast.state.event.SoulBeastStateChangedEvent;
 import net.tigereye.chestcavity.soulbeast.damage.SoulBeastDamageContext;
 import net.tigereye.chestcavity.soulbeast.damage.SoulBeastDamageHooks;
 import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
@@ -24,6 +25,7 @@ import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
 import net.tigereye.chestcavity.linkage.LinkageChannel;
 import net.tigereye.chestcavity.linkage.LinkageManager;
 import net.tigereye.chestcavity.registration.CCAttachments;
+import net.tigereye.chestcavity.util.DoTManager;
 import org.slf4j.Logger;
 
 import java.util.Optional;
@@ -203,5 +205,19 @@ public final class SoulBeastRuntimeEvents {
             }
         });
         return Math.max(0.0, maxHunpo * SOUL_FLAME_PERCENT * eff[0]);
+    }
+
+    @SubscribeEvent
+    public static void onSoulBeastStateChanged(SoulBeastStateChangedEvent event) {
+        LivingEntity entity = event.entity();
+        if (entity == null || entity.level().isClientSide()) {
+            return;
+        }
+        if (event.previous().isSoulBeast() && !event.current().isSoulBeast()) {
+            DoTManager.cancelAttacker(entity);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("[soulbeast] cleared pending DoT pulses after {} exited soul beast state", entity.getName().getString());
+            }
+        }
     }
 }

--- a/src/main/java/net/tigereye/chestcavity/soulbeast/state/SoulBeastSyncPayload.java
+++ b/src/main/java/net/tigereye/chestcavity/soulbeast/state/SoulBeastSyncPayload.java
@@ -13,6 +13,7 @@ import javax.annotation.Nullable;
  */
 public record SoulBeastSyncPayload(int entityId,
                                    boolean active,
+                                   boolean enabled,
                                    boolean permanent,
                                    long lastTick,
                                    @Nullable ResourceLocation source) implements CustomPacketPayload {
@@ -26,6 +27,7 @@ public record SoulBeastSyncPayload(int entityId,
     private static void encode(RegistryFriendlyByteBuf buf, SoulBeastSyncPayload payload) {
         buf.writeVarInt(payload.entityId());
         buf.writeBoolean(payload.active());
+        buf.writeBoolean(payload.enabled());
         buf.writeBoolean(payload.permanent());
         buf.writeVarLong(payload.lastTick());
         if (payload.source() != null) {
@@ -39,13 +41,14 @@ public record SoulBeastSyncPayload(int entityId,
     private static SoulBeastSyncPayload decode(RegistryFriendlyByteBuf buf) {
         int entityId = buf.readVarInt();
         boolean active = buf.readBoolean();
+        boolean enabled = buf.readBoolean();
         boolean permanent = buf.readBoolean();
         long lastTick = buf.readVarLong();
         ResourceLocation source = null;
         if (buf.readBoolean()) {
             source = buf.readResourceLocation();
         }
-        return new SoulBeastSyncPayload(entityId, active, permanent, lastTick, source);
+        return new SoulBeastSyncPayload(entityId, active, enabled, permanent, lastTick, source);
     }
 
     @Override

--- a/src/main/java/net/tigereye/chestcavity/soulbeast/state/event/SoulBeastStateChangedEvent.java
+++ b/src/main/java/net/tigereye/chestcavity/soulbeast/state/event/SoulBeastStateChangedEvent.java
@@ -1,0 +1,45 @@
+package net.tigereye.chestcavity.soulbeast.state.event;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.neoforged.bus.api.Event;
+
+/**
+ * Fired whenever a {@link net.tigereye.chestcavity.soulbeast.state.SoulBeastState} attached to an entity
+ * changes its activation flags.
+ */
+public final class SoulBeastStateChangedEvent extends Event {
+
+    private final LivingEntity entity;
+    private final Snapshot previous;
+    private final Snapshot current;
+
+    public SoulBeastStateChangedEvent(LivingEntity entity, Snapshot previous, Snapshot current) {
+        this.entity = entity;
+        this.previous = previous;
+        this.current = current;
+    }
+
+    public LivingEntity entity() {
+        return entity;
+    }
+
+    public Snapshot previous() {
+        return previous;
+    }
+
+    public Snapshot current() {
+        return current;
+    }
+
+    /**
+     * Immutable view over the soul beast state flags at a moment in time.
+     */
+    public record Snapshot(boolean active, boolean enabled, boolean permanent) {
+
+        public static final Snapshot EMPTY = new Snapshot(false, false, false);
+
+        public boolean isSoulBeast() {
+            return active || enabled || permanent;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `SoulBeastStateChangedEvent` and publish it from the state manager on server and client updates, carrying full activation flags
- expand Soul Beast sync payloads, DoT cancellation utilities, and command/intimidation helpers to react to the new event semantics
- wire Soul Beast runtime hooks and admin commands to listen for state changes so downstream systems can initialise or tear down effects promptly

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68e0c5a3185c8326989415af4e6d3fe3