### PR TITLE
Add random wolf organ fillers to Guzhenren wolves

### DIFF
--- a/src/main/resources/data/chestcavity/types/compatibility/guzhenren/wolves/dian_lang.json
+++ b/src/main/resources/data/chestcavity/types/compatibility/guzhenren/wolves/dian_lang.json
@@ -104,5 +104,19 @@
       "item": "chestcavity:swift_muscle",
       "position": 26
     }
+  ],
+  "randomGenerators": [
+    {
+      "id": "chestcavity:guzhenren/wolves/dian_lang/organs",
+      "count": {
+        "min": 2,
+        "max": 3
+      },
+      "items": [
+        "guzhenren:langrou",
+        "guzhenren:llangpi",
+        "guzhenren:langyan"
+      ]
+    }
   ]
 }

--- a/src/main/resources/data/chestcavity/types/compatibility/guzhenren/wolves/hao_dian_lang.json
+++ b/src/main/resources/data/chestcavity/types/compatibility/guzhenren/wolves/hao_dian_lang.json
@@ -104,5 +104,19 @@
       "item": "chestcavity:swift_muscle",
       "position": 26
     }
+  ],
+  "randomGenerators": [
+    {
+      "id": "chestcavity:guzhenren/wolves/hao_dian_lang/organs",
+      "count": {
+        "min": 2,
+        "max": 3
+      },
+      "items": [
+        "guzhenren:bailangwurou",
+        "guzhenren:bbaishouwanglangpi",
+        "guzhenren:langyan"
+      ]
+    }
   ]
 }

--- a/src/main/resources/data/chestcavity/types/compatibility/guzhenren/wolves/hui_lang.json
+++ b/src/main/resources/data/chestcavity/types/compatibility/guzhenren/wolves/hui_lang.json
@@ -104,5 +104,19 @@
       "item": "chestcavity:swift_muscle",
       "position": 26
     }
+  ],
+  "randomGenerators": [
+    {
+      "id": "chestcavity:guzhenren/wolves/hui_lang/organs",
+      "count": {
+        "min": 2,
+        "max": 3
+      },
+      "items": [
+        "guzhenren:langrou",
+        "guzhenren:llangpi",
+        "guzhenren:langyan"
+      ]
+    }
   ]
 }

--- a/src/main/resources/data/chestcavity/types/compatibility/guzhenren/wolves/lei_dian_lang.json
+++ b/src/main/resources/data/chestcavity/types/compatibility/guzhenren/wolves/lei_dian_lang.json
@@ -104,5 +104,19 @@
       "item": "chestcavity:swift_muscle",
       "position": 26
     }
+  ],
+  "randomGenerators": [
+    {
+      "id": "chestcavity:guzhenren/wolves/lei_dian_lang/organs",
+      "count": {
+        "min": 2,
+        "max": 3
+      },
+      "items": [
+        "guzhenren:qianlangwangrou",
+        "guzhenren:qqianshouwanglangpi",
+        "guzhenren:qqianshouwanglangyan"
+      ]
+    }
   ]
 }

--- a/src/main/resources/data/chestcavity/types/compatibility/guzhenren/wolves/lei_guan_tou_lang.json
+++ b/src/main/resources/data/chestcavity/types/compatibility/guzhenren/wolves/lei_guan_tou_lang.json
@@ -104,5 +104,19 @@
       "item": "chestcavity:swift_muscle",
       "position": 26
     }
+  ],
+  "randomGenerators": [
+    {
+      "id": "chestcavity:guzhenren/wolves/lei_guan_tou_lang/organs",
+      "count": {
+        "min": 2,
+        "max": 3
+      },
+      "items": [
+        "guzhenren:wanlangwurou",
+        "guzhenren:wanshangwanglangpi",
+        "guzhenren:wawanshouwanglangyan"
+      ]
+    }
   ]
 }

--- a/src/main/resources/data/chestcavity/types/compatibility/guzhenren/wolves/tu_lang.json
+++ b/src/main/resources/data/chestcavity/types/compatibility/guzhenren/wolves/tu_lang.json
@@ -104,5 +104,19 @@
       "item": "chestcavity:swift_muscle",
       "position": 26
     }
+  ],
+  "randomGenerators": [
+    {
+      "id": "chestcavity:guzhenren/wolves/tu_lang/organs",
+      "count": {
+        "min": 2,
+        "max": 3
+      },
+      "items": [
+        "guzhenren:langrou",
+        "guzhenren:llangpi",
+        "guzhenren:langyan"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- add random chest cavity fillers to normal Guzhenren wolves so they can roll wolf organs
- configure higher tier wolves to roll their corresponding king-grade organs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6628e5e9c832682e4f18b05f00d21