### PR TITLE
Implement soul beast intimidation flee behavior

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/behavior/DaHunGuBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/behavior/DaHunGuBehavior.java
@@ -3,7 +3,6 @@ package net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.behavior;
 import com.mojang.logging.LogUtils;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -14,6 +13,7 @@ import net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.HunDaoOrganRegistr
 import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
 import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge.ResourceHandle;
 import net.tigereye.chestcavity.compat.guzhenren.util.IntimidationHelper;
+import net.tigereye.chestcavity.registration.CCStatusEffects;
 import net.tigereye.chestcavity.listeners.OrganRemovalContext;
 import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
 import net.tigereye.chestcavity.soulbeast.state.SoulBeastStateManager;
@@ -145,7 +145,7 @@ public final class DaHunGuBehavior extends AbstractGuzhenrenOrganBehavior implem
         IntimidationHelper.Settings settings = new IntimidationHelper.Settings(
                 hunpoValue,
                 IntimidationHelper.AttitudeScope.HOSTILE,
-                MobEffects.WEAKNESS,
+                CCStatusEffects.SOUL_BEAST_INTIMIDATED,
                 WEILING_EFFECT_DURATION_TICKS,
                 0,
                 false,

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/util/SoulBeastIntimidationEvents.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/util/SoulBeastIntimidationEvents.java
@@ -1,0 +1,46 @@
+package net.tigereye.chestcavity.compat.guzhenren.util;
+
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.LivingEntity;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.living.MobEffectEvent;
+
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.mob_effect.SoulBeastIntimidatedEffect;
+import net.tigereye.chestcavity.registration.CCStatusEffects;
+
+/**
+ * Event hooks ensuring the soul beast intimidation flee goal lifecycle tracks the effect.
+ */
+@EventBusSubscriber(modid = ChestCavity.MODID)
+public final class SoulBeastIntimidationEvents {
+
+    private SoulBeastIntimidationEvents() {}
+
+    @SubscribeEvent
+    public static void onEffectAdded(MobEffectEvent.Added event) {
+        LivingEntity entity = event.getEntity();
+        MobEffectInstance instance = event.getEffectInstance();
+        if (entity == null || instance == null) {
+            return;
+        }
+        if (instance.getEffect() != CCStatusEffects.SOUL_BEAST_INTIMIDATED.value()) {
+            return;
+        }
+        SoulBeastIntimidatedEffect.handleEffectAdded(entity);
+    }
+
+    @SubscribeEvent
+    public static void onEffectRemoved(MobEffectEvent.Remove event) {
+        LivingEntity entity = event.getEntity();
+        MobEffectInstance instance = event.getEffectInstance();
+        if (entity == null || instance == null) {
+            return;
+        }
+        if (instance.getEffect() != CCStatusEffects.SOUL_BEAST_INTIMIDATED.value()) {
+            return;
+        }
+        SoulBeastIntimidatedEffect.handleEffectRemoved(entity);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/util/SoulBeastIntimidationGoalManager.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/util/SoulBeastIntimidationGoalManager.java
@@ -1,0 +1,82 @@
+package net.tigereye.chestcavity.compat.guzhenren.util;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.ai.goal.AvoidEntityGoal;
+
+import net.tigereye.chestcavity.mob_effect.SoulBeastIntimidatedEffect;
+
+/**
+ * Handles adding and removing flee goals for entities intimidated by soul beasts.
+ */
+public final class SoulBeastIntimidationGoalManager {
+
+    private static final Map<Mob, IntimidatedFleeGoal> GOALS = new WeakHashMap<>();
+
+    private SoulBeastIntimidationGoalManager() {}
+
+    public static void ensureFleeGoal(Mob mob) {
+        if (mob == null || mob.level().isClientSide()) {
+            return;
+        }
+        if (!(mob instanceof PathfinderMob pathfinder)) {
+            return;
+        }
+        IntimidatedFleeGoal goal = GOALS.get(mob);
+        if (goal == null) {
+            goal = new IntimidatedFleeGoal(pathfinder);
+            GOALS.put(mob, goal);
+            mob.goalSelector.addGoal(1, goal);
+        }
+        mob.getNavigation().stop();
+        mob.setTarget(null);
+    }
+
+    public static void clearFleeGoal(Mob mob) {
+        if (mob == null) {
+            return;
+        }
+        IntimidatedFleeGoal goal = GOALS.remove(mob);
+        if (goal != null) {
+            mob.goalSelector.removeGoal(goal);
+        }
+    }
+
+    static boolean hasIntimidator(Mob mob) {
+        return SoulBeastIntimidatedEffect.getIntimidator(mob).isPresent();
+    }
+
+    static boolean isCurrentIntimidator(Mob mob, LivingEntity candidate) {
+        if (mob == null || candidate == null) {
+            return false;
+        }
+        return SoulBeastIntimidatedEffect.getIntimidator(mob)
+                .map(uuid -> uuid.equals(candidate.getUUID()))
+                .orElse(false);
+    }
+
+    private static final class IntimidatedFleeGoal extends AvoidEntityGoal<LivingEntity> {
+
+        private final PathfinderMob mob;
+
+        private IntimidatedFleeGoal(PathfinderMob mob) {
+            super(mob, LivingEntity.class, 12.0F, 1.25D, 1.5D,
+                    candidate -> SoulBeastIntimidationGoalManager.isCurrentIntimidator(mob, candidate));
+            this.mob = mob;
+        }
+
+        @Override
+        public boolean canUse() {
+            return SoulBeastIntimidationGoalManager.hasIntimidator(this.mob) && super.canUse();
+        }
+
+        @Override
+        public boolean canContinueToUse() {
+            return SoulBeastIntimidationGoalManager.hasIntimidator(this.mob) && super.canContinueToUse();
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/mob_effect/SoulBeastIntimidatedEffect.java
+++ b/src/main/java/net/tigereye/chestcavity/mob_effect/SoulBeastIntimidatedEffect.java
@@ -1,0 +1,76 @@
+package net.tigereye.chestcavity.mob_effect;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.effect.MobEffectCategory;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+
+import net.tigereye.chestcavity.compat.guzhenren.util.SoulBeastIntimidationGoalManager;
+
+/**
+ * Mob effect applied to entities that should temporarily flee from the soul beast intimidator.
+ * Stores the intimidator's UUID on the affected entity and injects a flee goal while active.
+ */
+public class SoulBeastIntimidatedEffect extends CCStatusEffect {
+
+    private static final String INTIMIDATOR_TAG = "ChestCavitySoulBeastIntimidator";
+
+    public SoulBeastIntimidatedEffect() {
+        super(MobEffectCategory.HARMFUL, 0x4b2f70);
+    }
+
+    public static void assignIntimidator(LivingEntity entity, UUID intimidatorId) {
+        if (entity == null || intimidatorId == null) {
+            return;
+        }
+        CompoundTag data = entity.getPersistentData();
+        data.putUUID(INTIMIDATOR_TAG, intimidatorId);
+    }
+
+    public static void handleEffectAdded(LivingEntity entity) {
+        if (entity == null || entity.level().isClientSide()) {
+            return;
+        }
+        if (entity instanceof Mob mob) {
+            SoulBeastIntimidationGoalManager.ensureFleeGoal(mob);
+        }
+    }
+
+    public static void handleEffectRemoved(LivingEntity entity) {
+        if (entity == null || entity.level().isClientSide()) {
+            return;
+        }
+        if (entity instanceof Mob mob) {
+            SoulBeastIntimidationGoalManager.clearFleeGoal(mob);
+        }
+        clearIntimidator(entity);
+    }
+
+    public static void clearIntimidator(LivingEntity entity) {
+        if (entity == null) {
+            return;
+        }
+        CompoundTag data = entity.getPersistentData();
+        if (data.contains(INTIMIDATOR_TAG)) {
+            data.remove(INTIMIDATOR_TAG);
+        }
+    }
+
+    public static Optional<UUID> getIntimidator(LivingEntity entity) {
+        if (entity == null) {
+            return Optional.empty();
+        }
+        CompoundTag data = entity.getPersistentData();
+        if (!data.hasUUID(INTIMIDATOR_TAG)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(data.getUUID(INTIMIDATOR_TAG));
+        } catch (IllegalArgumentException ignored) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/registration/CCStatusEffects.java
+++ b/src/main/java/net/tigereye/chestcavity/registration/CCStatusEffects.java
@@ -10,6 +10,7 @@ import net.tigereye.chestcavity.mob_effect.CCStatusEffect;
 import net.tigereye.chestcavity.mob_effect.FurnacePower;
 import net.tigereye.chestcavity.mob_effect.OrganRejection;
 import net.tigereye.chestcavity.mob_effect.Ruminating;
+import net.tigereye.chestcavity.mob_effect.SoulBeastIntimidatedEffect;
 
 public class CCStatusEffects {
     public static final DeferredRegister<MobEffect> MOB_EFFECTS = DeferredRegister.create(Registries.MOB_EFFECT, ChestCavity.MODID);
@@ -29,4 +30,5 @@ public class CCStatusEffects {
     public static final DeferredHolder<MobEffect, MobEffect> SILK_COOLDOWN = MOB_EFFECTS.register("silk_cooldown", () -> new CCStatusEffect(MobEffectCategory.NEUTRAL,0x000000));
     public static final DeferredHolder<MobEffect, MobEffect> VENOM_COOLDOWN = MOB_EFFECTS.register("venom_cooldown", () -> new CCStatusEffect(MobEffectCategory.NEUTRAL,0x000000));
     public static final DeferredHolder<MobEffect, MobEffect> WATER_VULNERABILITY = MOB_EFFECTS.register("water_vulnerability", () -> new CCStatusEffect(MobEffectCategory.NEUTRAL,0x000000));
+    public static final DeferredHolder<MobEffect, MobEffect> SOUL_BEAST_INTIMIDATED = MOB_EFFECTS.register("soul_beast_intimidated", SoulBeastIntimidatedEffect::new);
 }

--- a/src/main/java/net/tigereye/chestcavity/soulbeast/SoulBeastRuntimeEvents.java
+++ b/src/main/java/net/tigereye/chestcavity/soulbeast/SoulBeastRuntimeEvents.java
@@ -27,6 +27,7 @@ import net.tigereye.chestcavity.util.DoTManager;
 import net.tigereye.chestcavity.compat.guzhenren.util.IntimidationHelper;
 import net.tigereye.chestcavity.soulbeast.state.SoulBeastStateManager;
 import net.tigereye.chestcavity.soulbeast.state.event.SoulBeastStateChangedEvent;
+import net.tigereye.chestcavity.registration.CCStatusEffects;
 import org.slf4j.Logger;
 
 import java.util.Optional;
@@ -246,7 +247,7 @@ public final class SoulBeastRuntimeEvents {
             IntimidationHelper.Settings settings = new IntimidationHelper.Settings(
                     hunpo,
                     IntimidationHelper.AttitudeScope.HOSTILE,
-                    net.minecraft.world.effect.MobEffects.WEAKNESS,
+                    CCStatusEffects.SOUL_BEAST_INTIMIDATED,
                     INTIMIDATION_DURATION,
                     0,
                     false,


### PR DESCRIPTION
## Summary
- add a dedicated Soul Beast Intimidated mob effect that stores the intimidator and injects a flee goal while active
- wire IntimidationHelper and soul beast abilities to use the new effect and goal manager, covering effect refresh and cleanup
- register the status effect and add mob-effect events to keep hostile mobs running from the caster

## Testing
- `./gradlew build` *(fails: existing XiaoHunGuBehavior references missing HUN_JI_RECOVERY_EFFECT constant)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f03071b0832695608cc4ae71c658