### PR TITLE
Add Bing Bu Gu organ behavior integration

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/bing_xue_dao/BingXueDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/bing_xue_dao/BingXueDaoOrganRegistry.java
@@ -1,6 +1,7 @@
 package net.tigereye.chestcavity.compat.guzhenren.item.bing_xue_dao;
 
 import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.compat.guzhenren.item.bing_xue_dao.behavior.BingBuGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.bing_xue_dao.behavior.BingJiGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.bing_xue_dao.behavior.QingReGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.bing_xue_dao.behavior.ShuangXiGuOrganBehavior;
@@ -14,11 +15,15 @@ import java.util.List;
 public final class BingXueDaoOrganRegistry {
 
     private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation BING_BU_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "bing_bu_gu");
     private static final ResourceLocation BING_JI_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "bing_ji_gu");
     private static final ResourceLocation SHUANG_XI_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "shuang_xi_gu");
     private static final ResourceLocation QING_RE_GU_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "qing_re_gu");
 
     private static final List<OrganIntegrationSpec> SPECS = List.of(
+            OrganIntegrationSpec.builder(BING_BU_GU_ID)
+                    .addSlowTickListener(BingBuGuOrganBehavior.INSTANCE)
+                    .build(),
             OrganIntegrationSpec.builder(BING_JI_GU_ID)
                     .addSlowTickListener(BingJiGuOrganBehavior.INSTANCE)
                     .addOnHitListener(BingJiGuOrganBehavior.INSTANCE)

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/bing_xue_dao/behavior/BingBuGuOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/bing_xue_dao/behavior/BingBuGuOrganBehavior.java
@@ -1,0 +1,169 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.bing_xue_dao.behavior;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.food.FoodData;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.AbstractGuzhenrenOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.OrganState;
+import net.tigereye.chestcavity.listeners.OrganSlowTickListener;
+import net.tigereye.chestcavity.registration.CCItems;
+
+/**
+ * Behaviour implementation for 冰布蛊 (Bing Bu Gu).
+ */
+public final class BingBuGuOrganBehavior extends AbstractGuzhenrenOrganBehavior implements OrganSlowTickListener {
+
+    public static final BingBuGuOrganBehavior INSTANCE = new BingBuGuOrganBehavior();
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation ORGAN_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "bing_bu_gu");
+
+    private static final String STATE_ROOT = "BingBuGu";
+    private static final String NON_PLAYER_COOLDOWN_KEY = "NonPlayerCooldown";
+
+    private static final int PLAYER_REGEN_DURATION_TICKS = 5 * 20;
+    private static final int PLAYER_REGEN_AMPLIFIER = 1;
+    private static final int NON_PLAYER_REGEN_DURATION_TICKS = 10 * 20;
+    private static final int NON_PLAYER_REGEN_AMPLIFIER = 1;
+    private static final int SATURATION_DURATION_TICKS = 20;
+    private static final int EFFECT_REFRESH_THRESHOLD_TICKS = 40;
+    private static final int NON_PLAYER_INTERVAL_SECONDS = 120;
+
+    private static final float BURP_VOLUME = 0.6f;
+    private static final float BURP_PITCH_MIN = 0.9f;
+    private static final float BURP_PITCH_VARIANCE = 0.1f;
+
+    private BingBuGuOrganBehavior() {
+    }
+
+    @Override
+    public void onSlowTick(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        if (entity == null || entity.level().isClientSide()) {
+            return;
+        }
+        if (!matchesOrgan(organ, CCItems.GUZHENREN_BING_BU_GU, ORGAN_ID)) {
+            return;
+        }
+        if (!entity.isAlive()) {
+            return;
+        }
+        if (entity instanceof Player player) {
+            handlePlayer(player);
+        } else {
+            handleNonPlayer(entity, cc, organ);
+        }
+    }
+
+    private void handlePlayer(Player player) {
+        Inventory inventory = player.getInventory();
+        boolean hasSnowball = inventory != null && inventory.countItem(Items.SNOWBALL) > 0;
+        boolean hasIce = inventory != null && inventory.countItem(Items.ICE) > 0;
+
+        if (hasSnowball && tryGrantSaturation(player)) {
+            playEatingSound(player);
+            return;
+        }
+
+        if (hasIce && tryGrantPlayerRegeneration(player)) {
+            playEatingSound(player);
+        }
+    }
+
+    private void handleNonPlayer(LivingEntity entity, ChestCavityInstance cc, ItemStack organ) {
+        OrganState state = organState(organ, STATE_ROOT);
+        int cooldown = state.getInt(NON_PLAYER_COOLDOWN_KEY, -1);
+        if (cooldown < 0) {
+            cooldown = entity.getRandom().nextInt(NON_PLAYER_INTERVAL_SECONDS + 1);
+            var change = state.setInt(NON_PLAYER_COOLDOWN_KEY, cooldown);
+            if (change.changed() && cc != null) {
+                sendSlotUpdate(cc, organ);
+            }
+        }
+
+        if (cooldown > 0) {
+            int next = cooldown - 1;
+            var change = state.setInt(NON_PLAYER_COOLDOWN_KEY, next);
+            if (change.changed() && cc != null) {
+                sendSlotUpdate(cc, organ);
+            }
+            return;
+        }
+
+        boolean applied = tryGrantNonPlayerRegeneration(entity);
+        int nextCooldown = applied ? NON_PLAYER_INTERVAL_SECONDS : 1;
+        var change = state.setInt(NON_PLAYER_COOLDOWN_KEY, nextCooldown);
+        if (change.changed() && cc != null) {
+            sendSlotUpdate(cc, organ);
+        }
+    }
+
+    private boolean tryGrantSaturation(Player player) {
+        if (player == null) {
+            return false;
+        }
+        FoodData foodData = player.getFoodData();
+        if (foodData == null) {
+            return false;
+        }
+        float saturation = foodData.getSaturationLevel();
+        float maxSaturation = Math.min(foodData.getFoodLevel(), 20);
+        if (saturation >= maxSaturation) {
+            return false;
+        }
+        MobEffectInstance existing = player.getEffect(MobEffects.SATURATION);
+        if (existing != null && existing.getDuration() > 1) {
+            return false;
+        }
+        return player.addEffect(new MobEffectInstance(MobEffects.SATURATION, SATURATION_DURATION_TICKS, 0));
+    }
+
+    private boolean tryGrantPlayerRegeneration(Player player) {
+        if (player == null) {
+            return false;
+        }
+        if (player.getHealth() >= player.getMaxHealth()) {
+            return false;
+        }
+        MobEffectInstance existing = player.getEffect(MobEffects.REGENERATION);
+        if (existing != null && existing.getAmplifier() >= PLAYER_REGEN_AMPLIFIER
+                && existing.getDuration() > EFFECT_REFRESH_THRESHOLD_TICKS) {
+            return false;
+        }
+        return player.addEffect(new MobEffectInstance(MobEffects.REGENERATION, PLAYER_REGEN_DURATION_TICKS,
+                PLAYER_REGEN_AMPLIFIER));
+    }
+
+    private boolean tryGrantNonPlayerRegeneration(LivingEntity entity) {
+        if (entity == null) {
+            return false;
+        }
+        MobEffectInstance existing = entity.getEffect(MobEffects.REGENERATION);
+        if (existing != null && existing.getAmplifier() >= NON_PLAYER_REGEN_AMPLIFIER
+                && existing.getDuration() > EFFECT_REFRESH_THRESHOLD_TICKS) {
+            return false;
+        }
+        return entity.addEffect(new MobEffectInstance(MobEffects.REGENERATION, NON_PLAYER_REGEN_DURATION_TICKS,
+                NON_PLAYER_REGEN_AMPLIFIER));
+    }
+
+    private void playEatingSound(LivingEntity entity) {
+        Level level = entity == null ? null : entity.level();
+        if (level == null) {
+            return;
+        }
+        float pitch = BURP_PITCH_MIN + level.getRandom().nextFloat() * BURP_PITCH_VARIANCE;
+        SoundSource source = entity instanceof Player ? SoundSource.PLAYERS : SoundSource.NEUTRAL;
+        level.playSound(null, entity.getX(), entity.getY(), entity.getZ(), SoundEvents.PLAYER_BURP, source,
+                BURP_VOLUME, pitch);
+    }
+}

--- a/src/main/java/net/tigereye/chestcavity/registration/CCItems.java
+++ b/src/main/java/net/tigereye/chestcavity/registration/CCItems.java
@@ -31,6 +31,7 @@ public class CCItems {
 	public static final Item GUZHENREN_XUE_FEI_GU = resolveExternalItem("guzhenren", "xie_fei_gu");
         public static final Item GUZHENREN_XIE_DI_GU = resolveExternalItem("guzhenren", "xie_di_gu");
         public static final Item GUZHENREN_XIE_YAN_GU = resolveExternalItem("guzhenren", "xie_yan_gu");
+        public static final Item GUZHENREN_BING_BU_GU = resolveExternalItem("guzhenren", "bing_bu_gu");
         public static final Item GUZHENREN_BING_JI_GU = resolveExternalItem("guzhenren", "bing_ji_gu");
         public static final Item GUZHENREN_SHUANG_XI_GU = resolveExternalItem("guzhenren", "shuang_xi_gu");
         public static final Item GUZHENREN_QING_RE_GU = resolveExternalItem("guzhenren", "qing_re_gu");

--- a/src/main/resources/data/chestcavity/organs/guzhenren/human/bing_xue_dao/bing_bu_gu.json
+++ b/src/main/resources/data/chestcavity/organs/guzhenren/human/bing_xue_dao/bing_bu_gu.json
@@ -1,0 +1,7 @@
+{
+  "itemID": "guzhenren:bing_bu_gu",
+  "organScores": [
+    {"id": "chestcavity:nutrition", "value": "2"},
+    {"id": "guzhenren:daohen_bingxuedao", "value": "1"}
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Bing Bu Gu slow-tick behavior that grants saturation or regeneration based on available snowballs or ice and includes a non-player regeneration cadence
- register the organ with the Bing Xue Dao integration and expose the external Guzhenren item handle
- add the Bing Bu Gu organ data definition for nutrition and Bing Xue Dao score contributions

## Testing
- `./gradlew --console=plain -q compileJava`


------
https://chatgpt.com/codex/tasks/task_e_68e3548d8da8832684b8c2915abd4daf