### PR TITLE
Add Soul Beast fail FX action

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/behavior/DaHunGuBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/behavior/DaHunGuBehavior.java
@@ -13,7 +13,7 @@ import net.tigereye.chestcavity.compat.guzhenren.item.common.OrganState;
 import net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.HunDaoOrganRegistry;
 import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
 import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge.ResourceHandle;
-import net.tigereye.chestcavity.guzhenren.nudao.IntimidationHelper;
+import net.tigereye.chestcavity.compat.guzhenren.util.IntimidationHelper;
 import net.tigereye.chestcavity.listeners.OrganRemovalContext;
 import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
 import net.tigereye.chestcavity.soulbeast.state.SoulBeastStateManager;

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/util/IntimidationHelper.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/util/IntimidationHelper.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import net.tigereye.chestcavity.guzhenren.nudao.GuzhenrenNudaoBridge;
+import net.tigereye.chestcavity.guzhenren.nudao.SoulBeastIntimidationHooks;
 
 /**
  * Utility methods for applying intimidation-style减益。

--- a/src/main/java/net/tigereye/chestcavity/guscript/registry/GuScriptFlowLoader.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/registry/GuScriptFlowLoader.java
@@ -269,6 +269,7 @@ public final class GuScriptFlowLoader extends SimpleJsonResourceReloadListener {
                     json.has("scale_variable") ? GsonHelper.getAsString(json, "scale_variable") : null,
                     GsonHelper.getAsDouble(json, "default_scale", 1.0D)
             );
+            case "emit_fail_fx" -> FlowActions.emitFailFx();
             case "emit_gecko" -> FlowActions.emitGecko(parseGeckoFxParameters(json));
             case "emit_gecko_relative" -> FlowActions.emitGecko(parseGeckoFxParameters(json));
             case "play_sound" -> FlowActions.playSound(

--- a/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/FlowActions.java
+++ b/src/main/java/net/tigereye/chestcavity/guscript/runtime/flow/actions/FlowActions.java
@@ -8,13 +8,17 @@ import java.util.function.Function;
 
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
+import net.tigereye.chestcavity.ChestCavity;
 import net.tigereye.chestcavity.guscript.ast.Action;
 import net.tigereye.chestcavity.guscript.runtime.flow.FlowController;
 import net.tigereye.chestcavity.guscript.runtime.flow.FlowEdgeAction;
 import net.tigereye.chestcavity.guscript.runtime.flow.fx.GeckoFxAnchor;
+import net.tigereye.chestcavity.guscript.fx.FxEventParameters;
+import net.tigereye.chestcavity.guscript.runtime.action.DefaultGuScriptExecutionBridge;
 import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
 
 /**
@@ -26,6 +30,16 @@ public final class FlowActions {
     }
 
     private static final ResourceLocation BREAK_AIR_SOUND_ID = ResourceLocation.parse("chestcavity:custom.sword.break_air");
+    private static final ResourceLocation FAIL_TO_SOULBEAST_SOUND_ID = ChestCavity.id("custom.soulbeast.fail_to_soulbeast");
+    private static final ResourceLocation FAIL_TO_SOULBEAST_FX_ID = ChestCavity.id("soulbeast_fail");
+    private static final FlowEdgeAction FAIL_TO_SOULBEAST_SOUND_ACTION = SoundFlowActions.playSound(
+            FAIL_TO_SOULBEAST_SOUND_ID,
+            SoundAnchor.PERFORMER,
+            Vec3.ZERO,
+            1.0F,
+            1.0F,
+            0
+    );
 
     public static void overrideResourceOpenerForTests(Function<Player, Optional<GuzhenrenResourceBridge.ResourceHandle>> opener) {
         ResourceFlowActions.overrideResourceOpenerForTests(opener);
@@ -105,6 +119,25 @@ public final class FlowActions {
 
     public static FlowEdgeAction emitGecko(GeckoFxParameters parameters) {
         return FxFlowActions.emitGecko(parameters);
+    }
+
+    public static FlowEdgeAction emitFailFx() {
+        return new FlowEdgeAction() {
+            @Override
+            public void apply(Player performer, LivingEntity target, FlowController controller, long gameTime) {
+                FAIL_TO_SOULBEAST_SOUND_ACTION.apply(performer, target, controller, gameTime);
+                if (performer == null) {
+                    return;
+                }
+                DefaultGuScriptExecutionBridge bridge = new DefaultGuScriptExecutionBridge(performer, target, 0);
+                bridge.playFx(FAIL_TO_SOULBEAST_FX_ID, FxEventParameters.DEFAULT);
+            }
+
+            @Override
+            public String describe() {
+                return "emit_fail_fx(sound=" + FAIL_TO_SOULBEAST_SOUND_ID + ", fx=" + FAIL_TO_SOULBEAST_FX_ID + ")";
+            }
+        };
     }
 
     public static FlowEdgeAction playSound(ResourceLocation soundId, SoundAnchor anchor, Vec3 offset, float volume, float pitch, int delayTicks) {

--- a/src/main/java/net/tigereye/chestcavity/registration/CCSoundEvents.java
+++ b/src/main/java/net/tigereye/chestcavity/registration/CCSoundEvents.java
@@ -20,4 +20,8 @@ public final class CCSoundEvents {
     public static final DeferredHolder<SoundEvent, SoundEvent> CUSTOM_SWORD_BREAK_AIR =
             SOUND_EVENTS.register("custom.sword.break_air",
                     () -> SoundEvent.createVariableRangeEvent(ChestCavity.id("custom.sword.break_air")));
+
+    public static final DeferredHolder<SoundEvent, SoundEvent> CUSTOM_SOULBEAST_FAIL_TO_SOULBEAST =
+            SOUND_EVENTS.register("custom.soulbeast.fail_to_soulbeast",
+                    () -> SoundEvent.createVariableRangeEvent(ChestCavity.id("custom.soulbeast.fail_to_soulbeast")));
 }

--- a/src/main/resources/assets/chestcavity/guscript/fx/soulbeast_fail.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/soulbeast_fail.json
@@ -1,0 +1,28 @@
+{
+  "modules": [
+    {
+      "type": "particle",
+      "particle": "minecraft:soul_fire_flame",
+      "count": 48,
+      "offset": [0.0, 0.35, 0.0],
+      "spread": [0.45, 0.6, 0.45],
+      "speed": 0.03
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:smoke",
+      "count": 32,
+      "offset": [0.0, 0.25, 0.0],
+      "spread": [0.55, 0.4, 0.55],
+      "speed": 0.015
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:soul",
+      "count": 20,
+      "offset": [0.0, 0.3, 0.0],
+      "spread": [0.3, 0.35, 0.3],
+      "speed": 0.04
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/sounds.json
+++ b/src/main/resources/assets/chestcavity/sounds.json
@@ -6,5 +6,13 @@
         "stream": false
       }
     ]
+  },
+  "custom.soulbeast.fail_to_soulbeast": {
+    "sounds": [
+      {
+        "name": "chestcavity:custom/soulbeast/fail_soulbeast_transform",
+        "stream": false
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `emit_fail_fx` flow action that plays the shared Soul Beast failure sound and FX
- register the fail-to-soulbeast sound event and provide the soulbeast_fail FX resource definition
- correct Guzhenren intimidation imports after the helper move

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68e0d47b35d483269bb5a34268065457