### PR TITLE
Add Xu Li Gu organ charge behavior

### DIFF
--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/LiDaoOrganRegistry.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/LiDaoOrganRegistry.java
@@ -5,6 +5,7 @@ import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior.BaiShiGuOr
 import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior.HeiShiGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior.LongWanQuQuGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior.QuanLiYiFuGuOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior.XuLiGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior.ZiLiGengShengGuOrganBehavior;
 import net.tigereye.chestcavity.compat.guzhenren.module.OrganIntegrationSpec;
 
@@ -27,6 +28,8 @@ public final class LiDaoOrganRegistry {
             ResourceLocation.fromNamespaceAndPath(MOD_ID, "long_wan_qu_qu_gu");
     private static final ResourceLocation ZI_LI_GENG_SHENG_GU_ID =
             ResourceLocation.fromNamespaceAndPath(MOD_ID, "zi_li_geng_sheng_gu_3");
+    private static final ResourceLocation XU_LI_GU_ID =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "xu_li_gu");
 
     private static final List<OrganIntegrationSpec> SPECS = List.of(
             OrganIntegrationSpec.builder(BAI_SHI_GU_ID)
@@ -44,6 +47,10 @@ public final class LiDaoOrganRegistry {
                     .build(),
             OrganIntegrationSpec.builder(LONG_WAN_QU_QU_GU_ID)
                     .addIncomingDamageListener(LongWanQuQuGuOrganBehavior.INSTANCE)
+                    .build(),
+            OrganIntegrationSpec.builder(XU_LI_GU_ID)
+                    .addOnHitListener(XuLiGuOrganBehavior.INSTANCE)
+                    .ensureAttached(XuLiGuOrganBehavior.INSTANCE::ensureAttached)
                     .build(),
             OrganIntegrationSpec.builder(ZI_LI_GENG_SHENG_GU_ID)
                     .addSlowTickListener(ZiLiGengShengGuOrganBehavior.INSTANCE)

--- a/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/behavior/XuLiGuOrganBehavior.java
+++ b/src/main/java/net/tigereye/chestcavity/compat/guzhenren/item/li_dao/behavior/XuLiGuOrganBehavior.java
@@ -1,0 +1,129 @@
+package net.tigereye.chestcavity.compat.guzhenren.item.li_dao.behavior;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.DamageTypeTags;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.tigereye.chestcavity.chestcavities.instance.ChestCavityInstance;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.AbstractLiDaoOrganBehavior;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.LiDaoConstants;
+import net.tigereye.chestcavity.compat.guzhenren.item.li_dao.LiDaoHelper;
+import net.tigereye.chestcavity.linkage.ActiveLinkageContext;
+import net.tigereye.chestcavity.listeners.OrganOnHitListener;
+
+/**
+ * Behaviour for 蓄力蛊（三转力道，肋骨）。
+ */
+public final class XuLiGuOrganBehavior extends AbstractLiDaoOrganBehavior implements OrganOnHitListener {
+
+    public static final XuLiGuOrganBehavior INSTANCE = new XuLiGuOrganBehavior();
+
+    private static final String MOD_ID = "guzhenren";
+    private static final ResourceLocation ORGAN_ID = ResourceLocation.fromNamespaceAndPath(MOD_ID, "xu_li_gu");
+
+    private static final double BASE_TRIGGER_CHANCE = 0.12;
+    private static final double BONUS_PER_MUSCLE_GROUP = 0.005;
+    private static final int MUSCLES_PER_GROUP = 16;
+    private static final double MAX_TRIGGER_CHANCE = 0.23;
+    private static final double DAMAGE_MULTIPLIER_BASE = 1.4;
+
+    private XuLiGuOrganBehavior() {
+    }
+
+    public void ensureAttached(ChestCavityInstance cc) {
+        ActiveLinkageContext context = linkageContext(cc);
+        ensureChannel(context, LiDaoConstants.LI_DAO_INCREASE_EFFECT);
+    }
+
+    @Override
+    public float onHit(
+            DamageSource source,
+            LivingEntity attacker,
+            LivingEntity target,
+            ChestCavityInstance cc,
+            ItemStack organ,
+            float damage
+    ) {
+        if (!(attacker instanceof Player player) || attacker.level().isClientSide()) {
+            return damage;
+        }
+        if (!matchesOrgan(organ, ORGAN_ID)) {
+            return damage;
+        }
+        if (!isPrimaryOrgan(cc, organ)) {
+            return damage;
+        }
+        if (damage <= 0.0f) {
+            return damage;
+        }
+        if (target == null || !target.isAlive() || target == attacker || target.isAlliedTo(attacker)) {
+            return damage;
+        }
+        if (source == null || source.is(DamageTypeTags.IS_PROJECTILE) || source.getDirectEntity() != attacker) {
+            return damage;
+        }
+
+        double triggerChance = computeTriggerChance(cc);
+        if (triggerChance <= 0.0) {
+            return damage;
+        }
+
+        RandomSource random = player.getRandom();
+        if (random.nextDouble() >= triggerChance) {
+            return damage;
+        }
+
+        double liDaoIncrease = Math.max(0.0, liDaoIncrease(cc));
+        double multiplier = DAMAGE_MULTIPLIER_BASE * (1.0 + liDaoIncrease);
+        if (multiplier <= 0.0) {
+            return damage;
+        }
+
+        return (float) (damage * multiplier);
+    }
+
+    private double computeTriggerChance(ChestCavityInstance cc) {
+        int muscles = countMuscleStacks(cc);
+        int groups = muscles / MUSCLES_PER_GROUP;
+        double bonus = groups * BONUS_PER_MUSCLE_GROUP;
+        double chance = BASE_TRIGGER_CHANCE + bonus;
+        return Mth.clamp(chance, 0.0, MAX_TRIGGER_CHANCE);
+    }
+
+    private int countMuscleStacks(ChestCavityInstance cc) {
+        if (cc == null || cc.inventory == null) {
+            return 0;
+        }
+        int total = 0;
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack stack = cc.inventory.getItem(i);
+            if (LiDaoHelper.isMuscle(stack)) {
+                total += 1;
+            }
+        }
+        return total;
+    }
+
+    private boolean isPrimaryOrgan(ChestCavityInstance cc, ItemStack organ) {
+        if (cc == null || cc.inventory == null || organ == null || organ.isEmpty()) {
+            return false;
+        }
+        int size = cc.inventory.getContainerSize();
+        for (int i = 0; i < size; i++) {
+            ItemStack slotStack = cc.inventory.getItem(i);
+            if (slotStack == null || slotStack.isEmpty()) {
+                continue;
+            }
+            if (!matchesOrgan(slotStack, ORGAN_ID)) {
+                continue;
+            }
+            return slotStack == organ;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Xu Li Gu organ behaviour that grants a charge strike damage multiplier with muscle-based proc chances
- register the new behaviour in the Li Dao organ registry so the rib organ hooks into linkage channels and hit listeners

## Testing
- ./gradlew compileJava *(fails: existing FenShenGuOrganBehavior references non-existent DamageTypeTags.IS_MELEE and new behaviour was initially missing proper access modifier)*

------
https://chatgpt.com/codex/tasks/task_e_68e5fd3333788326a4e781e0680625b2