### PR TITLE
Implement Li Dao third-turn self-reliant gu organ

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/LiDaoClientAbilities.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/LiDaoClientAbilities.java
@@ -1,0 +1,20 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.li_dao;
+
+import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior.ZiLiGengShengGuOrganBehavior;
+import net.tigereye.chestcavity.registration.CCKeybindings;
+
+/**
+ * Client-side ability registration for 力道（三转） organs.
+ */
+public final class LiDaoClientAbilities {
+
+    private LiDaoClientAbilities() {
+    }
+
+    public static void onClientSetup(FMLClientSetupEvent event) {
+        if (!CCKeybindings.ATTACK_ABILITY_LIST.contains(ZiLiGengShengGuOrganBehavior.ABILITY_ID)) {
+            CCKeybindings.ATTACK_ABILITY_LIST.add(ZiLiGengShengGuOrganBehavior.ABILITY_ID);
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/LiDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/LiDaoOrganRegistry.java
@@ -1,0 +1,33 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.li_dao;
+
+import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior.ZiLiGengShengGuOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
+
+import java.util.List;
+
+/**
+ * Declarative registry for 力道（三转） organ behaviours.
+ */
+public final class LiDaoOrganRegistry {
+
+    private static final String MOD_ID = "guzhenren";
+
+    private static final ResourceLocation ZI_LI_GENG_SHENG_GU_ID =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "zi_li_geng_sheng_gu_3");
+
+    private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(ZI_LI_GENG_SHENG_GU_ID)
+                    .addSlowTickListener(ZiLiGengShengGuOrganBehavior.INSTANCE)
+                    .addRemovalListener(ZiLiGengShengGuOrganBehavior.INSTANCE)
+                    .ensureAttached(ZiLiGengShengGuOrganBehavior.INSTANCE::ensureAttached)
+                    .build()
+    );
+
+    private LiDaoOrganRegistry() {
+    }
+
+    public static List<OrganIntegrationSpec> specs() {
+        return SPECS;
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/behavior/ZiLiGengShengGuOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/behavior/ZiLiGengShengGuOrganBehavior.java
@@ -1,0 +1,269 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior;
+
+import com.mojang.logging.LogUtils;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.OrganState;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.AbstractLiDaoOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.LiDaoConstants;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.LiDaoHelper;
+import net.tigereye.chestcavity.guzhenren.util.GuzhenrenResourceCostHelper;
+import net.tigereye.chestcavity.guzhenren.util.GuzhenrenResourceCostHelper.ConsumptionResult;
+import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.linkage.LinkageChannel;
+import net.tigereye.chestcavity.linkage.policy.ClampPolicy;
+import net.tigereye.chestcavity.listeners.OrganActivationListeners;
+import net.tigereye.chestcavity.listeners.OrganRemovalListener;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.util.NetworkUtil;
+import org.slf4j.Logger;
+
+/**
+ * Behaviour implementation for 自力更生蛊（三转）。
+ */
+public final class ZiLiGengShengGuOrganBehavior extends AbstractLiDaoOrganBehavior implements OrganSlowTickListener, OrganRemovalListener {
+
+    public static final ZiLiGengShengGuOrganBehavior INSTANCE = new ZiLiGengShengGuOrganBehavior();
+
+    private static final Logger LOGGER = LogUtils.getLogger();
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation ORGAN_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "zi_li_geng_sheng_gu_3");
+    public static final ResourceLocation ABILITY_ID = ORGAN_ID;
+
+    private static final String STATE_ROOT = "ZiLiGengShengGu";
+    private static final String NEXT_PASSIVE_TICK_KEY = "NextPassiveTick";
+    private static final String ACTIVE_FLAG_KEY = "AbilityActive";
+    private static final String ACTIVE_END_TICK_KEY = "AbilityEndTick";
+    private static final String NEXT_REGEN_TICK_KEY = "NextRegenTick";
+    private static final String ACTIVE_EFFICIENCY_KEY = "AbilityEfficiency";
+
+    private static final long PASSIVE_INTERVAL_TICKS = 200L; // 10 seconds
+    private static final double PASSIVE_HEAL_BASE = 30.0;
+    private static final double PASSIVE_ZHENYUAN_COST = 500.0;
+
+    private static final long ABILITY_DURATION_TICKS = 600L; // 30 seconds
+    private static final double ABILITY_REGEN_PER_SECOND = 1.0;
+    private static final double WEAKNESS_BASE_SECONDS = 30.0;
+    private static final long REGEN_STEP_TICKS = 20L;
+    private static final double EPSILON = 1.0E-4;
+
+    private static final ClampPolicy NON_NEGATIVE = new ClampPolicy(0.0, Double.MAX_VALUE);
+
+    static {
+        OrganActivationListeners.register(ABILITY_ID, ZiLiGengShengGuOrganBehavior::activateAbility);
+    }
+
+    private ZiLiGengShengGuOrganBehavior() {
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        ActiveLinkageContext context = linkageContext(cc);
+        if (context == null) {
+            return;
+        }
+        LinkageChannel channel = context.getOrCreateChannel(LiDaoConstants.LI_DAO_INCREASE_EFFECT);
+        if (channel != null) {
+            channel.addPolicy(NON_NEGATIVE);
+        }
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (entity == null || entity.level().isClientSide() || cc == null || organ == null || organ.isEmpty()) {
+            return;
+        }
+
+        OrganState state = organState(organ, STATE_ROOT);
+        long gameTime = entity.level().getGameTime();
+
+        boolean dirty = false;
+        dirty |= tickPassive(entity, cc, state, gameTime);
+        dirty |= tickAbility(entity, state, gameTime);
+
+        if (dirty) {
+            NetworkUtil.sendOrganSlotUpdate(cc, organ);
+        }
+    }
+
+    private boolean tickPassive(LivingEntity entity, ChestCavityInstance cc, OrganState state, long gameTime) {
+        long nextAllowed = state.getLong(NEXT_PASSIVE_TICK_KEY, 0L);
+        if (nextAllowed > gameTime) {
+            return false;
+        }
+
+        double efficiency = Math.max(0.0, 1.0 + liDaoIncrease(cc));
+        ConsumptionResult payment = GuzhenrenResourceCostHelper.consumeStrict(entity, PASSIVE_ZHENYUAN_COST, 0.0);
+        long reschedule = Math.max(gameTime + PASSIVE_INTERVAL_TICKS, gameTime + 1);
+        boolean dirty = state.setLong(NEXT_PASSIVE_TICK_KEY, reschedule).changed();
+
+        if (!payment.succeeded()) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("[compat/guzhenren][zi_li_geng_sheng] passive upkeep failed: {}", payment.failureReason());
+            }
+            return dirty;
+        }
+
+        float healAmount = (float) (PASSIVE_HEAL_BASE * Math.max(efficiency, 0.0));
+        if (healAmount > EPSILON && entity.isAlive()) {
+            entity.heal(healAmount);
+        }
+        return dirty;
+    }
+
+    private boolean tickAbility(LivingEntity entity, OrganState state, long gameTime) {
+        if (!state.getBoolean(ACTIVE_FLAG_KEY, false)) {
+            return false;
+        }
+        double efficiency = Math.max(state.getDouble(ACTIVE_EFFICIENCY_KEY, 1.0), 0.0);
+        long abilityEnd = state.getLong(ACTIVE_END_TICK_KEY, 0L);
+        boolean dirty = false;
+
+        if (abilityEnd > 0L && gameTime >= abilityEnd) {
+            dirty |= finishAbility(entity, state, efficiency);
+            return dirty;
+        }
+
+        long nextRegen = state.getLong(NEXT_REGEN_TICK_KEY, gameTime);
+        if (gameTime >= nextRegen) {
+            float healAmount = (float) (ABILITY_REGEN_PER_SECOND * Math.max(efficiency, 0.0));
+            if (healAmount > EPSILON && entity.isAlive()) {
+                entity.heal(healAmount);
+            }
+            long newNext = Math.max(gameTime + REGEN_STEP_TICKS, nextRegen + REGEN_STEP_TICKS);
+            dirty |= state.setLong(NEXT_REGEN_TICK_KEY, newNext).changed();
+        }
+        return dirty;
+    }
+
+    private boolean finishAbility(LivingEntity entity, OrganState state, double efficiency) {
+        boolean dirty = false;
+        dirty |= state.setBoolean(ACTIVE_FLAG_KEY, false).changed();
+        dirty |= state.setLong(ACTIVE_END_TICK_KEY, 0L).changed();
+        dirty |= state.setLong(NEXT_REGEN_TICK_KEY, 0L).changed();
+        dirty |= state.setDouble(ACTIVE_EFFICIENCY_KEY, 0.0).changed();
+
+        int weaknessTicks = computeWeaknessDurationTicks(efficiency);
+        if (weaknessTicks > 0 && entity != null && entity.isAlive()) {
+            entity.addEffect(new MobEffectInstance(MobEffects.WEAKNESS, weaknessTicks, 0));
+        }
+        return dirty;
+    }
+
+    private int computeWeaknessDurationTicks(double efficiency) {
+        double safeEfficiency = Math.max(efficiency, 0.001);
+        double seconds = WEAKNESS_BASE_SECONDS / safeEfficiency;
+        int ticks = (int) Math.round(seconds * 20.0);
+        return Math.max(ticks, 0);
+    }
+
+    private static void activateAbility(LivingEntity entity, ChestCavityInstance cc) {
+        if (!(entity instanceof Player player) || player.level().isClientSide()) {
+            return;
+        }
+        if (cc == null) {
+            return;
+        }
+        ItemStack organ = findOrgan(cc);
+        if (organ.isEmpty()) {
+            return;
+        }
+
+        OrganState state = INSTANCE.organState(organ, STATE_ROOT);
+        long gameTime = player.level().getGameTime();
+
+        if (state.getBoolean(ACTIVE_FLAG_KEY, false)) {
+            long endTick = state.getLong(ACTIVE_END_TICK_KEY, 0L);
+            if (endTick > 0L && gameTime >= endTick) {
+                double efficiency = Math.max(state.getDouble(ACTIVE_EFFICIENCY_KEY, 1.0), 0.0);
+                boolean dirty = INSTANCE.finishAbility(entity, state, efficiency);
+                if (dirty) {
+                    NetworkUtil.sendOrganSlotUpdate(cc, organ);
+                }
+            }
+            if (state.getBoolean(ACTIVE_FLAG_KEY, false)) {
+                NetworkUtil.sendOrganSlotUpdate(cc, organ);
+                return;
+            }
+        }
+
+        int consumed = INSTANCE.consumeMuscles(player, cc);
+        if (consumed <= 0) {
+            return;
+        }
+
+        double efficiency = Math.max(0.0, 1.0 + INSTANCE.liDaoIncrease(cc));
+        state.setBoolean(ACTIVE_FLAG_KEY, true);
+        state.setLong(ACTIVE_END_TICK_KEY, gameTime + ABILITY_DURATION_TICKS);
+        state.setLong(NEXT_REGEN_TICK_KEY, gameTime + REGEN_STEP_TICKS);
+        state.setDouble(ACTIVE_EFFICIENCY_KEY, Math.max(efficiency, 0.0));
+        NetworkUtil.sendOrganSlotUpdate(cc, organ);
+    }
+
+    private int consumeMuscles(LivingEntity entity, ChestCavityInstance cc) {
+        if (cc == null || cc.inventory == null) {
+            return 0;
+        }
+        Level level = entity.level();
+        RandomSource random = entity.getRandom();
+        int consumed = 0;
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (!LiDaoHelper.isMuscle(stack)) {
+                continue;
+            }
+            int count = stack.getCount();
+            if (count <= 0) {
+                continue;
+            }
+            cc.inventory.removeItem(i, count);
+            consumed += count;
+            for (int n = 0; n < count; n++) {
+                float pitch = 0.9f + random.nextFloat() * 0.2f;
+                level.playSound(null, entity.getX(), entity.getY(), entity.getZ(),
+                        SoundEvents.GENERIC_EAT, entity.getSoundSource(), 0.6f, pitch);
+            }
+        }
+        if (consumed > 0) {
+            cc.inventory.setChanged();
+        }
+        return consumed;
+    }
+
+    private static ItemStack findOrgan(ChestCavityInstance cc) {
+        if (cc == null || cc.inventory == null) {
+            return ItemStack.EMPTY;
+        }
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (INSTANCE.matchesOrgan(stack, ORGAN_ID)) {
+                return stack;
+            }
+        }
+        return ItemStack.EMPTY;
+    }
+
+    @Override
+    public void onRemoved(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (entity == null || entity.level().isClientSide() || organ == null || organ.isEmpty()) {
+            return;
+        }
+        OrganState state = organState(organ, STATE_ROOT);
+        double efficiency = Math.max(state.getDouble(ACTIVE_EFFICIENCY_KEY, 1.0), 0.0);
+        boolean dirty = finishAbility(entity, state, efficiency);
+        dirty |= state.setLong(NEXT_PASSIVE_TICK_KEY, 0L).changed();
+        if (dirty && cc != null) {
+            NetworkUtil.sendOrganSlotUpdate(cc, organ);
+        }
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/GuzhenrenIntegrationModule.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/module/GuzhenrenIntegrationModule.java
@@ -17,6 +17,7 @@ import net.tigereye.chestcavity.compat.guzhenren.item.shui_dao.ShuiDaoOrganRegis
 import net.tigereye.chestcavity.compat.guzhenren.item.tu_dao.TuDaoOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.XueDaoOrganRegistry;
 import net.tigereye.chestcavity.compat.guzhenren.item.yu_dao.YuDaoOrganRegistry;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.LiDaoOrganRegistry;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,6 +37,7 @@ public final class GuzhenrenIntegrationModule {
             DuDaoOrganRegistry::specs,
             GuDaoOrganRegistry::specs,
             LeiDaoOrganRegistry::specs,
+            LiDaoOrganRegistry::specs,
             KongqiaoOrganRegistry::specs,
             MuDaoOrganRegistry::specs,
             HunDaoOrganRegistry::specs,

--- a/src/main/java/net/tigereye/chestcavity/guzhenren/GuzhenrenModule.java
+++ b/src/main/java/net/tigereye/chestcavity/guzhenren/GuzhenrenModule.java
@@ -12,6 +12,7 @@ import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoClientAbil
 import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoClientRenderers;
 import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JiandaoEntityAttributes;
 import net.tigereye.chestcavity.compat.guzhenren.item.jian_dao.JianYingGuEvents;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.LiDaoClientAbilities;
 import net.tigereye.chestcavity.compat.guzhenren.item.mu_dao.MuDaoClientAbilities;
 import net.tigereye.chestcavity.compat.guzhenren.item.shi_dao.ShiDaoClientAbilities;
 import net.tigereye.chestcavity.compat.guzhenren.item.xue_dao.XueDaoClientAbilities;
@@ -89,6 +90,7 @@ public final class GuzhenrenModule {
             modBus.addListener(Abilities::onClientSetup);
             modBus.addListener(GuDaoClientAbilities::onClientSetup);
             modBus.addListener(BingXueDaoClientAbilities::onClientSetup);
+            modBus.addListener(LiDaoClientAbilities::onClientSetup);
             modBus.addListener(MuDaoClientAbilities::onClientSetup);
             modBus.addListener(ShiDaoClientAbilities::onClientSetup);
             modBus.addListener(JiandaoClientAbilities::onClientSetup);


### PR DESCRIPTION
## Summary
- add the ZiLiGengShengGu behaviour with passive healing upkeep and an active regeneration ability driven by muscle consumption
- register the new Li Dao organ integration and expose the attack ability hotkey on the client

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68e1106ed3b483269d1d2154922adf14