### PR TITLE
Add Gui Qi Gu organ behaviour with ghost fog ability

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/HunDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/HunDaoOrganRegistry.java
@@ -2,6 +2,7 @@ package net.tigereye.chestcavity.compat.guzhenren.item.hun_dao;
 
 import net.minecraft.resources.ResourceLocation;
 import net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.behavior.DaHunGuBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.behavior.GuiQiGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.behavior.XiaoHunGuBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
 
@@ -26,6 +27,7 @@ public final class HunDaoOrganRegistry {
     private static final String MOD_ID = "guzhenren";
     public static final ResourceLocation XIAO_HUN_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "xiao_hun_gu");
     public static final ResourceLocation DA_HUN_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "dahungu");
+    public static final ResourceLocation GUI_QI_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "guiqigu");
 
     private static final List<OrganIntegrationSpec> SPECS = List.of(
             OrganIntegrationSpec.builder(XIAO_HUN_GU_ID)
@@ -38,6 +40,12 @@ public final class HunDaoOrganRegistry {
                     .addSlowTickListener(DaHunGuBehavior.INSTANCE)
                     .ensureAttached(DaHunGuBehavior.INSTANCE::ensureAttached)
                     .onEquip(DaHunGuBehavior.INSTANCE::onEquip)
+                    .build(),
+            OrganIntegrationSpec.builder(GUI_QI_GU_ID)
+                    .addSlowTickListener(GuiQiGuOrganBehavior.INSTANCE)
+                    .addOnHitListener(GuiQiGuOrganBehavior.INSTANCE)
+                    .ensureAttached(GuiQiGuOrganBehavior.INSTANCE::ensureAttached)
+                    .onEquip(GuiQiGuOrganBehavior.INSTANCE::onEquip)
                     .build()
     );
 

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/behavior/GuiQiGuEvents.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/behavior/GuiQiGuEvents.java
@@ -1,0 +1,87 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.behavior;
+
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.living.LivingDeathEvent;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.interfaces.ChestCavityEntity;
+import net.tigereye.chestcavity.soulbeast.state.SoulBeastStateManager;
+
+import java.util.Optional;
+
+/**
+ * Event hooks for Gui Qi Gu's soul-beast specific passive ("噬魂").
+ */
+@EventBusSubscriber(modid = ChestCavity.MODID)
+public final class GuiQiGuEvents {
+
+    private static final double SOUL_EATER_MIN_HEALTH = 40.0D;
+    private static final double SOUL_EATER_TRIGGER_CHANCE = 0.12D;
+    private static final double SOUL_EATER_HUNPO_SCALE = 0.001D; // 0.1% of victim max health
+    private static final double SOUL_EATER_STABILITY_PENALTY = 0.05D; // 5% of stability max
+
+    private GuiQiGuEvents() {
+    }
+
+    @SubscribeEvent
+    public static void onLivingDeath(LivingDeathEvent event) {
+        LivingEntity victim = event.getEntity();
+        if (victim == null || victim.level().isClientSide()) {
+            return;
+        }
+        DamageSource source = event.getSource();
+        if (source == null) {
+            return;
+        }
+        Entity direct = source.getEntity();
+        if (!(direct instanceof LivingEntity attacker)) {
+            return;
+        }
+        if (!(attacker instanceof Player player)) {
+            return; // Gui Qi Gu's resources are only available on players for now.
+        }
+        if (!SoulBeastStateManager.isActive(attacker)) {
+            return;
+        }
+        if (victim.getMaxHealth() <= SOUL_EATER_MIN_HEALTH) {
+            return;
+        }
+        if (attacker.getRandom().nextDouble() >= SOUL_EATER_TRIGGER_CHANCE) {
+            return;
+        }
+
+        ChestCavityInstance cc = ChestCavityEntity.of(attacker)
+                .map(ChestCavityEntity::getChestCavityInstance)
+                .orElse(null);
+        if (cc == null || !GuiQiGuOrganBehavior.hasGuiQiGu(cc)) {
+            return;
+        }
+
+        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+        if (handleOpt.isEmpty()) {
+            return;
+        }
+        GuzhenrenResourceBridge.ResourceHandle handle = handleOpt.get();
+
+        double bonus = victim.getMaxHealth() * SOUL_EATER_HUNPO_SCALE;
+        if (!(bonus > 0.0D)) {
+            return;
+        }
+        handle.adjustDouble("zuida_hunpo", bonus, false);
+
+        double stabilityMax = handle.read("hunpo_kangxing_shangxian").orElse(0.0D);
+        double penalty = stabilityMax > 0.0D
+                ? stabilityMax * SOUL_EATER_STABILITY_PENALTY
+                : handle.read("hunpo_kangxing").orElse(0.0D) * SOUL_EATER_STABILITY_PENALTY;
+        if (penalty > 0.0D) {
+            handle.adjustDouble("hunpo_kangxing", -penalty, true, "hunpo_kangxing_shangxian");
+        }
+    }
+}
+

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/behavior/GuiQiGuOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/hun_dao/behavior/GuiQiGuOrganBehavior.java
@@ -1,0 +1,246 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.hun_dao.behavior;
+
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.DamageTypeTags;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.tigereye.chestcavity.ChestCavity;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.combat.HunDaoDamageUtil;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.AbstractGuzhenrenOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.OrganState;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowController;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowControllerManager;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowProgram;
+import net.tigereye.chestcavity.guscript.runtime.flow.FlowProgramRegistry;
+import net.tigereye.chestcavity.guzhenren.resource.GuzhenrenResourceBridge;
+import net.tigereye.chestcavity.listeners.OrganActivationListeners;
+import net.tigereye.chestcavity.listeners.OrganOnHitListener;
+import net.tigereye.chestcavity.listeners.OrganRemovalContext;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Behaviour for 鬼气蛊 (Gui Qi Gu).
+ * <p>
+ * Passive effects:
+ * <ul>
+ *     <li>Regenerates hunpo and jingli every slow tick.</li>
+ *     <li>Empowers melee hits with additional true damage equal to 1% of the carrier's maximum hunpo.</li>
+ * </ul>
+ * <p>
+ * Active ability "鬼雾": starts the {@code hun_dao/gui_wu} GuScript flow that emits a black fog
+ * in front of the caster and inflicts Slowness IV and Blindness on nearby hostiles.
+ */
+public final class GuiQiGuOrganBehavior extends AbstractGuzhenrenOrganBehavior
+        implements OrganSlowTickListener, OrganOnHitListener {
+
+    public static final GuiQiGuOrganBehavior INSTANCE = new GuiQiGuOrganBehavior();
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation ORGAN_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "guiqigu");
+    public static final ResourceLocation ABILITY_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "gui_wu");
+
+    private static final ResourceLocation GUI_WU_FLOW_ID = ChestCavity.id("hun_dao/gui_wu");
+
+    private static final double PASSIVE_HUNPO_PER_SECOND = 3.0D;
+    private static final double PASSIVE_JINGLI_PER_SECOND = 1.0D;
+    private static final double TRUE_DAMAGE_RATIO = 0.01D;
+    private static final double GUI_WU_RADIUS = 4.0D;
+    private static final int GUI_WU_COOLDOWN_TICKS = 160;
+
+    private static final String STATE_ROOT_KEY = "GuiQiGu";
+    private static final String KEY_COOLDOWN_UNTIL = "CooldownUntil";
+
+    private static final ThreadLocal<Boolean> REENTRY_GUARD = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    static {
+        OrganActivationListeners.register(ABILITY_ID, GuiQiGuOrganBehavior::activateAbility);
+    }
+
+    private GuiQiGuOrganBehavior() {
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        // No dedicated linkage channels needed yet; method kept for future expansion.
+    }
+
+    public void onEquip(ChestCavityInstance cc, ItemStack organ, List<OrganRemovalContext> staleRemovalContexts) {
+        if (cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+        sendSlotUpdate(cc, organ);
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (!(entity instanceof Player player) || entity.level().isClientSide()) {
+            return;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID)) {
+            return;
+        }
+
+        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+        if (handleOpt.isEmpty()) {
+            return;
+        }
+        GuzhenrenResourceBridge.ResourceHandle handle = handleOpt.get();
+        int stackCount = Math.max(1, organ.getCount());
+        double hunpoGain = PASSIVE_HUNPO_PER_SECOND * stackCount;
+        double jingliGain = PASSIVE_JINGLI_PER_SECOND * stackCount;
+        handle.adjustDouble("hunpo", hunpoGain, true, "zuida_hunpo");
+        handle.adjustDouble("jingli", jingliGain, true, "zuida_jingli");
+    }
+
+    @Override
+    public float onHit(
+            DamageSource source,
+            LivingEntity attacker,
+            LivingEntity target,
+            ChestCavityInstance cc,
+            ItemStack organ,
+            float damage
+    ) {
+        if (Boolean.TRUE.equals(REENTRY_GUARD.get())) {
+            return damage;
+        }
+        if (!(attacker instanceof Player player) || attacker.level().isClientSide()) {
+            return damage;
+        }
+        if (target == null || !target.isAlive()) {
+            return damage;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID)) {
+            return damage;
+        }
+        if (source == null || source.is(DamageTypeTags.IS_PROJECTILE)) {
+            return damage;
+        }
+
+        Optional<GuzhenrenResourceBridge.ResourceHandle> handleOpt = GuzhenrenResourceBridge.open(player);
+        if (handleOpt.isEmpty()) {
+            return damage;
+        }
+        double maxHunpo = handleOpt.get().read("zuida_hunpo").orElse(0.0D);
+        if (!(maxHunpo > 0.0D)) {
+            return damage;
+        }
+
+        float extraDamage = (float) (maxHunpo * TRUE_DAMAGE_RATIO);
+        if (extraDamage <= 0.0F) {
+            return damage;
+        }
+
+        REENTRY_GUARD.set(Boolean.TRUE);
+        try {
+            DamageSource trueSource = player.damageSources().magic();
+            HunDaoDamageUtil.markHunDaoAttack(trueSource);
+            target.hurt(trueSource, extraDamage);
+        } finally {
+            REENTRY_GUARD.set(Boolean.FALSE);
+        }
+        return damage;
+    }
+
+    public static boolean hasGuiQiGu(ChestCavityInstance cc) {
+        if (cc == null || cc.inventory == null) {
+            return false;
+        }
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack candidate = cc.inventory.getItem(i);
+            if (candidate.isEmpty()) {
+                continue;
+            }
+            if (BuiltInOrganIds.matches(candidate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void activateAbility(LivingEntity entity, ChestCavityInstance cc) {
+        if (!(entity instanceof Player player) || cc == null || entity.level().isClientSide()) {
+            return;
+        }
+        ItemStack organ = findOrgan(cc);
+        if (organ.isEmpty()) {
+            return;
+        }
+
+        Level level = entity.level();
+        if (!(level instanceof net.minecraft.server.level.ServerLevel server)) {
+            return;
+        }
+
+        if (!(player instanceof net.minecraft.server.level.ServerPlayer serverPlayer)) {
+            return;
+        }
+
+        long currentTick = level.getGameTime();
+        OrganState state = INSTANCE.organState(organ, STATE_ROOT_KEY);
+        long nextAllowed = state.getLong(KEY_COOLDOWN_UNTIL, 0L);
+        if (nextAllowed > currentTick) {
+            return;
+        }
+
+        Optional<FlowProgram> programOpt = FlowProgramRegistry.get(GUI_WU_FLOW_ID);
+        if (programOpt.isEmpty()) {
+            return;
+        }
+
+        FlowController controller = FlowControllerManager.get(serverPlayer);
+        Map<String, String> params = new HashMap<>();
+        params.put("gui_wu.radius", formatDouble(GUI_WU_RADIUS));
+        controller.start(programOpt.get(), player, 1.0D, params, server.getGameTime(), "hun_dao.gui_wu");
+
+        state.setLong(KEY_COOLDOWN_UNTIL, currentTick + GUI_WU_COOLDOWN_TICKS);
+        INSTANCE.sendSlotUpdate(cc, organ);
+    }
+
+    private static ItemStack findOrgan(ChestCavityInstance cc) {
+        if (cc == null || cc.inventory == null) {
+            return ItemStack.EMPTY;
+        }
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (stack.isEmpty()) {
+                continue;
+            }
+            if (BuiltInOrganIds.matches(stack)) {
+                return stack;
+            }
+        }
+        return ItemStack.EMPTY;
+    }
+
+    private static String formatDouble(double value) {
+        return String.format(Locale.ROOT, "%.3f", value);
+    }
+
+    private static final class BuiltInOrganIds {
+        private BuiltInOrganIds() {
+        }
+
+        private static boolean matches(ItemStack stack) {
+            if (stack == null || stack.isEmpty()) {
+                return false;
+            }
+            ResourceLocation id = BuiltInRegistries.ITEM.getKey(stack.getItem());
+            return Objects.equals(id, ORGAN_ID);
+        }
+    }
+}
+

--- a/src/main/resources/assets/chestcavity/guscript/fx/hun_dao/gui_wu_cast.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/hun_dao/gui_wu_cast.json
@@ -1,0 +1,31 @@
+{
+  "modules": [
+    {
+      "type": "sound",
+      "sound": "minecraft:entity.witch.celebrate",
+      "volume": 0.9,
+      "pitch": 0.6
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:smoke",
+      "count": 30,
+      "speed": 0.02,
+      "spread": [0.6, 0.4, 0.6],
+      "offset": [0.0, 1.0, 0.0]
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:soul_fire_flame",
+      "count": 12,
+      "speed": 0.01,
+      "spread": [0.45, 0.35, 0.45],
+      "offset": [0.0, 1.1, 0.0]
+    },
+    {
+      "type": "screen_shake",
+      "intensity": 0.12,
+      "duration": 6
+    }
+  ]
+}

--- a/src/main/resources/assets/chestcavity/guscript/fx/hun_dao/gui_wu_pulse.json
+++ b/src/main/resources/assets/chestcavity/guscript/fx/hun_dao/gui_wu_pulse.json
@@ -1,0 +1,20 @@
+{
+  "modules": [
+    {
+      "type": "particle",
+      "particle": "minecraft:smoke",
+      "count": 18,
+      "speed": 0.015,
+      "spread": [0.7, 0.45, 0.7],
+      "offset": [0.0, 1.0, 0.0]
+    },
+    {
+      "type": "particle",
+      "particle": "minecraft:ash",
+      "count": 10,
+      "speed": 0.02,
+      "spread": [0.6, 0.4, 0.6],
+      "offset": [0.0, 1.0, 0.0]
+    }
+  ]
+}

--- a/src/main/resources/data/chestcavity/guscript/flows/hun_dao/gui_wu.json
+++ b/src/main/resources/data/chestcavity/guscript/flows/hun_dao/gui_wu.json
@@ -1,0 +1,34 @@
+{
+  "initial_state": "idle",
+  "states": {
+    "idle": {
+      "transitions": [
+        { "trigger": "start", "target": "releasing" }
+      ]
+    },
+    "releasing": {
+      "enter_actions": [
+        { "type": "set_variable_from_param", "param": "gui_wu.radius", "name": "gui_wu.radius", "default": 4.0 },
+        { "type": "set_cooldown", "key": "hun_dao.gui_wu", "ticks": 160 },
+        { "type": "emit_fx", "fx": "chestcavity:hun_dao/gui_wu_cast", "base_intensity": 1.0 },
+        { "type": "play_sound", "id": "minecraft:entity.illusioner.prepare_mirror", "anchor": "performer", "volume": 1.0, "pitch": 0.8 },
+        { "type": "area_effect", "id": "minecraft:slowness", "duration": 160, "amplifier": 3, "radius": 4.0, "radius_variable": "gui_wu.radius", "hostiles_only": true, "include_self": false, "show_particles": false, "show_icon": true },
+        { "type": "area_effect", "id": "minecraft:blindness", "duration": 100, "amplifier": 0, "radius": 4.0, "radius_variable": "gui_wu.radius", "hostiles_only": true, "include_self": false, "show_particles": false, "show_icon": true }
+      ],
+      "update_period": 20,
+      "update_actions": [
+        { "type": "emit_fx", "fx": "chestcavity:hun_dao/gui_wu_pulse", "base_intensity": 0.8 },
+        { "type": "area_effect", "id": "minecraft:slowness", "duration": 100, "amplifier": 3, "radius": 4.0, "radius_variable": "gui_wu.radius", "hostiles_only": true, "include_self": false, "show_particles": false, "show_icon": false },
+        { "type": "area_effect", "id": "minecraft:blindness", "duration": 80, "amplifier": 0, "radius": 4.0, "radius_variable": "gui_wu.radius", "hostiles_only": true, "include_self": false, "show_particles": false, "show_icon": false }
+      ],
+      "transitions": [
+        { "trigger": "auto", "target": "cooldown", "min_ticks": 60 }
+      ]
+    },
+    "cooldown": {
+      "transitions": [
+        { "trigger": "auto", "target": "idle", "min_ticks": 20 }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement Gui Qi Gu behaviour with passive resource sustain, melee true damage, and the Ghost Fog ability
- hook soul beast kill bonuses via Gui Qi Gu events and register the organ in the Hun Dao registry
- add GuScript flow and FX resources for the Ghost Fog activation

## Testing
- `./gradlew compileJava`


------
https://chatgpt.com/codex/tasks/task_e_68e109f6cc188326aeda0e6175b1fdaa