### PR TITLE
Add dodge ability for Long Wan Qu Qu Gu rib

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/LiDaoClientAbilities.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/LiDaoClientAbilities.java
@@ -1,6 +1,7 @@
 package net.tigereye.chestcavity.compat.guzhenren.item.li_dao;
 
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior.LongWanQuQuGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior.ZiLiGengShengGuOrganBehavior;
 import net.tigereye.chestcavity.registration.CCKeybindings;
 
@@ -13,6 +14,9 @@ public final class LiDaoClientAbilities {
     }
 
     public static void onClientSetup(FMLClientSetupEvent event) {
+        if (!CCKeybindings.ATTACK_ABILITY_LIST.contains(LongWanQuQuGuOrganBehavior.ABILITY_ID)) {
+            CCKeybindings.ATTACK_ABILITY_LIST.add(LongWanQuQuGuOrganBehavior.ABILITY_ID);
+        }
         if (!CCKeybindings.ATTACK_ABILITY_LIST.contains(ZiLiGengShengGuOrganBehavior.ABILITY_ID)) {
             CCKeybindings.ATTACK_ABILITY_LIST.add(ZiLiGengShengGuOrganBehavior.ABILITY_ID);
         }

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/LiDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/LiDaoOrganRegistry.java
@@ -1,6 +1,7 @@
 package net.tigereye.chestcavity.compat.guzhenren.item.li_dao;
 
 import net.minecraft.resources.ResourceLocation;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior.LongWanQuQuGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior.QuanLiYiFuGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior.ZiLiGengShengGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
@@ -16,12 +17,17 @@ public final class LiDaoOrganRegistry {
     private static final String MOD_ID = "guzhenren";
     private static final ResourceLocation QUAN_LI_YI_FU_GU_ID =
             ResourceLocation.fromNamespaceAndPath(MOD_ID, "quan_li_yi_fu_gu");
+    private static final ResourceLocation LONG_WAN_QU_QU_GU_ID =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "long_wan_qu_qu_gu");
     private static final ResourceLocation ZI_LI_GENG_SHENG_GU_ID =
             ResourceLocation.fromNamespaceAndPath(MOD_ID, "zi_li_geng_sheng_gu_3");
 
     private static final List<OrganIntegrationSpec> SPECS = List.of(
             OrganIntegrationSpec.builder(QUAN_LI_YI_FU_GU_ID)
                     .addSlowTickListener(QuanLiYiFuGuOrganBehavior.INSTANCE)
+                    .build(),
+            OrganIntegrationSpec.builder(LONG_WAN_QU_QU_GU_ID)
+                    .addIncomingDamageListener(LongWanQuQuGuOrganBehavior.INSTANCE)
                     .build(),
             OrganIntegrationSpec.builder(ZI_LI_GENG_SHENG_GU_ID)
                     .addSlowTickListener(ZiLiGengShengGuOrganBehavior.INSTANCE)

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/behavior/LongWanQuQuGuOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/behavior/LongWanQuQuGuOrganBehavior.java
@@ -1,0 +1,180 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior;
+
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.item.common.OrganState;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.AbstractLiDaoOrganBehavior;
+import net.tigereye.chestcavity.listeners.OrganActivationListeners;
+import net.tigereye.chestcavity.listeners.OrganIncomingDamageListener;
+import net.tigereye.chestcavity.util.CombatUtil;
+
+/**
+ * Behaviour for 龙丸蛐蛐蛊（三转力道，肋骨）。
+ */
+public final class LongWanQuQuGuOrganBehavior extends AbstractLiDaoOrganBehavior implements OrganIncomingDamageListener {
+
+    public static final LongWanQuQuGuOrganBehavior INSTANCE = new LongWanQuQuGuOrganBehavior();
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation ORGAN_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "long_wan_qu_qu_gu");
+    public static final ResourceLocation ABILITY_ID = ORGAN_ID;
+
+    private static final String STATE_ROOT = "LongWanQuQuGu";
+    private static final String ACTIVE_KEY = "Active";
+    private static final String CHARGES_KEY = "Charges";
+    private static final String NEXT_READY_TICK_KEY = "NextReadyTick";
+    private static final String INVULN_EXPIRE_TICK_KEY = "InvulnExpireTick";
+
+    private static final int MAX_CHARGES = 3;
+    private static final long COOLDOWN_TICKS = 30L * 20L; // 30 seconds
+    private static final long INVULN_WINDOW_TICKS = 10L; // half a second
+    private static final float MIN_DODGE_DISTANCE = 0.9f;
+    private static final float MAX_DODGE_DISTANCE = 1.4f;
+    private static final float DODGE_YAW_RANGE = 100.0f;
+
+    static {
+        OrganActivationListeners.register(ABILITY_ID, LongWanQuQuGuOrganBehavior::activateAbility);
+    }
+
+    private LongWanQuQuGuOrganBehavior() {
+    }
+
+    @Override
+    public float onIncomingDamage(DamageSource source, LivingEntity victim, ChestCavityInstance cc, ItemStack organ, float damage) {
+        if (!(victim instanceof Player) || victim.level().isClientSide() || cc == null || organ == null || organ.isEmpty()) {
+            return damage;
+        }
+        if (!isPrimaryOrgan(cc, organ)) {
+            return damage;
+        }
+
+        OrganState state = organState(organ, STATE_ROOT);
+        long gameTime = victim.level().getGameTime();
+
+        long invulnExpire = state.getLong(INVULN_EXPIRE_TICK_KEY, 0L);
+        if (invulnExpire > gameTime) {
+            return 0.0f;
+        }
+
+        if (!state.getBoolean(ACTIVE_KEY, false)) {
+            return damage;
+        }
+
+        int charges = Math.max(0, state.getInt(CHARGES_KEY, 0));
+        if (charges <= 0) {
+            boolean dirty = state.setBoolean(ACTIVE_KEY, false).changed();
+            if (dirty) {
+                sendSlotUpdate(cc, organ);
+            }
+            return damage;
+        }
+
+        LivingEntity attacker = source != null && source.getEntity() instanceof LivingEntity living ? living : null;
+        boolean dodged = CombatUtil.performShortDodge(
+                victim,
+                attacker,
+                MIN_DODGE_DISTANCE,
+                MAX_DODGE_DISTANCE,
+                DODGE_YAW_RANGE,
+                SoundEvents.SHULKER_TELEPORT,
+                ParticleTypes.CLOUD
+        );
+        if (!dodged) {
+            return damage;
+        }
+
+        boolean dirty = false;
+        int remaining = Math.max(0, charges - 1);
+        dirty |= state.setInt(CHARGES_KEY, remaining).changed();
+        dirty |= state.setLong(INVULN_EXPIRE_TICK_KEY, gameTime + INVULN_WINDOW_TICKS).changed();
+        if (remaining <= 0) {
+            dirty |= state.setBoolean(ACTIVE_KEY, false).changed();
+        }
+        if (dirty) {
+            sendSlotUpdate(cc, organ);
+        }
+        victim.invulnerableTime = Math.max(victim.invulnerableTime, (int) INVULN_WINDOW_TICKS);
+        return 0.0f;
+    }
+
+    private static void activateAbility(LivingEntity entity, ChestCavityInstance cc) {
+        if (!(entity instanceof Player player) || player.level().isClientSide()) {
+            return;
+        }
+        if (cc == null) {
+            return;
+        }
+        ItemStack organ = findOrgan(cc);
+        if (organ.isEmpty()) {
+            return;
+        }
+
+        OrganState state = INSTANCE.organState(organ, STATE_ROOT);
+        long gameTime = player.level().getGameTime();
+        long nextReady = Math.max(0L, state.getLong(NEXT_READY_TICK_KEY, 0L));
+        if (nextReady > gameTime) {
+            return;
+        }
+        if (state.getBoolean(ACTIVE_KEY, false) && state.getInt(CHARGES_KEY, 0) > 0) {
+            return;
+        }
+
+        boolean dirty = false;
+        dirty |= state.setBoolean(ACTIVE_KEY, true).changed();
+        dirty |= state.setInt(CHARGES_KEY, MAX_CHARGES).changed();
+        dirty |= state.setLong(NEXT_READY_TICK_KEY, gameTime + COOLDOWN_TICKS).changed();
+        dirty |= state.setLong(INVULN_EXPIRE_TICK_KEY, 0L).changed();
+        if (dirty) {
+            INSTANCE.sendSlotUpdate(cc, organ);
+        }
+
+        player.level().playSound(
+                null,
+                player.getX(),
+                player.getY(),
+                player.getZ(),
+                SoundEvents.SHIELD_BLOCK,
+                player.getSoundSource(),
+                0.8f,
+                1.1f
+        );
+    }
+
+    private static ItemStack findOrgan(ChestCavityInstance cc) {
+        if (cc == null || cc.inventory == null) {
+            return ItemStack.EMPTY;
+        }
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (INSTANCE.matchesOrgan(stack, ORGAN_ID)) {
+                return stack;
+            }
+        }
+        return ItemStack.EMPTY;
+    }
+
+    private boolean isPrimaryOrgan(ChestCavityInstance cc, ItemStack organ) {
+        if (cc == null || cc.inventory == null || organ == null || organ.isEmpty()) {
+            return false;
+        }
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack slotStack = cc.inventory.getItem(i);
+            if (slotStack == null || slotStack.isEmpty()) {
+                continue;
+            }
+            if (!matchesOrgan(slotStack, ORGAN_ID)) {
+                continue;
+            }
+            return slotStack == organ;
+        }
+        return false;
+    }
+}

--- a/src/main/resources/data/chestcavity/organs/guzhenren/human/li_dao/long_wan_qu_qu_gu.json
+++ b/src/main/resources/data/chestcavity/organs/guzhenren/human/li_dao/long_wan_qu_qu_gu.json
@@ -1,0 +1,9 @@
+{
+  "itemID": "guzhenren:long_wan_qu_qu_gu",
+  "organScores": [
+    {"id":"guzhenren:max_jingli","value": "5"},
+    {"id":"guzhenren:max_zhenyuan","value": "10"},
+    {"id":"chestcavity:defense","value": "4"},
+    {"id":"chestcavity:speed","value": "0.1"}
+  ]
+}


### PR DESCRIPTION
## Summary
- implement a Long Wan Qu Qu Gu rib behaviour that grants three automatic dodges on its attack ability with a short invulnerability window and 30s cooldown
- register the new behaviour with the Li Dao organ registry and attack-ability keybinding list
- add the organ score definition for the guzhenren:long_wan_qu_qu_gu rib item

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68e4d79a79008326b2bb211b1fa1cded